### PR TITLE
Malgoモナドの設計を見直し

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,19 +1,53 @@
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Main where
 
+import           Control.Monad
+import           Control.Monad.State
 import qualified Language.Malgo.Beta      as Beta
 import qualified Language.Malgo.Closure   as Closure
+import qualified Language.Malgo.Eval      as Eval
 import qualified Language.Malgo.Eval      as Eval
 import qualified Language.Malgo.Flatten   as Flatten
 import qualified Language.Malgo.KNormal   as KNormal
 import qualified Language.Malgo.Lexer     as Lexer
+import qualified Language.Malgo.MIR       as MIR
 import qualified Language.Malgo.Parser    as Parser
 import qualified Language.Malgo.Rename    as Rename
+import qualified Language.Malgo.Syntax    as Syntax
 import qualified Language.Malgo.TypeCheck as TypeCheck
 import           Language.Malgo.Utils
-
 import           System.Environment       (getArgs)
+
+compile ::
+  Monad m =>
+  Syntax.Expr Name
+  -> StateT Int m (MIR.Program TypeCheck.TypedID)
+compile ast = do
+  renamed <- doMalgoT (Rename.rename ast)
+    >>= \case Left x  -> error $ show x
+              Right x -> return x
+  typechecked <- doMalgoT (TypeCheck.typeCheck renamed)
+    >>= \case Left x -> error $ show x
+              Right x -> return x
+  knormal <- doMalgoT (KNormal.knormal typechecked)
+    >>= \case Left x -> error $ show x
+              Right x -> return x
+  beta <- doMalgoT (Beta.betaTrans knormal)
+    >>= \case Left x -> error $ show x
+              Right x -> return x
+  mir <- doMalgoT (Closure.conv (Flatten.flatten beta))
+    >>= \case Left x -> error $ show x
+              Right x -> return x
+  return mir
+
+eval ::
+  Syntax.Expr Name
+  -> IO (Either MalgoError Eval.Value)
+eval ast = flip evalStateT 0 $ do
+  mir <- compile ast
+  doMalgoT (Eval.eval mir)
 
 main :: IO ()
 main = do
@@ -28,31 +62,10 @@ main = do
         Left x  -> error $ show x
         Right x -> x
 
-  let (renamedAST, rnenv) = case Rename.rename ast of
-        (Right x, e) -> (x, e)
-        (Left x, _)  -> error $ show $ pretty x
+  e <- eval ast
 
-  let typedAST = case TypeCheck.typeCheck renamedAST of
-        (Right x, _) -> x
-        (Left x, _)  -> error $ show $ pretty x
-
-  let (knormal, kenv) = case KNormal.knormal rnenv typedAST of
-        (Right x, e) -> (x, e)
-        (Left x, _)  -> error $ show $ pretty x
-
-  let beta = case Beta.betaTrans knormal of
-        (Right x, _) -> x
-        (Left x, _)  -> error $ show $ pretty x
-
-  let flatten = Flatten.flatten beta
-
-  let closure = case Closure.conv (KNormal._count kenv) flatten of
-        (Right x, _) -> x
-        (Left x, _)  -> error $ show $ pretty x
-
-  eval <- Eval.eval closure
-  let result = case eval of
-        (Right x, _) -> x
-        (Left x, _)  -> error $ show $ pretty x
+  let result = case e of
+        Right x -> x
+        Left x  -> error $ show $ pretty x
 
   seq result $ return ()


### PR DESCRIPTION
コンパイルパスをモナドの演算として合成するように変更。
ユニークな整数生成をMalgoT s mモナドの機能に昇格。

各パスで扱うモナドをモナド変換子に変更、任意のモナドを内包できるようにした。
この変更はsrc/Language/Malgo/Eval.hsに合わせたもの。