### PR TITLE
fix(ci): remove manual GHCup cache step causing utime errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,6 @@ jobs:
 
       - name: Set up GHCup
         uses: haskell/ghcup-setup@2860d0b41e2c5aa7d005bcbc2bd2506a09557ed8 # v1.2.2
-        id: ghcup
-
-      - name: Cache GHCup
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ${{ steps.ghcup.outputs.basedir }}
-          key: ${{ runner.os }}-ghcup-v2-${{ matrix.ghc-version }}
 
       - name: Install GHC and cabal
         id: setup


### PR DESCRIPTION
## Summary

- `haskell/ghcup-setup` v1.2+ は内部でキャッシュを管理しており、手動の `Cache GHCup` ステップは不要
- `/usr/local/.ghcup` は root 所有のため、`actions/cache` による tar 展開時に runner ユーザーが `utime`/`chmod` できずエラーが発生していた
- 手動キャッシュステップを削除することで解決

## Test plan

- [ ] CI が utime エラーなしで通過することを確認