### PR TITLE
fix(ci): close stale release PRs when version bumps

### DIFF
--- a/.github/scripts/create-or-update-pr.js
+++ b/.github/scripts/create-or-update-pr.js
@@ -40,13 +40,16 @@ try {
     `gh pr list --base ${baseBranch} --state open --json number,headRefName --jq '[.[] | select(.headRefName | startswith("release/")) | select(.headRefName != "${branchName}")]'`,
     { silent: true, ignoreError: true }
   );
-  if (staleReleasePrs) {
-    const stalePrs = JSON.parse(staleReleasePrs);
-    for (const pr of stalePrs) {
-      console.log(`Closing stale release PR #${pr.number} (${pr.headRefName})`);
-      exec(`gh pr close ${pr.number} --comment "Superseded by release ${version}"`);
-      exec(`git push origin --delete ${pr.headRefName}`, { ignoreError: true });
-    }
+  let stalePrs = [];
+  try {
+    stalePrs = staleReleasePrs ? JSON.parse(staleReleasePrs) : [];
+  } catch (_) {
+    console.log('Warning: failed to parse stale release PR list, skipping cleanup');
+  }
+  for (const pr of stalePrs) {
+    console.log(`Closing stale release PR #${pr.number} (${pr.headRefName})`);
+    exec(`gh pr close ${pr.number} --comment "Superseded by release ${version}"`, { ignoreError: true });
+    exec(`git push origin --delete ${pr.headRefName}`, { ignoreError: true });
   }
 
   const existingPr = exec(

--- a/.github/scripts/create-or-update-pr.js
+++ b/.github/scripts/create-or-update-pr.js
@@ -36,6 +36,19 @@ try {
   exec(`git checkout -b ${branchName}`);
   exec(`git commit --allow-empty -m "chore(release): prepare ${version}"`);
 
+  const staleReleasePrs = exec(
+    `gh pr list --base ${baseBranch} --state open --json number,headRefName --jq '[.[] | select(.headRefName | startswith("release/")) | select(.headRefName != "${branchName}")]'`,
+    { silent: true, ignoreError: true }
+  );
+  if (staleReleasePrs) {
+    const stalePrs = JSON.parse(staleReleasePrs);
+    for (const pr of stalePrs) {
+      console.log(`Closing stale release PR #${pr.number} (${pr.headRefName})`);
+      exec(`gh pr close ${pr.number} --comment "Superseded by release ${version}"`);
+      exec(`git push origin --delete ${pr.headRefName}`, { ignoreError: true });
+    }
+  }
+
   const existingPr = exec(
     `gh pr list --head ${branchName} --base ${baseBranch} --json number --jq '.[0].number'`,
     { silent: true, ignoreError: true }

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -99,6 +99,18 @@ jobs:
           echo "next_tag=$next_tag" >> $GITHUB_OUTPUT
           echo "bump_type=$bump_type" >> $GITHUB_OUTPUT
 
+      - name: Clean up stale draft releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.compute.outputs.next_tag }}
+        run: |
+          gh release list --exclude-pre-releases --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName' | while read -r tag; do
+            if [ "$tag" != "$NEXT_TAG" ]; then
+              echo "Deleting stale draft release: $tag"
+              gh release delete "$tag" --yes
+            fi
+          done
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- バージョンが変わった時（例: patch → minor）に古いリリースPRとドラフトリリースが残る問題を修正
- `create-or-update-pr.js` に、異なるバージョンの既存リリースPRを自動クローズする処理を追加
- `create-release-pr.yml` に、古いドラフトリリースを削除するステップを追加

## 背景
v2.3.1 のリリースPR (#292) が存在する状態で `feat` ラベル付きPRがマージされると、v2.4.0 のリリースPR (#300) が新たに作成されるが、v2.3.1 のPRはクローズされずに残っていた。

## Test plan
- [ ] `fix` ラベルPRマージ後にリリースPRが1つだけ作成されることを確認
- [ ] その後 `feat` ラベルPRをマージし、古いリリースPRが自動クローズされ新しいPRのみ残ることを確認
- [ ] 古いドラフトリリースが削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)