### PR TITLE
feat(ci): cache GHC installation with custom setup action

### DIFF
--- a/.github/actions/setup-haskell-cached/action.yml
+++ b/.github/actions/setup-haskell-cached/action.yml
@@ -31,12 +31,6 @@ runs:
         path: ~/.ghcup
         key: ghcup-${{ runner.os }}-${{ runner.arch }}-ghc-${{ inputs.ghc-version }}-cabal-${{ inputs.cabal-version }}
 
-    - name: Setup PATH
-      shell: bash
-      run: |
-        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-
     - name: Install ghcup, GHC, and Cabal (on cache miss)
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
@@ -48,14 +42,25 @@ runs:
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
         source "$HOME/.ghcup/env"
         ghcup install ghc ${{ inputs.ghc-version }}
-        ghcup set ghc ${{ inputs.ghc-version }}
         ghcup install cabal ${{ inputs.cabal-version }}
-        ghcup set cabal ${{ inputs.cabal-version }}
+
+    - name: Setup PATH
+      shell: bash
+      run: |
+        echo "$HOME/.ghcup/ghc/${{ inputs.ghc-version }}/bin" >> $GITHUB_PATH
+        cabal_dir=$(ls -d "$HOME/.ghcup/cabal/"*/bin 2>/dev/null | head -1)
+        if [ -n "$cabal_dir" ]; then
+          echo "$cabal_dir" >> $GITHUB_PATH
+        fi
+        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
 
     - name: Verify installation
       shell: bash
       run: |
+        which ghc
         ghc --version
+        which cabal
         cabal --version
 
     - name: Update cabal package index

--- a/.github/actions/setup-haskell-cached/action.yml
+++ b/.github/actions/setup-haskell-cached/action.yml
@@ -24,35 +24,32 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Prepare ghcup directory for caching
+      shell: bash
+      run: |
+        sudo mkdir -p /usr/local/.ghcup
+        sudo chown -R $(whoami) /usr/local/.ghcup
+
     - name: Restore ghcup cache
       id: cache
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        path: ~/.ghcup
+        path: /usr/local/.ghcup
         key: ghcup-${{ runner.os }}-${{ runner.arch }}-ghc-${{ inputs.ghc-version }}-cabal-${{ inputs.cabal-version }}
 
-    - name: Install ghcup, GHC, and Cabal (on cache miss)
+    - name: Install GHC and Cabal (on cache miss)
       if: steps.cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        export GHCUP_INSTALL_BASE_PREFIX="$HOME"
-        export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
-        export BOOTSTRAP_HASKELL_NO_UPGRADE=1
-        export BOOTSTRAP_HASKELL_MINIMAL=1
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-        source "$HOME/.ghcup/env"
-        ghcup install ghc ${{ inputs.ghc-version }}
-        ghcup install cabal ${{ inputs.cabal-version }}
+      uses: haskell-actions/setup@de26526e12bc780fb9d384c1fb61c0bf02e3a40d # v2.10.4
+      with:
+        ghc-version: ${{ inputs.ghc-version }}
+        cabal-version: ${{ inputs.cabal-version }}
+        cabal-update: false
 
-    - name: Setup PATH
+    - name: Setup PATH (on cache hit)
+      if: steps.cache.outputs.cache-hit == 'true'
       shell: bash
       run: |
-        echo "$HOME/.ghcup/ghc/${{ inputs.ghc-version }}/bin" >> $GITHUB_PATH
-        cabal_dir=$(ls -d "$HOME/.ghcup/cabal/"*/bin 2>/dev/null | head -1)
-        if [ -n "$cabal_dir" ]; then
-          echo "$cabal_dir" >> $GITHUB_PATH
-        fi
-        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        echo "/usr/local/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
 
     - name: Verify installation

--- a/.github/actions/setup-haskell-cached/action.yml
+++ b/.github/actions/setup-haskell-cached/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Haskell (Cached)"
-description: "GHC/Cabal を ~/.ghcup にインストールし、キャッシュする"
+description: "GHC/Cabal セットアップを /usr/local/.ghcup のキャッシュで高速化する"
 
 inputs:
   ghc-version:

--- a/.github/actions/setup-haskell-cached/action.yml
+++ b/.github/actions/setup-haskell-cached/action.yml
@@ -40,14 +40,13 @@ runs:
     - name: Install ghcup, GHC, and Cabal (on cache miss)
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      env:
-        GHCUP_INSTALL_BASE_PREFIX: ${{ github.home }}
-        BOOTSTRAP_HASKELL_NONINTERACTIVE: "1"
-        BOOTSTRAP_HASKELL_NO_UPGRADE: "1"
-        BOOTSTRAP_HASKELL_MINIMAL: "1"
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
-          GHCUP_INSTALL_BASE_PREFIX="$HOME" sh
+        export GHCUP_INSTALL_BASE_PREFIX="$HOME"
+        export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+        export BOOTSTRAP_HASKELL_NO_UPGRADE=1
+        export BOOTSTRAP_HASKELL_MINIMAL=1
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+        source "$HOME/.ghcup/env"
         ghcup install ghc ${{ inputs.ghc-version }}
         ghcup set ghc ${{ inputs.ghc-version }}
         ghcup install cabal ${{ inputs.cabal-version }}

--- a/.github/actions/setup-haskell-cached/action.yml
+++ b/.github/actions/setup-haskell-cached/action.yml
@@ -1,0 +1,73 @@
+name: "Setup Haskell (Cached)"
+description: "GHC/Cabal を ~/.ghcup にインストールし、キャッシュする"
+
+inputs:
+  ghc-version:
+    description: "GHC version to install"
+    required: true
+  cabal-version:
+    description: "Cabal version to install"
+    required: false
+    default: "latest"
+
+outputs:
+  ghc-version:
+    description: "Installed GHC version"
+    value: ${{ steps.info.outputs.ghc-version }}
+  cabal-version:
+    description: "Installed Cabal version"
+    value: ${{ steps.info.outputs.cabal-version }}
+  cabal-store:
+    description: "Cabal store path"
+    value: ${{ steps.info.outputs.cabal-store }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore ghcup cache
+      id: cache
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ~/.ghcup
+        key: ghcup-${{ runner.os }}-${{ runner.arch }}-ghc-${{ inputs.ghc-version }}-cabal-${{ inputs.cabal-version }}
+
+    - name: Setup PATH
+      shell: bash
+      run: |
+        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+
+    - name: Install ghcup, GHC, and Cabal (on cache miss)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GHCUP_INSTALL_BASE_PREFIX: ${{ github.home }}
+        BOOTSTRAP_HASKELL_NONINTERACTIVE: "1"
+        BOOTSTRAP_HASKELL_NO_UPGRADE: "1"
+        BOOTSTRAP_HASKELL_MINIMAL: "1"
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
+          GHCUP_INSTALL_BASE_PREFIX="$HOME" sh
+        ghcup install ghc ${{ inputs.ghc-version }}
+        ghcup set ghc ${{ inputs.ghc-version }}
+        ghcup install cabal ${{ inputs.cabal-version }}
+        ghcup set cabal ${{ inputs.cabal-version }}
+
+    - name: Verify installation
+      shell: bash
+      run: |
+        ghc --version
+        cabal --version
+
+    - name: Update cabal package index
+      shell: bash
+      run: cabal update
+
+    - name: Collect outputs
+      id: info
+      shell: bash
+      run: |
+        echo "ghc-version=$(ghc --numeric-version)" >> $GITHUB_OUTPUT
+        echo "cabal-version=$(cabal --numeric-version)" >> $GITHUB_OUTPUT
+        store_dir=$(cabal path --store-dir 2>/dev/null || echo "$HOME/.cabal/store")
+        echo "cabal-store=$store_dir" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-lsp.yml
+++ b/.github/workflows/build-lsp.yml
@@ -26,12 +26,10 @@ jobs:
             touch -d "$(git log --pretty=format:%cI -1 "$rev" -- "$f")" "$f"
           done
 
-      - uses: haskell-actions/setup@de26526e12bc780fb9d384c1fb61c0bf02e3a40d # v2.10.4
+      - uses: ./.github/actions/setup-haskell-cached
         id: setup
         with:
           ghc-version: ${{ matrix.ghc-version }}
-          cabal-version: latest
-          cabal-update: true
 
       - name: Configure the build
         run: cabal configure --disable-tests --disable-documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,10 @@ jobs:
             touch -d "$(git log --pretty=format:%cI -1 "$rev" -- "$f")" "$f"
           done
 
-      - uses: haskell-actions/setup@de26526e12bc780fb9d384c1fb61c0bf02e3a40d # v2.10.4
+      - uses: ./.github/actions/setup-haskell-cached
         id: setup
         with:
           ghc-version: ${{ matrix.ghc-version }}
-          cabal-version: latest
-          cabal-update: true
 
       - name: Configure the build
         run: cabal configure --enable-tests --disable-documentation


### PR DESCRIPTION
## Summary

- `haskell-actions/setup` の GHC インストール（~3分）を `actions/cache` でキャッシュし高速化
- GitHub runner の ghcup インストール先 `/usr/local/.ghcup`（root 所有）を `sudo chown` で権限修正し、直接キャッシュ可能にした
- キャッシュヒット時、CI 全体が 5m → 2m40s に短縮

## 変更内容

- `.github/actions/setup-haskell-cached/action.yml` — 新規 composite action
  - `sudo chown` で `/usr/local/.ghcup` の権限をユーザーに変更
  - `actions/cache` で `/usr/local/.ghcup` をキャッシュ/リストア
  - キャッシュミス時は `haskell-actions/setup` で通常インストール
  - キャッシュヒット時は PATH 設定のみ
  - `cabal update` は常に実行
- `.github/workflows/build.yml` — `haskell-actions/setup` → カスタム action に置き換え
- `.github/workflows/build-lsp.yml` — 同上

## Test plan

- [x] キャッシュミス: ghcup インストール → ビルド・テスト通過（5m21s / 4m47s）
- [x] キャッシュヒット: インストールスキップ → ビルド・テスト通過（2m40s / 1m45s）
- [x] `ghc --version` / `cabal --version` の出力が正しい
- [x] `cabal-store` output が正しく設定され、cabal store キャッシュが機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)