### PR TITLE
chore(devcontainer): GHC 9.12.4 toolchain workarounds and GH_TOKEN passthrough

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
 		"dockerfile": "Dockerfile"
 	},
 	"remoteEnv": {
-		"PATH": "${containerEnv:PATH}:/home/vscode/.ghcup/bin:/home/vscode/.cabal/bin:/home/vscode/.go/bin:/home/vscode/.local/share/mise/installs/ghcup/latest"
+		"PATH": "${containerEnv:PATH}:/home/vscode/.ghcup/bin:/home/vscode/.cabal/bin:/home/vscode/.go/bin:/home/vscode/.local/share/mise/installs/ghcup/latest",
+		"GH_TOKEN": "${localEnv:COPILOT_TOKEN}"
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,5 @@
 /home/vscode/.local/bin/mise trust
 /home/vscode/.local/bin/mise install
 /home/vscode/.local/bin/mise run setup
-/home/vscode/.local/bin/mise run setup-hls
+# HLS setup is skipped: HLS 2.13.0.0 does not yet support GHC 9.12.4.
+# Run `mise run setup-hls` manually once HLS gains GHC 9.12.4 support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Malgo is a statically typed functional programming language with an interpreter 
 ## Build, Test, and Development Commands
 
 ```bash
-mise run setup       # Install toolchain (GHC 9.12.2, cabal, hpack, ormolu)
+mise run setup       # Install toolchain (GHC 9.12.4, cabal, hpack, ormolu)
 mise run build       # Format + build (hpack && cabal build)
 mise run test        # Run test suite
 mise run test -- --match=Parser  # Run tests matching "Parser"

--- a/mise.toml
+++ b/mise.toml
@@ -30,17 +30,21 @@ run = [
     "ghcup install cabal latest",
     "ghcup set cabal latest",
     "cabal update",
-    "cabal install hpack --overwrite-policy=always",
-    "cabal install ormolu --overwrite-policy=always",
+    "cabal install hpack --overwrite-policy=always --ignore-project",
+    "cabal install ormolu --overwrite-policy=always --ignore-project",
 ]
 
 [tasks.setup-hls]
-description = "Setup HLS"
-# run = [
-#     "ghcup install hls latest",
-#     "ghcup set hls latest",
-# ]
-run = "ghcup compile hls -g 2.13.0.0 --ghc 9.12.4 --cabal-update"
+description = "Setup HLS (requires HLS support for the project's GHC version)"
+# No HLS binary distribution for GHC 9.12.4 yet (see haskell/haskell-language-server#4890).
+# Compiles HLS 2.13.0.0 from source. This takes a long time (~30-60 min).
+# Once HLS 2.14.0.0 ships with bindists, replace with:
+#   "ghcup install hls latest"
+#   "ghcup set hls latest"
+run = [
+    "ghcup compile hls -v 2.13.0.0 --ghc 9.12.4",
+    "ghcup set hls 2.13.0.0",
+]
 
 [tasks.format]
 description = "Format the code"


### PR DESCRIPTION
## Summary

- Bump documented GHC version 9.12.2 → 9.12.4 in `AGENTS.md` (and `CLAUDE.md` via the symlink).
- Pass `COPILOT_TOKEN` through as `GH_TOKEN` inside the devcontainer so `gh` works out of the box.
- Skip auto-running `setup-hls` in `post-create.sh`: HLS 2.13.0.0 has no bindist for GHC 9.12.4, so users now invoke it manually.
- Rewrite `mise.toml` `[tasks.setup-hls]` to compile HLS 2.13.0.0 from source against GHC 9.12.4 (~30–60 min). Comment notes the simpler bindist install path to switch back to once HLS 2.14.0.0 ships.
- Pass `--ignore-project` to `cabal install hpack`/`ormolu` so the project's freeze file does not constrain global tool installs.

## Test plan

- [ ] Rebuild the devcontainer and confirm `post-create.sh` finishes without trying setup-hls.
- [ ] Confirm `gh auth status` works inside the container (uses `GH_TOKEN`).
- [ ] Run `mise run setup-hls` manually and confirm HLS 2.13.0.0 builds against GHC 9.12.4.
- [ ] Run `mise run setup` and confirm hpack / ormolu install cleanly with `--ignore-project`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)