### PR TITLE
fix(module): replace pwdPath with parseArtifactPathFromPwd

### DIFF
--- a/src/Malgo/Driver.hs
+++ b/src/Malgo/Driver.hs
@@ -85,8 +85,7 @@ compile ::
   Eff es ()
 compile srcPath = do
   flags <- ask @Flag
-  pwd <- pwdPath
-  srcModulePath <- parseArtifactPath pwd srcPath
+  srcModulePath <- parseArtifactPathFromPwd srcPath
   src <- liftIO $ BS.readFile srcPath
   save srcModulePath ".mlg" src
   runCompileError do

--- a/src/Malgo/Module.hs
+++ b/src/Malgo/Module.hs
@@ -11,8 +11,8 @@ module Malgo.Module
     ArtifactPath (..),
     WorkspaceError (..),
     Resource (..),
-    pwdPath,
     parseArtifactPath,
+    parseArtifactPathFromPwd,
     ViaBinary (..),
     ViaShow (..),
     moduleNameToString,
@@ -132,8 +132,7 @@ searchAndRegister (ModuleName moduleName) = do
   workspace <- getWorkspaceAbs
   file <- search [toFilePath workspace] fileName
   let relPath = makeRelative (toFilePath workspace) file
-  pwd <- pwdPath
-  path <- parseArtifactPath pwd relPath
+  path <- parseArtifactPathFromPwd relPath
   registerModule (ModuleName moduleName) path
   pure path
   where
@@ -191,21 +190,6 @@ instance Show ArtifactPath where
 instance Pretty ArtifactPath where
   pretty path = pretty $ toFilePath path.relPath
 
-pwdPath :: (Workspace :> es) => Eff es ArtifactPath
-pwdPath = do
-  workspace <- getWorkspaceAbs
-  let pwd = parent workspace
-  let originPath = pwd </> mkRelFile "dummy"
-  let relPath = mkRelFile "dummy"
-  let targetPath = workspace </> mkRelFile "dummy"
-  pure
-    $ ArtifactPath
-      { rawPath = ".",
-        originPath,
-        relPath,
-        targetPath
-      }
-
 parseArtifactPath :: (IOE :> es, Workspace :> es) => ArtifactPath -> FilePath -> Eff es ArtifactPath
 parseArtifactPath from path = do
   basePath <- liftIO $ makeAbsolute $ toFilePath $ parent from.originPath
@@ -216,6 +200,19 @@ parseArtifactPath from path = do
   let originBasePath = parent workspace
   relPath <- stripProperPrefix originBasePath originPath
 
+  let targetPath = workspace </> relPath
+  pure $ ArtifactPath {rawPath = path, originPath, relPath, targetPath}
+
+-- | Resolve a path string relative to the directory containing the workspace
+-- (i.e. the user's "pwd" in the project root).
+parseArtifactPathFromPwd :: (IOE :> es, Workspace :> es) => FilePath -> Eff es ArtifactPath
+parseArtifactPathFromPwd path = do
+  workspace <- getWorkspaceAbs
+  let pwd = parent workspace
+  basePath <- liftIO $ makeAbsolute $ toFilePath pwd
+  rawPath <- liftIO $ canonicalizePath (basePath F.</> path)
+  originPath <- parseAbsFile rawPath
+  relPath <- stripProperPrefix pwd originPath
   let targetPath = workspace </> relPath
   pure $ ArtifactPath {rawPath = path, originPath, relPath, targetPath}
 

--- a/src/Malgo/Parser/CStyle.hs
+++ b/src/Malgo/Parser/CStyle.hs
@@ -9,7 +9,7 @@ import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Effectful (Eff, IOE, type (:>))
 import Malgo.Features (Features)
-import Malgo.Module (ModuleName (..), Workspace, parseArtifactPath, pwdPath)
+import Malgo.Module (ModuleName (..), Workspace, parseArtifactPath, parseArtifactPathFromPwd)
 import Malgo.Parser.Core
   ( Parser,
     captureRange,
@@ -47,8 +47,7 @@ pModule :: (IOE :> es, Workspace :> es, Features :> es) => Parser es (Module (Ma
 pModule = do
   space -- consume leading whitespace and comments
   sourcePath <- (.sourceName) <$> getSourcePos
-  pwd <- lift pwdPath
-  sourcePath <- lift $ parseArtifactPath pwd sourcePath
+  sourcePath <- lift $ parseArtifactPathFromPwd sourcePath
   decls <- many pDecl
   pure
     Module
@@ -212,8 +211,7 @@ pImport = captureRange do
     asPath = do
       path <- pStringLiteral
       sourcePath <- (.sourceName) <$> getSourcePos
-      pwd <- lift pwdPath
-      sourcePath <- lift $ parseArtifactPath pwd sourcePath
+      sourcePath <- lift $ parseArtifactPathFromPwd sourcePath
       path' <- lift $ parseArtifactPath sourcePath path
       pure $ Artifact path'
 

--- a/test/Malgo/TestUtils.hs
+++ b/test/Malgo/TestUtils.hs
@@ -174,8 +174,7 @@ setupEvalModule srcPath = do
   src <- BS.readFile srcPath
   db <- newDatabase
   runMalgoM flag $ runCompileError $ runQueryDB db do
-    pwd <- pwdPath
-    srcModulePath <- parseArtifactPath pwd srcPath
+    srcModulePath <- parseArtifactPathFromPwd srcPath
     save srcModulePath ".mlg" src
     parsed <- runPass ParserPass (srcPath, convertString src)
     rnEnv <- genBuiltinRnEnv
@@ -190,8 +189,7 @@ compileTestCase builtinName preludeName srcPath = do
   src <- BS.readFile srcPath
   db <- newDatabase
   runMalgoM flag $ runCompileError $ runQueryDB db do
-    pwd <- pwdPath
-    srcModulePath <- parseArtifactPath pwd srcPath
+    srcModulePath <- parseArtifactPathFromPwd srcPath
     save srcModulePath ".mlg" src
     parsed <- runPass ParserPass (srcPath, convertString src)
     rnEnv <- genBuiltinRnEnv
@@ -212,8 +210,7 @@ compileTestCaseWithElaborate builtinName preludeName srcPath = do
   src <- BS.readFile srcPath
   db <- newDatabase
   runMalgoMWith flag (FeatureFlags (Set.singleton Malgo2025)) $ runCompileError $ runQueryDB db do
-    pwd <- pwdPath
-    srcModulePath <- parseArtifactPath pwd srcPath
+    srcModulePath <- parseArtifactPathFromPwd srcPath
     save srcModulePath ".mlg" src
     parsed <- runPass ParserPass (srcPath, convertString src)
     rnEnv <- genBuiltinRnEnv


### PR DESCRIPTION
## Summary

- Closes #324: `pwdPath` returned an `ArtifactPath` with the fixed `relPath = mkRelFile \"dummy\"`, so after #319 made `Eq`/`Ord`/`Hashable` depend solely on `relPath`, distinct workspaces' `pwdPath` instances collided in `HashMap`/`Set`.
- All 7 call sites used the same pattern (`pwd <- pwdPath; x <- parseArtifactPath pwd p`); the synthetic `ArtifactPath` was scaffolding only.
- Introduce `parseArtifactPathFromPwd :: FilePath -> Eff es ArtifactPath` that resolves a path against the directory containing the workspace, and remove `pwdPath` entirely.

## Test plan

- [x] \`mise run format\`
- [x] \`mise run test\` (1128 examples, 0 failures, 23 pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)