### PR TITLE
fix(infer): make constraint solving failure-atomic

### DIFF
--- a/src/Malgo/Infer/Unify.hs
+++ b/src/Malgo/Infer/Unify.hs
@@ -33,7 +33,9 @@ unify pos t1 t2 = do
   subst <- currentSubst
   let t1' = applySubst subst t1
       t2' = applySubst subst t2
-  evalState (Set.empty :: Set (Ty, Ty)) $ unifyTypes pos t1' t2'
+  s <- evalState (Set.empty :: Set (Ty, Ty)) $ unifyTypes pos t1' t2'
+  commitSubst s
+  pure s
 
 -- | Core unification
 unifyTypes :: (UnifyEffs es, State (Set (Ty, Ty)) :> es) => Range -> Ty -> Ty -> Eff es Subst
@@ -63,13 +65,9 @@ unifyInternal _ (TVar x _) t
   | occursIn x t = do
       -- Equi-recursive unification: create TMu
       let t' = TMu x t
-      let s = Map.singleton x t'
-      modify (\st -> st {solvedSubst = Map.map (applySubst s) st.solvedSubst <> s})
-      pure s
+      pure $ Map.singleton x t'
   | otherwise = do
-      let s = Map.singleton x t
-      modify (\st -> st {solvedSubst = Map.map (applySubst s) st.solvedSubst <> s})
-      pure s
+      pure $ Map.singleton x t
 -- Variable on the right
 unifyInternal pos t (TVar x l) = unifyTypes pos (TVar x l) t
 -- TMu on the left: unroll and unify
@@ -237,28 +235,36 @@ solveConstraints :: (UnifyEffs es) => Eff es Subst
 solveConstraints = do
   st <- get
   let cs = reverse st.constraints
-  modify (\s -> s {constraints = []})
-  mapM_ solveOne cs
+      baseSubst = st.solvedSubst
+  s <- foldlM' (solveOne baseSubst) Map.empty cs
+  commitSubst s
+  modify (\st' -> st' {constraints = []})
   currentSubst
   where
-    solveOne :: (UnifyEffs es) => TyConstraint -> Eff es ()
-    solveOne (CUnify pos t1 t2) = do
-      subst <- currentSubst
+    solveOne :: (UnifyEffs es) => Subst -> Subst -> TyConstraint -> Eff es Subst
+    solveOne baseSubst acc (CUnify pos t1 t2) = do
+      let subst = composeSubst acc baseSubst
       let t1' = applySubst subst t1
           t2' = applySubst subst t2
-      _ <- evalState (Set.empty @(Ty, Ty)) $ unifyTypes pos t1' t2'
-      pure ()
-    solveOne (CBottomProp sources target) = do
-      subst <- currentSubst
-      let sources' = map (applySubst subst) sources
+      s <- evalState (Set.empty @(Ty, Ty)) $ unifyTypes pos t1' t2'
+      pure $ composeSubst s acc
+    solveOne baseSubst acc (CBottomProp sources target) = do
+      let subst = composeSubst acc baseSubst
+          sources' = map (applySubst subst) sources
           target' = applySubst subst target
       -- If any source is bottom, target should also be bottom
-      when (any isBottom sources') $ do
-        case target' of
+      if any isBottom sources'
+        then case target' of
           TVar _ _ -> do
-            _ <- evalState (Set.empty @(Ty, Ty)) $ unifyTypes dummyRange target' TBottom
-            pure ()
-          _ -> pure ()
+            s <- evalState (Set.empty @(Ty, Ty)) $ unifyTypes dummyRange target' TBottom
+            pure $ composeSubst s acc
+          _ -> pure acc
+        else pure acc
+
+-- | Commit a successfully-computed substitution to the global inference state.
+commitSubst :: (State GenState :> es) => Subst -> Eff es ()
+commitSubst s =
+  modify (\st -> st {solvedSubst = composeSubst s st.solvedSubst})
 
 -- | Check if a type is bottom (after substitution)
 isBottom :: Ty -> Bool

--- a/test/Malgo/InferSpec.hs
+++ b/test/Malgo/InferSpec.hs
@@ -7,13 +7,13 @@ import Data.Set qualified as Set
 import Effectful (runPureEff)
 import Effectful.Error.Static (runError)
 import Effectful.Reader.Static (runReader)
-import Effectful.State.Static.Local (evalState)
+import Effectful.State.Static.Local (evalState, runState)
 import Malgo.Elaborate (ElaboratePass (..))
 import Malgo.Features (Feature (..), FeatureFlags (..))
 import Malgo.Id (Id (..), IdSort (..))
 import Malgo.Infer (InferPass (..), TyEnv)
 import Malgo.Infer.Constraint
-import Malgo.Infer.Unify (unify)
+import Malgo.Infer.Unify (solveConstraints, unify)
 import Malgo.Module (ModuleName (..))
 import Malgo.Monad (runMalgoMWith)
 import Malgo.Parser (ParserPass (..))
@@ -240,6 +240,27 @@ spec = parallel do
           Left _ -> pure ()
           Right _ -> expectationFailure "Expected failure on different-length tuples"
 
+    describe "constraint solving" do
+      it "does not commit substitutions or clear constraints when solving fails" do
+        let existing = mkId "_existing"
+            inferred = mkId "_inferred"
+            initialSubst = Map.singleton existing tyString
+            successfulConstraint = CUnify dummyRange (TVar inferred 0) tyInt32
+            failingConstraint = CUnify dummyRange tyInt32 tyString
+            initialConstraints = [failingConstraint, successfulConstraint]
+            initState =
+              GenState
+                { constraints = initialConstraints,
+                  currentLevel = 0,
+                  solvedSubst = initialSubst
+                }
+        (result, finalState) <- runSolveConstraints initState
+        case result of
+          Left _ -> pure ()
+          Right _ -> expectationFailure "Expected constraint solving to fail"
+        finalState.solvedSubst `shouldBe` initialSubst
+        finalState.constraints `shouldBe` initialConstraints
+
 -- | Module name used by tests when constructing 'Id' values via 'mkId'.
 testModule :: ModuleName
 testModule = ModuleName "Test"
@@ -268,6 +289,20 @@ runUnify pos t1 t2 = pure (stripCallStack result)
         $ unify pos t1 t2
     stripCallStack (Left (_, err)) = Left err
     stripCallStack (Right x) = Right x
+
+-- | Helper to run constraint solving while preserving the final GenState.
+runSolveConstraints :: GenState -> IO (Either InferError Subst, GenState)
+runSolveConstraints initState = pure (stripCallStack result)
+  where
+    result =
+      runPureEff
+        $ runReader testModule
+        $ evalState (Uniq 0)
+        $ runState initState
+        $ runError @InferError
+        $ solveConstraints
+    stripCallStack (Left (_, err), finalState) = (Left err, finalState)
+    stripCallStack (Right x, finalState) = (Right x, finalState)
 
 -- | Testcases that are known to fail or hang under InferPass. Tracked
 -- in #333; promote a case out of this map once the underlying inferencer


### PR DESCRIPTION
Fix issue #328 by deferring solvedSubst commits until unification or constraint solving succeeds.

Changes:
- stop mutating solvedSubst inside unifyInternal
- commit substitutions only after successful unify
- make solveConstraints preserve state on failure and clear constraints only after success
- add a regression test covering a later constraint failure after an earlier successful substitution

Verification:
- mise run format
- mise run test
