### PR TITLE
fix(devcontainer): force UTF-8 locale for postCreate setup

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/copilot-cli:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/devcontainers/features/copilot-cli@sha256:757c6c2899dc902c44a9f6164c1f7392832ced13c6bb632d8d60a880f2e92456",
+      "integrity": "sha256:757c6c2899dc902c44a9f6164c1f7392832ced13c6bb632d8d60a880f2e92456"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,10 @@
 	},
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/home/vscode/.ghcup/bin:/home/vscode/.cabal/bin:/home/vscode/.go/bin:/home/vscode/.local/share/mise/installs/ghcup/latest",
-		"GH_TOKEN": "${localEnv:COPILOT_TOKEN}"
+		"GH_TOKEN": "${localEnv:COPILOT_TOKEN}",
+		"LANG": "C.UTF-8",
+		"LC_ALL": "C.UTF-8",
+		"LC_CTYPE": "C.UTF-8"
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,3 +1,7 @@
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export LC_CTYPE=C.UTF-8
+
 /home/vscode/.local/bin/mise trust
 /home/vscode/.local/bin/mise install
 /home/vscode/.local/bin/mise run setup


### PR DESCRIPTION
## Summary
- set UTF-8 locale variables in devcontainer `remoteEnv`
- export UTF-8 locale in `.devcontainer/post-create.sh`
- prevent `happy` decode failures when installing `ormolu` (`ghc-lib-parser` build)

## Root cause
`postCreateCommand` runs under non-interactive `sh`, which can differ from interactive shell locale settings. During `cabal install ormolu`, `happy` failed decoding `Parser.y` unless UTF-8 locale was explicitly enforced.

## Validation
- `cabal install ormolu --overwrite-policy=always --ignore-project` succeeded under `C.UTF-8`
- prior `ghc-lib-parser` decode error did not recur
