### PR TITLE
fix(infer): prevent infinite loop in composeSubst when TMu value gains free key

### DIFF
--- a/src/Malgo/Infer/Unify.hs
+++ b/src/Malgo/Infer/Unify.hs
@@ -3,6 +3,7 @@
 module Malgo.Infer.Unify
   ( unify,
     solveConstraints,
+    composeSubst,
   )
 where
 
@@ -310,9 +311,18 @@ isBottom :: Ty -> Bool
 isBottom TBottom = True
 isBottom _ = False
 
--- | Compose two substitutions: s2 after s1
+-- | Compose two substitutions: s2 after s1.
+-- After applying s2 to each value in s1, a key k may appear free in its
+-- own value (e.g. k ↦ TMu(... TVar k ...)).  Leaving that in place causes
+-- applySubst to loop infinitely when it chases k.  We normalise by
+-- wrapping any such self-referential value in TMu via abstractVar.
 composeSubst :: Subst -> Subst -> Subst
-composeSubst s2 s1 = Map.map (applySubst s2) s1 <> s2
+composeSubst s2 s1 = Map.mapWithKey normalizeRecursive (Map.map (applySubst s2) s1) <> s2
+  where
+    normalizeRecursive k v
+      | not (occursIn k v) = v
+      | TMu body <- v = TMu (abstractVar k body)
+      | otherwise = TMu (abstractVar k v)
 
 -- | Look up a field type in a field list
 lookupField :: T.Text -> [(T.Text, Ty)] -> Ty

--- a/test/Malgo/InferSpec.hs
+++ b/test/Malgo/InferSpec.hs
@@ -13,7 +13,7 @@ import Malgo.Features (Feature (..), FeatureFlags (..))
 import Malgo.Id (Id (..), IdSort (..))
 import Malgo.Infer (InferPass (..), TyEnv)
 import Malgo.Infer.Constraint
-import Malgo.Infer.Unify (solveConstraints, unify)
+import Malgo.Infer.Unify (composeSubst, solveConstraints, unify)
 import Malgo.Module (ModuleName (..))
 import Malgo.Monad (runMalgoMWith)
 import Malgo.Parser (ParserPass (..))
@@ -140,6 +140,31 @@ spec = parallel do
         scheme.vars `shouldBe` [mkId "_t6"]
 
   describe "Unify" do
+    describe "composeSubst" do
+      it "does not create self-referential entry when TMu value gains free key via composition" do
+        -- Regression for issue #330:
+        -- s1 = {_t0 ↦ TMu(TBound 0 -> _t1)}  (from: _t0 = _t0 -> _t1)
+        -- s2 = {_t1 ↦ _t0 -> Int32}            (from: _t1 = _t0 -> Int32, no occurs check)
+        -- Naive composeSubst s2 s1 produces {_t0 ↦ TMu(TBound 0 -> (_t0 -> Int32))}
+        -- where _t0 is free in its own value, causing applySubst to loop.
+        let t0 = mkId "_t0"
+            t1 = mkId "_t1"
+            s1 = Map.singleton t0 (TMu (TArr (TBound 0) (TVar t1 0)))
+            s2 = Map.singleton t1 (TArr (TVar t0 0) tyInt32)
+            composed = composeSubst s2 s1
+        case Map.lookup t0 composed of
+          Nothing -> pure ()
+          Just v -> occursIn t0 v `shouldBe` False
+
+      it "composeSubst is idempotent on normal (non-recursive) entries" do
+        let t0 = mkId "_t0"
+            t1 = mkId "_t1"
+            s1 = Map.singleton t0 tyInt32
+            s2 = Map.singleton t1 tyString
+            composed = composeSubst s2 s1
+        Map.lookup t0 composed `shouldBe` Just tyInt32
+        Map.lookup t1 composed `shouldBe` Just tyString
+
     describe "basic unification" do
       it "unifies identical type constructors" do
         result <- runUnify (dummyRange) tyInt32 tyInt32


### PR DESCRIPTION
## Summary

- `composeSubst s2 s1` could produce a substitution entry `k ↦ TMu(... TVar k ...)` where `k` appears free in its own mapped value
- `applySubst` then loops infinitely when chasing `k` through the substitution
- Fix: after applying `s2` to each value in `s1`, detect self-referential entries and normalise them via `abstractVar k` + `TMu` wrapping

Closes #330

## Test plan

- [ ] New unit test `composeSubst / does not create self-referential entry when TMu value gains free key` reproduces the exact `s1`/`s2` pair from issue #330 and asserts `occursIn k composed[k] == False`
- [ ] New unit test `composeSubst / composeSubst is idempotent on normal (non-recursive) entries` guards against regressions on the common path
- [ ] Full test suite passes: `cabal test` — 1167 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)