### PR TITLE
fix(infer): resolve non-termination and RecordP unification regression

### DIFF
--- a/src/Malgo/Infer.hs
+++ b/src/Malgo/Infer.hs
@@ -304,7 +304,7 @@ inferPat env (ConP pos conName pats) = do
 inferPat env (TupleP _ pats) = do
   (bindings, patTys) <- unzip <$> traverse (inferPat env) pats
   pure (concat bindings, TTuple patTys)
-inferPat env (RecordP _ fields) = do
+inferPat env (RecordP pos fields) = do
   (bindings, fieldTys) <-
     unzip
       <$> traverse
@@ -313,7 +313,9 @@ inferPat env (RecordP _ fields) = do
             pure (b, (name, ty))
         )
         fields
-  pure (concat bindings, TRecord fieldTys Nothing)
+  resultTy <- freshTyVar
+  addConstraint $ CUnify pos resultTy (TRecord fieldTys Nothing)
+  pure (concat bindings, resultTy)
 inferPat _ (ListP pos _) = absurd pos
 inferPat _ (UnboxedP _ lit) = pure ([], inferLiteral lit)
 inferPat _ (BoxedP pos _) = absurd pos

--- a/src/Malgo/Infer/Unify.hs
+++ b/src/Malgo/Infer/Unify.hs
@@ -276,17 +276,17 @@ solveConstraints = do
   st <- get
   let cs = reverse st.constraints
       baseSubst = st.solvedSubst
-  s <- foldlM' (solveOne baseSubst) Map.empty cs
+  s <- evalState (Set.empty @(Ty, Ty)) $ foldlM' (solveOne baseSubst) Map.empty cs
   commitSubst s
   modify (\st' -> st' {constraints = []})
   currentSubst
   where
-    solveOne :: (UnifyEffs es) => Subst -> Subst -> TyConstraint -> Eff es Subst
+    solveOne :: (UnifyEffs es, State (Set (Ty, Ty)) :> es) => Subst -> Subst -> TyConstraint -> Eff es Subst
     solveOne baseSubst acc (CUnify pos t1 t2) = do
       let subst = composeSubst acc baseSubst
       let t1' = applySubst subst t1
           t2' = applySubst subst t2
-      s <- evalState (Set.empty @(Ty, Ty)) $ unifyTypes pos t1' t2'
+      s <- unifyTypes pos t1' t2'
       pure $ composeSubst s acc
     solveOne baseSubst acc (CBottomProp sources target) = do
       let subst = composeSubst acc baseSubst
@@ -296,7 +296,7 @@ solveConstraints = do
       if any isBottom sources'
         then case target' of
           TVar _ _ -> do
-            s <- evalState (Set.empty @(Ty, Ty)) $ unifyTypes dummyRange target' TBottom
+            s <- unifyTypes dummyRange target' TBottom
             pure $ composeSubst s acc
           _ -> pure acc
         else pure acc

--- a/src/Malgo/Infer/Unify.hs
+++ b/src/Malgo/Infer/Unify.hs
@@ -3,6 +3,7 @@
 module Malgo.Infer.Unify
   ( unify,
     solveConstraints,
+    composeSubst,
   )
 where
 
@@ -310,9 +311,18 @@ isBottom :: Ty -> Bool
 isBottom TBottom = True
 isBottom _ = False
 
--- | Compose two substitutions: s2 after s1
+-- | Compose two substitutions: s2 after s1.
+-- After applying s2 to each value in s1, a key k may appear free in its
+-- own value (e.g. k ↦ TMu(... TVar k ...)).  Leaving that in place causes
+-- applySubst to loop infinitely when it chases k.  We normalise by
+-- wrapping any such self-referential value in TMu via abstractVar.
 composeSubst :: Subst -> Subst -> Subst
-composeSubst s2 s1 = Map.map (applySubst s2) s1 <> s2
+composeSubst s2 s1 = Map.mapWithKey normalizeRecursive (Map.map (applySubst s2) s1) <> s2
+  where
+    normalizeRecursive k v
+      | not (occursIn k v) = v
+      | TMu body <- v = TMu (abstractVar k body)
+      | otherwise = TMu (abstractVar k v)
 
 -- | Look up a field type in a field list
 lookupField :: T.Text -> [(T.Text, Ty)] -> Ty

--- a/test/Malgo/InferSpec.hs
+++ b/test/Malgo/InferSpec.hs
@@ -153,7 +153,7 @@ spec = parallel do
             s2 = Map.singleton t1 (TArr (TVar t0 0) tyInt32)
             composed = composeSubst s2 s1
         case Map.lookup t0 composed of
-          Nothing -> pure ()
+          Nothing -> expectationFailure "Expected _t0 binding in composed substitution"
           Just v -> occursIn t0 v `shouldBe` False
 
       it "composeSubst is idempotent on normal (non-recursive) entries" do

--- a/test/Malgo/InferSpec.hs
+++ b/test/Malgo/InferSpec.hs
@@ -13,7 +13,7 @@ import Malgo.Features (Feature (..), FeatureFlags (..))
 import Malgo.Id (Id (..), IdSort (..))
 import Malgo.Infer (InferPass (..), TyEnv)
 import Malgo.Infer.Constraint
-import Malgo.Infer.Unify (solveConstraints, unify)
+import Malgo.Infer.Unify (composeSubst, solveConstraints, unify)
 import Malgo.Module (ModuleName (..))
 import Malgo.Monad (runMalgoMWith)
 import Malgo.Parser (ParserPass (..))
@@ -140,6 +140,31 @@ spec = parallel do
         scheme.vars `shouldBe` [mkId "_t6"]
 
   describe "Unify" do
+    describe "composeSubst" do
+      it "does not create self-referential entry when TMu value gains free key via composition" do
+        -- Regression for issue #330:
+        -- s1 = {_t0 ↦ TMu(TBound 0 -> _t1)}  (from: _t0 = _t0 -> _t1)
+        -- s2 = {_t1 ↦ _t0 -> Int32}            (from: _t1 = _t0 -> Int32, no occurs check)
+        -- Naive composeSubst s2 s1 produces {_t0 ↦ TMu(TBound 0 -> (_t0 -> Int32))}
+        -- where _t0 is free in its own value, causing applySubst to loop.
+        let t0 = mkId "_t0"
+            t1 = mkId "_t1"
+            s1 = Map.singleton t0 (TMu (TArr (TBound 0) (TVar t1 0)))
+            s2 = Map.singleton t1 (TArr (TVar t0 0) tyInt32)
+            composed = composeSubst s2 s1
+        case Map.lookup t0 composed of
+          Nothing -> pure ()
+          Just v -> occursIn t0 v `shouldBe` False
+
+      it "composeSubst is idempotent on normal (non-recursive) entries" do
+        let t0 = mkId "_t0"
+            t1 = mkId "_t1"
+            s1 = Map.singleton t0 tyInt32
+            s2 = Map.singleton t1 tyString
+            composed = composeSubst s2 s1
+        Map.lookup t0 composed `shouldBe` Just tyInt32
+        Map.lookup t1 composed `shouldBe` Just tyString
+
     describe "basic unification" do
       it "unifies identical type constructors" do
         result <- runUnify (dummyRange) tyInt32 tyInt32

--- a/test/Malgo/InferSpec.hs
+++ b/test/Malgo/InferSpec.hs
@@ -325,6 +325,24 @@ spec = parallel do
         finalState.solvedSubst `shouldBe` initialSubst
         finalState.constraints `shouldBe` initialConstraints
 
+      it "terminates when row-tail constraints recurse across constraint boundaries" do
+        let a = mkId "_rowA"
+            b = mkId "_rowB"
+            c1 = CUnify dummyRange (TVar a 0) (TRecord [("x", tyInt32)] (Just (TVar b 0)))
+            c2 = CUnify dummyRange (TVar b 0) (TRecord [("y", tyString)] (Just (TVar a 0)))
+            initState =
+              GenState
+                { constraints = [c2, c1],
+                  currentLevel = 0,
+                  solvedSubst = Map.empty
+                }
+            timeoutMicros = 1_000_000
+        timed <- timeout timeoutMicros $ runSolveConstraints initState
+        case timed of
+          Nothing -> expectationFailure $ "Expected solveConstraints to terminate within " <> show timeoutMicros <> " microseconds"
+          Just (result, _) ->
+            result `shouldSatisfy` isRight
+
 -- | Module name used by tests when constructing 'Id' values via 'mkId'.
 testModule :: ModuleName
 testModule = ModuleName "Test"


### PR DESCRIPTION
## Summary
- persist unification cycle tracking across the whole `solveConstraints` pass instead of resetting per-constraint
- add explicit `CUnify` generation for `RecordP` in `inferPat` so record patterns are constrained consistently
- add an InferSpec regression test to ensure cross-constraint recursive row-tail solving terminates

## Why
Issue #333 reported:
- inferencer non-termination in several full-program cases
- spurious unification behavior around record pattern inference

This change addresses both root causes without reintroducing allowlist-based pending behavior.

## Validation
- `cabal test --test-options="--match=Infer"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/StringOps"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/RecordTest"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/ListOps"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/MapFilter"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/Punctuate"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/TuplePattern"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/CopatternApplyChain"` (pass)
- `cabal test --test-options="--match=Malgo.Infer/full-program/ArithInt32"` (pass)

Closes #333