### PR TITLE
fix(parser): tighten field access precedence in CStyle parser

### DIFF
--- a/src/Malgo/Parser/CStyle.hs
+++ b/src/Malgo/Parser/CStyle.hs
@@ -17,11 +17,11 @@ import Malgo.Parser.Core
     decimal,
     ident,
     identContinue,
-    identStart,
     lexeme,
     manyUnaryOp,
     operator,
     optional,
+    rawIdent,
     reserved,
     reservedOperator,
     skipPragma,
@@ -765,7 +765,6 @@ pVariable = do
       endPos <- getSourcePos
       pure (Var (Range startPos endPos) name)
   where
-    rawIdent = TL.toStrict . TL.pack <$> ((:) <$> identStart <*> many identContinue)
     -- foldFields accumulates Project nodes; projStart is the start of the
     -- whole expression so each Project's range spans from the original start
     -- to the end of the latest field name.

--- a/src/Malgo/Parser/CStyle.hs
+++ b/src/Malgo/Parser/CStyle.hs
@@ -12,10 +12,12 @@ import Malgo.Features (Features)
 import Malgo.Module (ModuleName (..), Workspace, parseArtifactPath, parseArtifactPathFromPwd)
 import Malgo.Parser.Core
   ( Parser,
+    anyReserved,
     captureRange,
     decimal,
     ident,
     identContinue,
+    identStart,
     lexeme,
     manyUnaryOp,
     operator,
@@ -727,13 +729,53 @@ pStringLiteral = lexeme do
 
 -- * Utility Functions
 
--- | pVariable parses a variable.
+-- | pVariable parses a variable, greedily consuming any immediately-adjacent
+-- field access chains (no whitespace before the '.').
 --
--- > variable = ident ;
+-- This means @state.field@ parses as @Project (Var "state") "field"@ (a single
+-- atom), while @state .field@ (space before dot) leaves the projection to the
+-- outer @pApply@ loop, giving @(... state).field@.
+--
+-- Each AST node gets its own source range:
+-- * @Var@ covers only the identifier (@state@)
+-- * each @Project@ covers from the expression start to the end of the field name
+--
+-- > variable = ident ("." ident)* ;  -- where '.' must be immediately adjacent
 pVariable :: Parser es (Expr (Malgo Parse))
-pVariable = captureRange do
-  name <- ident
-  pure $ \range -> Var range name
+pVariable = do
+  startPos <- getSourcePos
+  -- Parse the identifier without consuming trailing whitespace so we can
+  -- check whether '.' follows immediately.
+  name <- notFollowedBy anyReserved *> rawIdent
+  identEndPos <- getSourcePos
+  -- Peek: is the next character '.' with no whitespace before it?
+  hasDot <- option False (True <$ lookAhead (char '.'))
+  if hasDot
+    then do
+      -- Tight field access: greedily consume '.field' chains before any whitespace.
+      -- The Var node gets identEndPos (which equals what ident-as-lexeme would give,
+      -- since no space was consumed before the '.').
+      result <- foldFields startPos (Var (Range startPos identEndPos) name)
+      space -- trailing whitespace after the whole chain
+      pure result
+    else do
+      -- No immediate dot: consume trailing whitespace now to match the range
+      -- that the old ident lexeme produced (end position after the space).
+      space
+      endPos <- getSourcePos
+      pure (Var (Range startPos endPos) name)
+  where
+    rawIdent = TL.toStrict . TL.pack <$> ((:) <$> identStart <*> many identContinue)
+    -- foldFields accumulates Project nodes; projStart is the start of the
+    -- whole expression so each Project's range spans from the original start
+    -- to the end of the latest field name.
+    foldFields projStart expr = do
+      mField <- optional (try (char '.' *> rawIdent))
+      case mField of
+        Nothing -> pure expr
+        Just field -> do
+          fieldEndPos <- getSourcePos
+          foldFields projStart (Project (Range projStart fieldEndPos) expr field)
 
 -- | pClause parses C-style clauses with optional parentheses
 -- > clause = "(" pattern ("," pattern)* ")" "->" stmts

--- a/src/Malgo/Parser/Core.hs
+++ b/src/Malgo/Parser/Core.hs
@@ -11,6 +11,7 @@ module Malgo.Parser.Core
     decimal,
     symbol,
     ident,
+    rawIdent,
     identStart,
     identContinue,
     reserved,
@@ -65,11 +66,16 @@ decimal = lexeme L.decimal
 symbol :: TL.Text -> Parser es ()
 symbol = void . L.symbol space
 
--- | ident consumes an identifier.
+-- | ident consumes an identifier, rejecting reserved keywords and skipping
+-- trailing whitespace.
 ident :: Parser es Text
-ident = lexeme do
-  notFollowedBy anyReserved
-  TL.toStrict . TL.pack <$> ((:) <$> identStart <*> many identContinue)
+ident = lexeme (notFollowedBy anyReserved *> rawIdent)
+
+-- | rawIdent consumes an identifier without rejecting reserved keywords or
+-- skipping trailing whitespace. Useful when adjacency to the following
+-- character matters (e.g. tight @.field@ projection).
+rawIdent :: Parser es Text
+rawIdent = TL.toStrict . TL.pack <$> ((:) <$> identStart <*> many identContinue)
 
 -- TODO: use XID_Start
 identStart :: Parser es Char

--- a/test/Malgo/ParserSpec.hs
+++ b/test/Malgo/ParserSpec.hs
@@ -94,6 +94,21 @@ spec = parallel do
       it "ignores unknown pragmas while preserving parse behavior" do
         expectParsed "#c-style-apply\n#debug\ndef main = f(x, y)"
 
+    -- Regression tests for #345: '.field' binds tighter than function
+    -- application only when no whitespace precedes the dot.
+    describe "field access precedence (#345)" do
+      it "binds .field to the adjacent atom when no space precedes the dot" do
+        sexpr <- parseToSExpr "def main = f a state.dict"
+        sexpr `shouldContain` "(apply (apply f a) (project state \"dict\"))"
+
+      it "treats .field as a postfix on the whole application when a space precedes the dot" do
+        sexpr <- parseToSExpr "def main = f a state .dict"
+        sexpr `shouldContain` "(project (apply (apply f a) state) \"dict\")"
+
+      it "chains adjacent .field projections tightly" do
+        sexpr <- parseToSExpr "def main = f state.dict.head"
+        sexpr `shouldContain` "(apply f (project (project state \"dict\") \"head\"))"
+
 driveParse :: FilePath -> IO String
 driveParse srcPath = do
   src <- convertString <$> BL.readFile srcPath
@@ -120,3 +135,14 @@ expectParsed src = do
   case result of
     Left err -> expectationFailure $ errorBundlePretty err
     Right _ -> pure ()
+
+-- | Parse a source snippet and render the resulting module as an S-expression,
+-- with all runs of whitespace collapsed to single spaces so structural
+-- assertions are insensitive to the pretty-printer's line breaking.
+parseToSExpr :: String -> IO String
+parseToSExpr src = do
+  result <- runMalgoM flag do
+    parse "test.mlg" (convertString src)
+  case result of
+    Left err -> error $ errorBundlePretty err
+    Right parsed -> pure $ unwords $ words $ sShow parsed


### PR DESCRIPTION
## Summary

Fixes a field-access precedence bug in the CStyle parser. Whitespace around `.` now determines binding tightness:

- `f a state.dict` parses as `f a (state.dict)` — **tight**: `.field` binds to the immediately-preceding atom when no whitespace precedes the `.`.
- `f a state .dict` (space before `.`) parses as `(f a state).dict` — **loose**: postfix projection on the whole application.

Previously every `.field` chain was handled by the postfix-operator layer at `pApply` level, so `.` always bound loosely regardless of whitespace. This forced explicit parentheses around any field access used as a function argument.

## Implementation

`pVariable` now peeks for an immediately-adjacent `.` (before consuming trailing whitespace) and folds the entire tight `.field` chain itself. The loose case continues to be handled by the postfix layer.

The `Var` node's source range is preserved to match the original `ident`-lexeme contract, so renamer error positions are unchanged:
- with an immediate dot: range ends at the identifier end (before the dot, no whitespace consumed);
- without a dot: range ends after consuming trailing whitespace.

## Testing

- Full test suite passes (1169 examples, 0 failures), including the `Rename` golden tests (`NotImported`, `NotQualifiedImported`) whose error ranges are sensitive to `Var` node positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
