### PR TITLE
feat(editors): add VS Code syntax highlighting extension

### DIFF
--- a/docs/research/forth-in-malgo-2026-06-20.md
+++ b/docs/research/forth-in-malgo-2026-06-20.md
@@ -1,0 +1,304 @@
+# Implementing Forth in Malgo
+
+## Overview
+
+This document surveys Forth's core semantics, existing Haskell/functional implementations, and assesses
+what a Forth interpreter written *in* Malgo would look like.
+
+---
+
+## Forth Core Semantics
+
+### Architecture
+
+Forth is a stack-based language with four fundamental components:
+
+| Component | Description |
+|-----------|-------------|
+| Data Stack | Parameter passing and arithmetic; values are pushed/popped |
+| Return Stack | Return addresses for word calls |
+| Dictionary | Linked list of word definitions; looked up by name |
+| Program Counter | Tracks execution position within a word body |
+
+### Dictionary
+
+The dictionary is the central data structure. Each entry contains:
+- **Name field** — the word's string name
+- **Link field** — pointer to the previous entry (linked-list traversal)
+- **Code field** — address of executable code (or list of execution tokens)
+- **Precedence bit** — marks `IMMEDIATE` words that execute at compile time
+
+Two kinds of words:
+1. **Code words** — primitive operations (implemented in the host language)
+2. **Colon words** — user-defined; a sequence of execution tokens compiled by `: ... ;`
+
+### Word Definitions
+
+```forth
+: square  ( n -- n^2 )  dup *  ;
+: greet   ." Hello, world!"  cr  ;
+```
+
+The colon compiler switches Forth from **interpret mode** to **compile mode**, recording execution
+tokens until `;` emits an `EXIT` token.
+
+**Immediate words** (flagged with `IMMEDIATE`) execute during compilation rather than being compiled.
+They enable compile-time control structures like `IF`, `BEGIN`, `LOOP`.
+
+### REPL (QUIT loop)
+
+```
+QUIT: get line → tokenize → for each token:
+        interpret mode: lookup word → execute (or push literal)
+        compile  mode: lookup word → if IMMEDIATE execute, else compile token
+```
+
+### Minimal Primitive Set
+
+A workable Forth kernel needs roughly 48 primitives:
+
+| Category | Words |
+|----------|-------|
+| Stack | `DUP DROP SWAP OVER ROT` |
+| Arithmetic | `+ - * / MOD` |
+| Comparison | `= < > 0=` |
+| Memory | `@ ! ALLOT HERE` |
+| Control | `IF THEN ELSE BEGIN UNTIL LOOP` |
+| Dictionary | `: ; IMMEDIATE` |
+| I/O | `EMIT KEY .` |
+| System | `QUIT BYE` |
+
+Theoretical minimum (eForth model): 7 assembly-level primitives (`nop nand ! @ um+ special lit`),
+with everything else bootstrapped in Forth itself.
+
+---
+
+## Existing Functional Implementations
+
+### Haskell Implementations
+
+| Project | Approach | Notes |
+|---------|----------|-------|
+| [harrorth](https://github.com/ezag/harrorth) | State machine → effects system | Tutorial-style, documents the learning process |
+| [hforth (jrp2014)](https://github.com/jrp2014/hforth) | Generic data/control stacks | Bare-bones, portable framework |
+| [forth (olemorud)](https://github.com/olemorud/forth) | Minimal subset | Inspired by Exercism; `+`, `-`, `*`, `/`, `DUP`, `DROP`, `OVER` |
+| [forth (reinvdwoerd)](https://github.com/reinvdwoerd/forth) | Haskell clone | General Forth clone |
+
+**"Write a Forth in Haskell"** blog series (glitchbra.in):
+- Part 01–02: Pure state machine `ForthState → ForthState`
+- Part 03–04: Refactor to effects system (`mtl`/IO) for real I/O
+- Part 05: Add new Forth constructs
+
+**Standard Haskell state representation:**
+```haskell
+data ForthState = ForthState
+  { dataStack   :: [Value]
+  , returnStack :: [Addr]
+  , dictionary  :: Map String Word
+  , heap        :: Array Addr Value
+  , pc          :: Addr
+  , mode        :: Mode   -- Interpret | Compile
+  }
+```
+Typically wrapped in a `State` monad or `StateT IO`.
+
+### Challenges in Pure Functional Languages
+
+| Challenge | Cause | Solution |
+|-----------|-------|----------|
+| Mutable dictionary | Forth allows runtime redefinition | Immutable `Map`; rebuild on `:` |
+| Mutable stacks | Stack operations are destructive | Thread `[Value]` lists through state |
+| Dual mode (interpret/compile) | Mode is runtime state | Carry `mode :: Mode` field in state record |
+| `IMMEDIATE` words | Execute at compile-time | Flag words in dictionary; check at compile |
+| Raw memory (`@ !`) | Pointer arithmetic | Unsafe vector API or `IORef`/`STRef` array |
+| I/O side effects | `EMIT`, `KEY` | Wrap state transformer in `IO` |
+
+---
+
+## Malgo Feature Assessment
+
+### Available Building Blocks
+
+**Data types:**
+- Numeric: `Int32`, `Int64`, `Float`, `Double`
+- Text: `Char`, `String`
+- Algebraic: full ADT with pattern matching
+- Lists: `data List a = Nil | Cons a (List a)` (built-in)
+- Records: named fields
+- Map: AVL-tree based ordered map in `runtime/malgo/Map.mlg`
+
+**Control flow:**
+- `case` expression with exhaustive pattern matching
+- Nested/constructor/literal patterns
+- Tail-recursive functions (compiler optimizes tail calls)
+- Higher-order functions, closures, lambdas (`{ x y -> expr }`)
+
+**I/O:**
+- Input: `getChar`, `getLine`, `getContents`, `getRawArgs`
+- Output: `printString`, `putStr`, `putStrLn`, `printInt32`, `flush`
+- Files: `readFile`, `writeFile`
+
+**String utilities:**
+- `appendString`, `lengthString`, `atString`, `substring`
+- `parseIntString32`, `parseIntString64`
+- `consString`, `reverseString`
+
+### State Threading Pattern
+
+Malgo has no mutable references in its pure core. State must be threaded explicitly — the same
+pattern the self-hosted compiler uses extensively:
+
+```malgo
+-- Forth interpreter state as a record
+type Stack = List Int64
+
+data ForthState = ForthState
+  { dataStack : Stack
+  , dictionary : Map String Word
+  , compiling : Bool
+  , output : String
+  }
+
+-- A Forth "step" function
+def step : ForthState -> Token -> ForthState
+def step state tok = ...
+```
+
+The self-hosted compiler at `runtime/malgo/compiler/` demonstrates this pattern with `InferState`
+records threaded through all inference passes — it works well and is idiomatic Malgo.
+
+### Mutable Memory
+
+For Forth's `@ !` (memory read/write), options in Malgo:
+
+1. **Functional map** (recommended for a pure implementation): model heap as `Map Int64 Int64`.
+   Sufficient for a learning-oriented Forth.
+2. **Unsafe vector API**: `runtime/malgo/Vector.mlg` exposes `malgo_new_vector`,
+   `malgo_read_vector`, `malgo_write_vector` via `foreign import`. Allows true mutable arrays
+   at the cost of safety.
+
+### Word Representation
+
+```malgo
+-- Forth values
+data ForthVal
+  = FInt Int64
+  | FStr String
+  | FBool Bool
+
+-- A word is either a primitive (built-in action) or a compiled sequence of word names
+data Word
+  = Prim (ForthState -> ForthState)
+  | Compiled (List String)   -- list of word names to execute in sequence
+
+type Dict = Map String Word
+```
+
+Higher-order functions (`Prim (ForthState -> ForthState)`) let primitive operations be stored
+directly in the dictionary as values — a natural fit for Malgo's first-class functions.
+
+### Feasibility Summary
+
+| Aspect | Assessment |
+|--------|------------|
+| Data stack | `List Int64` — easy, idiomatic |
+| Dictionary | `Map String Word` from `Map.mlg` — ready-made |
+| Tokenizer/lexer | String operations sufficient (`substring`, `atString`, `parseIntString64`) |
+| REPL loop | `getLine` + recursive `loop` function — straightforward |
+| Colon definitions | Track `compiling` flag + accumulate token list — feasible |
+| IMMEDIATE words | Flag in `Word` type; check at compile time — feasible |
+| Mutable heap (`@ !`) | Use `Map Int64 Int64` (pure) or `Vector.mlg` (unsafe) |
+| I/O words (`EMIT` etc.) | `printChar`, `getChar` — available |
+| Tail recursion | Supported — deep Forth recursion won't overflow |
+
+**Overall**: A core Forth interpreter is well within Malgo's capabilities. Estimated size:
+~1000–1500 lines for a clean implementation covering the minimal primitive set.
+
+---
+
+## Recommended Implementation Plan
+
+### Phase 1 — Token and Value Types
+
+```malgo
+data Token = TWord String | TInt Int64 | TStr String
+
+data ForthVal = FInt Int64 | FStr String
+
+data Word
+  = Prim { action : ForthState -> ForthState }
+  | Compiled { tokens : List String }
+  | Immediate { action : ForthState -> ForthState }
+
+type Stack = List ForthVal
+type Dict  = Map String Word
+
+data ForthState = ForthState
+  { stack : Stack
+  , rstack : List (List String)   -- return stack for colon words
+  , dict : Dict
+  , compiling : Bool
+  , compileBuffer : List String
+  }
+```
+
+### Phase 2 — Core Primitives
+
+Implement as `Prim` entries in the initial dictionary:
+`dup`, `drop`, `swap`, `over`, `+`, `-`, `*`, `/`, `mod`, `=`, `<`, `>`,
+`emit`, `cr`, `.` (print top of stack).
+
+### Phase 3 — Interpreter Loop
+
+```malgo
+def eval : ForthState -> Token -> ForthState
+def eval state (TInt n) =
+  -- push integer onto stack
+  { state | stack = Cons (FInt n) state.stack }
+def eval state (TWord w) =
+  case lookupMap w state.dict {
+    None -> ... -- error: unknown word
+    Some word ->
+      if state.compiling && not (isImmediate word)
+      then -- compile: append to compileBuffer
+        { state | compileBuffer = appendList state.compileBuffer [w] }
+      else -- interpret: execute
+        execWord state word
+  }
+```
+
+### Phase 4 — Colon Definitions
+
+Handle `:` (start compile mode, capture name) and `;`
+(stop compile, install `Compiled compileBuffer` into dictionary).
+
+### Phase 5 — Control Structures
+
+Implement `IF THEN ELSE BEGIN UNTIL` as `Immediate` words that patch jump offsets
+(or use a structured representation instead of raw addresses).
+
+### Phase 6 — REPL
+
+```malgo
+def repl : ForthState -> ()
+def repl state =
+  let line = getLine ();
+  let tokens = tokenize line;
+  let state' = foldl eval state tokens;
+  repl state'
+```
+
+---
+
+## References
+
+- [Easy Forth (interactive tutorial)](https://skilldrick.github.io/easyforth/)
+- [Implementing Forth in Go and C — Eli Bendersky](https://eli.thegreenplace.net/2025/implementing-forth-in-go-and-c/)
+- [Write a Forth in Haskell series](https://glitchbra.in/post/write-a-forth-in-haskell-intro/)
+- [harrorth — Haskell Forth tutorial](https://github.com/ezag/harrorth)
+- [hforth — bare-bones Haskell Forth](https://github.com/jrp2014/hforth)
+- [eForth overview](https://chochain.github.io/eforth/)
+- [ANS Forth standard words](https://forth-standard.org/standard/words)
+- [Malgo runtime builtins](../../runtime/malgo/Builtin.mlg)
+- [Malgo Map implementation](../../runtime/malgo/Map.mlg)
+- [Malgo self-hosted compiler](../../runtime/malgo/compiler/)

--- a/docs/research/vscode-syntax-highlight-2026-06-07.md
+++ b/docs/research/vscode-syntax-highlight-2026-06-07.md
@@ -1,0 +1,256 @@
+# VS Code シンタックスハイライト実装リサーチ
+
+**日付**: 2026-06-07  
+**対象**: Malgo 言語向け VS Code 拡張のシンタックスハイライト実装方法  
+**調査規模**: 102エージェント、25クレーム検証（13確定 / 12否決）、20ソース
+
+---
+
+## 概要
+
+VS Code カスタム言語のシンタックスハイライトは、**TextMate 文法**（.tmLanguage.json）と **LSP セマンティックトークン**の2層構造で実装する。
+両者は排他ではなく加算的に共存し、セマンティックトークンが TextMate ハイライトの上に重ねて適用される。
+
+---
+
+## 1. TextMate 文法（.tmLanguage.json）
+
+### スコープ名の命名規則 [confidence: high, vote: 2-1]
+
+- ルートスコープは `source.malgo`（`source.` プレフィックス + 言語名末尾）
+- 一般規則: `text` または `source` を最初に置き、言語名を末尾に置く
+- 例外: HTML 埋め込み言語は `text.html.markdown` のように中間に置く
+
+出典: [TextMate 公式マニュアル](https://macromates.com/manual/en/language_grammars)
+
+### begin/end ルールペア [confidence: high, vote: 3-0]
+
+- `begin`/`end` ペアで**複数行構造**を表現できる
+- `begin` パターンのキャプチャを `end` パターン内で後方参照（`\1` 等）できる
+- 「正規表現は1行しか扱えない」は**誤り**（否決）
+
+```json
+{
+  "name": "string.quoted.double.malgo",
+  "begin": "\"",
+  "end": "\""
+}
+```
+
+ヒアドキュメント例: `begin: "<<(\\w+)"` / `end: "^\\1$"`
+
+### Malgo 向けスコープ設計（推奨）
+
+```
+source.malgo
+  keyword.other.malgo          → def data foreign import module infix* let type with forall exists class impl goto label
+  keyword.control.malgo        → if then else
+  storage.type.malgo           → 型名（大文字始まり識別子）
+  entity.name.function.malgo   → 関数定義名
+  entity.name.type.malgo       → data/type 宣言の型名
+  variable.other.malgo         → 小文字始まり識別子
+  constant.language.malgo      → True False Nothing
+  constant.numeric.malgo       → 数値リテラル（整数・浮動小数・アンボックス）
+  string.quoted.double.malgo   → 文字列リテラル "..."
+  string.quoted.single.malgo   → 文字リテラル '.'
+  comment.line.double-dash.malgo   → -- コメント
+  comment.block.malgo          → {- ... -} ブロックコメント
+  punctuation.definition.malgo → { } ( ) [ ]
+  keyword.operator.malgo       → 演算子
+```
+
+---
+
+## 2. VS Code 拡張の package.json 登録 [confidence: high, vote: 3-0]
+
+### 基本構造
+
+```json
+{
+  "name": "malgo-language",
+  "displayName": "Malgo Language Support",
+  "contributes": {
+    "languages": [
+      {
+        "id": "malgo",
+        "aliases": ["Malgo", "malgo"],
+        "extensions": [".mlg"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "malgo",
+        "scopeName": "source.malgo",
+        "path": "./syntaxes/malgo.tmLanguage.json"
+      }
+    ]
+  }
+}
+```
+
+### セマンティックトークン用 contribution points [confidence: high, vote: 3-0]
+
+セマンティックトークンには3つの contribution point が存在する:
+
+```json
+{
+  "contributes": {
+    "semanticTokenTypes": [
+      { "id": "typeConstructor", "description": "型コンストラクタ" }
+    ],
+    "semanticTokenModifiers": [
+      { "id": "unboxed", "description": "アンボックス型" }
+    ],
+    "semanticTokenScopes": [
+      {
+        "language": "malgo",
+        "scopes": {
+          "function": ["entity.name.function.malgo"],
+          "type": ["storage.type.malgo"],
+          "variable": ["variable.other.malgo"]
+        }
+      }
+    ]
+  }
+}
+```
+
+`semanticTokenScopes` はテーマ互換性のためのフォールバック機構で、セマンティックトークンを TextMate スコープにマッピングする。
+
+### language-configuration.json
+
+```json
+{
+  "comments": {
+    "lineComment": "--",
+    "blockComment": ["{-", "-}"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["(", ")"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ]
+}
+```
+
+---
+
+## 3. LSP セマンティックトークン実装
+
+### Haskell lsp ライブラリ [confidence: high, vote: 3-0]
+
+- リポジトリ: https://github.com/haskell/lsp
+- 3パッケージ構成:
+  - `lsp` (v2.8.0.0) — サーバー構築ライブラリ
+  - `lsp-types` (v2.4.0.0) — 型安全な LSP 型定義
+  - `lsp-test` — 機能テストフレームワーク
+- **LSP 3.16 以降のセマンティックトークンをサポート**（「3.15のみ」は否決）
+
+### サーバー実装パターン
+
+`textDocument/semanticTokens/full` ハンドラーを `ServerDefinition` に登録する:
+
+```haskell
+-- package.yaml に lsp, lsp-types を追加
+-- セマンティックトークンのレジェンドを定義
+semanticTokensLegend :: SemanticTokensLegend
+semanticTokensLegend = SemanticTokensLegend
+  { _tokenTypes     = ["function", "type", "variable", "parameter", "typeParameter"]
+  , _tokenModifiers = ["declaration", "definition"]
+  }
+
+-- ServerCapabilities に登録
+serverCapabilities :: ServerCapabilities
+serverCapabilities = def
+  { _semanticTokensProvider = Just $ InL $ SemanticTokensOptions
+      { _legend    = semanticTokensLegend
+      , _range     = Just $ InL False
+      , _full      = Just $ InL True
+      , _workDoneProgress = Nothing
+      }
+  }
+
+-- ハンドラー実装
+handleSemanticTokensFull :: Uri -> LspM Config (Either ResponseError SemanticTokens)
+handleSemanticTokensFull uri = do
+  -- AST から (TokenType, line, startChar, length, modifiers) を計算
+  -- lsp-types の makeSemanticTokens で encode
+  pure $ Right $ SemanticTokens Nothing (encodeTokens tokens)
+```
+
+### HLS hls-semantic-tokens-plugin（参考実装）[confidence: medium, vote: 2-1]
+
+- PR: https://github.com/haskell/haskell-language-server/pull/3892（2024年1月マージ）
+- 実装パターン:
+  1. `GetHieAst` で型付き構文木を取得
+  2. `NameSemanticMap` を構築（名前 → トークン型のマッピング）
+  3. `(Name, Span)` ペアを走査して semantic tokens を生成
+- Malgo への適用: Rename パスの成果物（`RenamedAST`）から同様のマッピングを構築可能
+
+### VS Code クライアント側 [confidence: high, vote: 3-0]
+
+```typescript
+// LSP経由なら vscode-languageclient が自動的にセマンティックトークンを有効化する
+// package.json の engines.vscode は 1.43.0 以上を指定
+vscode.languages.registerDocumentSemanticTokensProvider(
+  { language: 'malgo' },
+  provider,
+  legend
+)
+```
+
+---
+
+## 4. TextMate 文法 ↔ セマンティックトークンの関係 [confidence: high, vote: 3-0]
+
+- **加算的（additive）**: 2つのシステムは共存する
+- セマンティックトークンが TextMate ハイライトの**上に重ねて**適用される
+- テーマにセマンティックルールがなければ `semanticTokenScopes` 経由で TextMate スコープにフォールバック
+- 実装順序: TextMate 文法でベースラインを作り、LSP でセマンティックハイライトを追加
+
+出典: [VS Code Semantic Highlight Guide](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide)
+
+---
+
+## 5. 未確定事項（要注意）
+
+| 質問 | 状態 |
+|------|------|
+| セマンティックハイライトはデフォルト有効か（テーマ側 opt-in 不要か） | 「明示的 opt-in 必要」は否決されたが、デフォルト挙動の詳細は要検証 |
+| `textDocument/semanticTokens/full/delta` の lsp 2.8.x サポート状況 | HLS PR では「将来作業」とされていたが否決。要確認 |
+| `contributes.languages` / `grammars` の必須フィールドの正確なセット | 「id/aliases/extensions が必須」「3フィールドのみ必須」はいずれも否決。公式ドキュメントを直接確認 |
+
+---
+
+## 実装ロードマップ
+
+### Phase 1: TextMate 文法（VS Code 拡張）
+1. `editors/vscode/` ディレクトリに VS Code 拡張を作成
+2. `syntaxes/malgo.tmLanguage.json` を作成（キーワード・コメント・リテラル）
+3. `language-configuration.json` を作成（コメント・ブラケット定義）
+4. `package.json` に `contributes.languages` / `contributes.grammars` を登録
+
+### Phase 2: LSP セマンティックトークン（malgo-lsp 拡張）
+1. `lsp-types` の `SemanticTokensOptions` を `serverCapabilities` に追加
+2. Rename パスの結果から `NameSemanticMap` を構築するロジックを実装
+3. `textDocument/semanticTokens/full` ハンドラーを登録
+4. VS Code 拡張側で LSP サーバーを起動する `LanguageClient` を設定
+
+---
+
+## 参考ソース
+
+| ソース | 品質 | 用途 |
+|--------|------|------|
+| [TextMate 公式マニュアル](https://macromates.com/manual/en/language_grammars) | primary | 文法書き方の正規ソース |
+| [VS Code Contribution Points](https://code.visualstudio.com/api/references/contribution-points) | primary | package.json 登録方法 |
+| [VS Code Semantic Highlight Guide](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide) | primary | セマンティックトークン API |
+| [haskell/lsp GitHub](https://github.com/haskell/lsp) | primary | Haskell LSP ライブラリ |
+| [HLS semantic tokens PR #3892](https://github.com/haskell/haskell-language-server/pull/3892) | primary | Haskell 向け参考実装 |
+| [VS Code Semantic Highlighting Overview](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview) | primary | 2層構造の仕様 |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,38 @@
+# Malgo Language Support for VS Code
+
+Syntax highlighting for the [Malgo](https://github.com/takoeight0821/malgo) programming language.
+
+## Features
+
+- Syntax highlighting for `.mlg` files
+- Comment toggling (`--` line comments, `{- -}` block comments)
+- Bracket matching and auto-closing
+- Code folding for block comments
+
+## Syntax coverage
+
+| Element | Example |
+|---------|---------|
+| Keywords | `def`, `data`, `foreign`, `import`, `module`, `type`, `class`, `impl`, `let`, `with`, `infix`, `forall`, `exists` |
+| Control | `if` |
+| Types / constructors | `Int32`, `List`, `Nothing`, `Just` |
+| Unboxed types | `Int32#`, `Float#` |
+| Comments | `-- line`, `{- block -}` |
+| Strings / chars | `"hello"`, `'a'` |
+| Numbers | `42`, `1i64`, `3.14`, `2.5f32`, `1#` |
+| Operators | `->`, `=>`, `=`, `:`, `|`, `#|`, `|#` |
+| Pragmas | `#c-style-apply` |
+
+## Installation
+
+### From source
+
+1. Copy the `editors/vscode/` directory to your VS Code extensions folder:
+   - macOS/Linux: `~/.vscode/extensions/malgo-language/`
+   - Windows: `%USERPROFILE%\.vscode\extensions\malgo-language\`
+
+2. Restart VS Code.
+
+### Development
+
+Open this directory in VS Code and press `F5` to launch an Extension Development Host with the extension loaded.

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,37 @@
+{
+  "comments": {
+    "lineComment": "--",
+    "blockComment": ["{-", "-}"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+    { "open": "{-", "close": "-}" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*\\{-",
+      "end": "^\\s*-\\}"
+    }
+  },
+  "indentationRules": {
+    "increaseIndentPattern": "\\b(let|if|data|def)\\b|=>|\\{\\s*$",
+    "decreaseIndentPattern": "^\\s*(\\}|\\|)\\s*$"
+  },
+  "wordPattern": "[a-zA-Z_][a-zA-Z0-9_#]*"
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "malgo-language",
+  "displayName": "Malgo Language",
+  "description": "Syntax highlighting for the Malgo programming language",
+  "version": "0.1.0",
+  "publisher": "takoeight0821",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/takoeight0821/malgo"
+  },
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "malgo",
+        "aliases": [
+          "Malgo",
+          "malgo"
+        ],
+        "extensions": [
+          ".mlg"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "malgo",
+        "scopeName": "source.malgo",
+        "path": "./syntaxes/malgo.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/editors/vscode/syntaxes/malgo.tmLanguage.json
+++ b/editors/vscode/syntaxes/malgo.tmLanguage.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Malgo",
+  "scopeName": "source.malgo",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#characters" },
+    { "include": "#pragmas" },
+    { "include": "#numbers" },
+    { "include": "#keywords" },
+    { "include": "#constructors" },
+    { "include": "#operators" },
+    { "include": "#punctuation" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-dash.malgo",
+          "match": "--.*$"
+        },
+        {
+          "name": "comment.block.malgo",
+          "begin": "\\{-",
+          "end": "-\\}",
+          "patterns": [
+            { "include": "#comments" }
+          ]
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.malgo",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.malgo",
+              "match": "\\\\[nrt\\\\\"'0]"
+            }
+          ]
+        }
+      ]
+    },
+    "characters": {
+      "patterns": [
+        {
+          "name": "string.quoted.single.malgo",
+          "match": "'(\\\\[nrt\\\\\"'0]|[^'\\\\])'"
+        }
+      ]
+    },
+    "pragmas": {
+      "patterns": [
+        {
+          "name": "meta.preprocessor.malgo",
+          "match": "^#[a-z][a-z0-9-]*"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.float.malgo",
+          "match": "-?\\b[0-9]+\\.[0-9]+(f(32|64))?#?"
+        },
+        {
+          "name": "constant.numeric.integer.malgo",
+          "match": "-?\\b[0-9]+(i(32|64))?#?"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.declaration.malgo",
+          "match": "\\b(def|data|foreign|import|module|type|class|impl)\\b"
+        },
+        {
+          "name": "keyword.other.malgo",
+          "match": "\\b(let|with|infix|infixl|infixr|forall|exists|goto|label)\\b"
+        },
+        {
+          "name": "keyword.control.malgo",
+          "match": "\\bif\\b"
+        },
+        {
+          "name": "constant.language.boolean.malgo",
+          "match": "\\b(True|False)\\b"
+        },
+        {
+          "name": "constant.language.unit.malgo",
+          "match": "\\(\\)"
+        }
+      ]
+    },
+    "constructors": {
+      "patterns": [
+        {
+          "name": "entity.name.tag.constructor.malgo",
+          "match": "\\b[A-Z][a-zA-Z0-9_#]*"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.arrow.malgo",
+          "match": "->|=>"
+        },
+        {
+          "name": "keyword.operator.malgo",
+          "match": "#\\||\\|#|~|!"
+        },
+        {
+          "name": "keyword.operator.type.malgo",
+          "match": ":"
+        },
+        {
+          "name": "keyword.operator.pipe.malgo",
+          "match": "\\|"
+        },
+        {
+          "name": "keyword.operator.assignment.malgo",
+          "match": "="
+        },
+        {
+          "name": "keyword.operator.other.malgo",
+          "match": "[+\\-*/%<>&^]+"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.malgo",
+          "match": "[,;]"
+        },
+        {
+          "name": "punctuation.bracket.malgo",
+          "match": "[\\{\\}\\[\\]\\(\\)]"
+        },
+        {
+          "name": "punctuation.accessor.malgo",
+          "match": "\\."
+        },
+        {
+          "name": "variable.language.wildcard.malgo",
+          "match": "\\b_\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.malgo",
+          "match": "\\b[a-z_][a-zA-Z0-9_#]*"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Malgo 言語の VS Code 拡張を `editors/vscode/` に追加します。

## 変更内容

- **`editors/vscode/`** — VS Code 拡張一式
  - `.mlg` ファイルのシンタックスハイライト（TextMate grammar）
  - コメントトグル（`--` 行コメント、`{- -}` ブロックコメント）
  - 括弧マッチ・自動補完
  - ブロックコメントのコードフォールディング
- **`docs/research/vscode-syntax-highlight-2026-06-07.md`** — 拡張の設計を支える調査メモ
- **`docs/research/forth-in-malgo-2026-06-20.md`** — Forth インタープリタ例の調査メモ

## カバーする構文

キーワード、型・コンストラクタ、unboxed 型、コメント、文字列・文字、数値リテラル、演算子、pragma（`#c-style-apply`）。

## 動作確認

VS Code の Extension Development Host（`F5`）で `.mlg` ファイルのハイライトを確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)