### PR TITLE
fix(zig): address deferred cleanup findings from #351/#352/#353 reviews

### DIFF
--- a/runtime/zig/runtime.zig
+++ b/runtime/zig/runtime.zig
@@ -359,16 +359,28 @@ pub fn mkCodata(branches: []const NamedBranch, captures: []const Value) Value {
 // only exercised directly by this file's own `test` blocks, so tracing
 // cannot perturb the RC decisions those tests already exercise.
 
+/// `name`\/`func` come from compiler-generated (unbounded-length) Zig-IR
+/// identifiers, so formatting into a fixed stack buffer can in principle
+/// overflow. Writes a valid one-line JSON marker in that case instead of
+/// silently dropping the event -- `scripts/rctrace.py` can then tell a
+/// missing event from one that was never emitted.
+fn emitTraced(result: std.fmt.BufPrintError![]const u8) void {
+    const line = result catch {
+        writeStderr("{\"ev\":\"trace_overflow\"}\n");
+        return;
+    };
+    writeStderr(line);
+}
+
 fn traceLine(event: []const u8, v: Value, name: []const u8, func: []const u8) void {
     if (!g_trace_enabled) return;
     const rc: i64 = if (v.rc == IMMORTAL) -1 else @intCast(v.rc);
-    var buf: [256]u8 = undefined;
-    const line = std.fmt.bufPrint(
+    var buf: [512]u8 = undefined;
+    emitTraced(std.fmt.bufPrint(
         &buf,
         "{{\"ev\":\"{s}\",\"ptr\":\"0x{x}\",\"rc\":{d},\"name\":\"{s}\",\"func\":\"{s}\"}}\n",
         .{ event, @intFromPtr(v), rc, name, func },
-    ) catch return;
-    writeStderr(line);
+    ));
 }
 
 /// Like 'traceLine', but identifies the object by an address captured
@@ -376,13 +388,12 @@ fn traceLine(event: []const u8, v: Value, name: []const u8, func: []const u8) vo
 /// (like 'dropReuseNamed') that may already have freed the object.
 fn traceAddr(event: []const u8, addr: usize, name: []const u8, func: []const u8) void {
     if (!g_trace_enabled) return;
-    var buf: [256]u8 = undefined;
-    const line = std.fmt.bufPrint(
+    var buf: [512]u8 = undefined;
+    emitTraced(std.fmt.bufPrint(
         &buf,
         "{{\"ev\":\"{s}\",\"ptr\":\"0x{x}\",\"name\":\"{s}\",\"func\":\"{s}\"}}\n",
         .{ event, addr, name, func },
-    ) catch return;
-    writeStderr(line);
+    ));
 }
 
 /// Traces a construction event (`mkStruct`/`mkClosure`/`mkStructReuse`):
@@ -391,22 +402,28 @@ fn traceAddr(event: []const u8, addr: usize, name: []const u8, func: []const u8)
 /// against the same (container, slot) pair can be resolved back to a name.
 fn traceSlots(event: []const u8, v: Value, fields: []const Value, names: []const []const u8, func: []const u8) void {
     if (!g_trace_enabled) return;
-    var head: [256]u8 = undefined;
+    var head: [512]u8 = undefined;
     const headLine = std.fmt.bufPrint(
         &head,
         "{{\"ev\":\"{s}\",\"ptr\":\"0x{x}\",\"func\":\"{s}\",\"slots\":[",
         .{ event, @intFromPtr(v), func },
-    ) catch return;
+    ) catch {
+        writeStderr("{\"ev\":\"trace_overflow\"}\n");
+        return;
+    };
     writeStderr(headLine);
     for (fields, 0..) |child, i| {
         if (i != 0) writeStderr(",");
         const name = if (i < names.len) names[i] else "?";
-        var slot: [256]u8 = undefined;
+        var slot: [512]u8 = undefined;
+        // A fallback placeholder, not `catch continue`: skipping the slot
+        // outright would also break the enclosing JSON array (a comma was
+        // already written above for every non-first slot).
         const slotLine = std.fmt.bufPrint(
             &slot,
             "{{\"i\":{d},\"name\":\"{s}\",\"child\":\"0x{x}\"}}",
             .{ i, name, @intFromPtr(child) },
-        ) catch continue;
+        ) catch "{\"i\":-1,\"name\":\"?\",\"child\":\"0x0\"}";
         writeStderr(slotLine);
     }
     writeStderr("]}\n");
@@ -711,7 +728,6 @@ pub fn reuseHint(args: []const Value) Value {
     _ = args;
     return no_self;
 }
-
 
 pub fn malgo_add_int32_t(args: []const Value) Value {
     return mkInt32(asI32(args[0]) +% asI32(args[1]));

--- a/runtime/zig/runtime.zig
+++ b/runtime/zig/runtime.zig
@@ -259,12 +259,17 @@ pub fn dropReuse(v: Value, arity: usize) ?Value {
 /// implications.
 pub fn mkStructReuse(tok: ?Value, tag: Tag, fields: []const Value) Value {
     const obj = tok orelse return mkStruct(tag, fields);
-    std.debug.assert(obj.rc == 1 and obj.kind == .strukt);
+    // A malformed token here would mean overwriting memory `dropReuse` never
+    // vacated -- corruption, not a recoverable error. Checked explicitly
+    // (not via `std.debug.assert`, which ReleaseFast/ReleaseSmall compile
+    // out entirely) as a last line of defense behind RcCheck's static
+    // token-linearity verification.
+    if (obj.rc != 1 or obj.kind != .strukt) panic("mkStructReuse: token does not own a unique strukt Object");
     if (obj.payload.strukt.fields.len == fields.len) {
         @memcpy(@constCast(obj.payload.strukt.fields), fields);
         obj.payload.strukt.tag = tag;
     } else {
-        std.debug.assert(obj.payload.strukt.fields.len == 0);
+        if (obj.payload.strukt.fields.len != 0) panic("mkStructReuse: arity-mismatched token was not cleared by dropReuse");
         obj.payload.strukt = .{ .tag = tag, .fields = g_value.dupe(Value, fields) catch @panic("Malgo: out of memory") };
     }
     return obj;

--- a/runtime/zig/runtime.zig
+++ b/runtime/zig/runtime.zig
@@ -260,15 +260,20 @@ pub fn dropReuse(v: Value, arity: usize) ?Value {
 pub fn mkStructReuse(tok: ?Value, tag: Tag, fields: []const Value) Value {
     const obj = tok orelse return mkStruct(tag, fields);
     // A malformed token here would mean overwriting memory `dropReuse` never
-    // vacated -- corruption, not a recoverable error. Checked explicitly
-    // (not via `std.debug.assert`, which ReleaseFast/ReleaseSmall compile
-    // out entirely) as a last line of defense behind RcCheck's static
-    // token-linearity verification.
+    // vacated -- corruption, not a recoverable error, and a last line of
+    // defense behind RcCheck's static token-linearity verification. The
+    // `std.debug.assert` gives a full stack trace pinpointing the call site
+    // in Debug/ReleaseSafe; it is compiled out entirely in
+    // ReleaseFast/ReleaseSmall, so the explicit `panic` after it is what
+    // actually catches a violation there (at the cost of only a one-line
+    // message, not a trace).
+    std.debug.assert(obj.rc == 1 and obj.kind == .strukt);
     if (obj.rc != 1 or obj.kind != .strukt) panic("mkStructReuse: token does not own a unique strukt Object");
     if (obj.payload.strukt.fields.len == fields.len) {
         @memcpy(@constCast(obj.payload.strukt.fields), fields);
         obj.payload.strukt.tag = tag;
     } else {
+        std.debug.assert(obj.payload.strukt.fields.len == 0);
         if (obj.payload.strukt.fields.len != 0) panic("mkStructReuse: arity-mismatched token was not cleared by dropReuse");
         obj.payload.strukt = .{ .tag = tag, .fields = g_value.dupe(Value, fields) catch @panic("Malgo: out of memory") };
     }

--- a/scripts/rctrace.py
+++ b/scripts/rctrace.py
@@ -17,6 +17,9 @@ section) is one JSON object per line:
   {"ev":"mkStruct"|"mkClosure"|"mkStructReuse","ptr":"0x..","func":"..",
    "slots":[{"i":0,"name":"..","child":"0x.."}, ...]}
   {"ev":"decChild","container":"0x..","slot":0,"child":"0x..","rc_before":N}
+  {"ev":"trace_overflow"}  -- a name/func string didn't fit runtime.zig's
+  fixed trace-line buffer; this marker takes the dropped event's place so a
+  missing event is visible instead of silent (see emitTraced there).
 """
 
 import argparse

--- a/scripts/rctrace.py
+++ b/scripts/rctrace.py
@@ -141,13 +141,37 @@ def print_birth(events, target, start_line):
     print(f"--- {target}'s construction event was not found in this trace (allocated before tracing was relevant, or via mk{{Int32,String,...}}) ---")
 
 
+def count_overflows(events, start_line, end_line):
+    """How many trace_overflow markers (see runtime.zig's emitTraced) fall in
+    [start_line, end_line) -- a construction event lost to one could have
+    been a referrer of `target` that every lookup below now can't see."""
+    total = 0
+    for ev in events:
+        if ev["_line"] < start_line:
+            continue
+        if end_line is not None and ev["_line"] >= end_line:
+            break
+        if ev.get("ev") == "trace_overflow":
+            total += 1
+    return total
+
+
 def print_live_referrers(events, target, start_line, at_line):
     referrers = live_referrers_at(events, target, start_line, at_line)
+    overflows = count_overflows(events, start_line, at_line + 1)
     print(f"--- live referrers of {target} at/before line {at_line} (this generation) ---")
+    if overflows:
+        print(f"  WARNING: {overflows} trace_overflow marker(s) in this range -- a lost")
+        print("  construction event could have been a referrer this trace can no")
+        print("  longer identify; the result below may be incomplete, not definitive.")
     if not referrers:
-        print("  (none found -- either truly unreferenced, or held only as a")
-        print("   direct local variable never captured into a struct/closure;")
-        print("   see the direct RC event timeline above for that case)")
+        if overflows:
+            print("  (none found in the events this trace could decode -- see the")
+            print("   trace_overflow warning above before concluding it is unreferenced)")
+        else:
+            print("  (none found -- either truly unreferenced, or held only as a")
+            print("   direct local variable never captured into a struct/closure;")
+            print("   see the direct RC event timeline above for that case)")
         return
     for r in referrers:
         print(
@@ -167,6 +191,15 @@ def main():
     if not events:
         print("no events read from trace", file=sys.stderr)
         return 1
+
+    total_overflows = sum(1 for ev in events if ev.get("ev") == "trace_overflow")
+    if total_overflows:
+        print(
+            f"warning: {total_overflows} trace_overflow marker(s) in this trace -- some "
+            "events (whose name/func string overflowed runtime.zig's fixed trace buffer) "
+            "were replaced by this marker at the source, so this trace may be incomplete",
+            file=sys.stderr,
+        )
 
     target = args.target
     at_line = args.at_line

--- a/src/Malgo/Backend/Zig/ClosureConv.hs
+++ b/src/Malgo/Backend/Zig/ClosureConv.hs
@@ -233,8 +233,9 @@ initialClassifyJoinsWithEscaping (Cut p _) =
 initialClassifyJoinsWithEscaping (Join _ name consumer stmt) =
   let (m, esc) = initialClassifyJoinsWithEscaping stmt
       ownership = if name `Set.member` esc then Escaping else Local
-   in ( Map.insert name ownership (initialClassifyJoinsConsumer consumer <> m),
-        escapingNamesConsumer consumer <> esc
+      (cm, cesc) = initialClassifyJoinsConsumerWithEscaping consumer
+   in ( Map.insert name ownership (cm <> m),
+        cesc <> esc
       )
 initialClassifyJoinsWithEscaping (Primitive _ _ ps _) =
   (Map.unions (map initialClassifyJoinsProducer ps), Set.unions (map escapingNamesProducer ps))
@@ -267,13 +268,25 @@ initialClassifyJoinsProducer (Mu _ _ _) = Map.empty
 initialClassifyJoinsProducer (Cocase _ _) = Map.empty
 
 initialClassifyJoinsConsumer :: Consumer -> Map Name Ownership
-initialClassifyJoinsConsumer (Label _ _) = Map.empty
-initialClassifyJoinsConsumer (Apply _ ps _) = Map.unions (map initialClassifyJoinsProducer ps)
-initialClassifyJoinsConsumer (Project _ _ _) = Map.empty
-initialClassifyJoinsConsumer (Then _ _ stmt) = initialClassifyJoins stmt
-initialClassifyJoinsConsumer (Finish _) = Map.empty
-initialClassifyJoinsConsumer (Select _ branches) = Map.unions (map (\(Branch _ _ stmt) -> initialClassifyJoins stmt) branches)
-initialClassifyJoinsConsumer (Destructor _ _ ps _) = Map.unions (map initialClassifyJoinsProducer ps)
+initialClassifyJoinsConsumer = fst . initialClassifyJoinsConsumerWithEscaping
+
+-- | 'initialClassifyJoinsConsumer' fused with 'escapingNamesConsumer', for
+-- the same reason 'initialClassifyJoinsWithEscaping' fuses with
+-- 'escapingNamesStatement': the 'Join' case above needs both a consumer's
+-- classification and its escaping-name set, and computing them separately
+-- would re-walk a 'Then'\/'Select' consumer's nested statement(s) twice.
+initialClassifyJoinsConsumerWithEscaping :: Consumer -> (Map Name Ownership, Set Name)
+initialClassifyJoinsConsumerWithEscaping (Label _ _) = (Map.empty, Set.empty)
+initialClassifyJoinsConsumerWithEscaping (Apply _ ps ks) =
+  (Map.unions (map initialClassifyJoinsProducer ps), Set.unions (map escapingNamesProducer ps) <> Set.fromList ks)
+initialClassifyJoinsConsumerWithEscaping (Project _ _ k) = (Map.empty, Set.singleton k)
+initialClassifyJoinsConsumerWithEscaping (Then _ _ stmt) = initialClassifyJoinsWithEscaping stmt
+initialClassifyJoinsConsumerWithEscaping (Finish _) = (Map.empty, Set.empty)
+initialClassifyJoinsConsumerWithEscaping (Select _ branches) =
+  let results = [initialClassifyJoinsWithEscaping stmt | Branch _ _ stmt <- branches]
+   in (Map.unions (map fst results), Set.unions (map snd results))
+initialClassifyJoinsConsumerWithEscaping (Destructor _ _ ps k) =
+  (Map.unions (map initialClassifyJoinsProducer ps), Set.unions (map escapingNamesProducer ps) <> Set.singleton k)
 
 -- | Local (same-function) substitution environment: a join name classified
 -- 'Local' maps to the 'Consumer' it was bound to, to be inlined at use.

--- a/src/Malgo/Backend/Zig/ClosureConv.hs
+++ b/src/Malgo/Backend/Zig/ClosureConv.hs
@@ -122,16 +122,19 @@ escapingNamesStatement (BinOp _ _ lhs rhs _k) = escapingNamesProducer lhs <> esc
 escapingNamesStatement (Ifz _ cond t e) =
   escapingNamesProducer cond <> escapingNamesStatement t <> escapingNamesStatement e
 
+-- | 'Lambda'\/'Object'\/'Mu'\/'Cocase' are all nested-closure-body
+-- producers: an escaping name of the *enclosing* statement is exactly a
+-- free variable of theirs (their own join structure is a separate,
+-- independently-analyzed scope — see the haddock above), so those cases
+-- just delegate to 'freeVarsProducer' rather than duplicating its rules.
 escapingNamesProducer :: Producer -> Set Name
 escapingNamesProducer (Var _ _) = Set.empty
 escapingNamesProducer (Literal _ _) = Set.empty
 escapingNamesProducer (Construct _ _ ps ks) = Set.unions (map escapingNamesProducer ps) <> Set.fromList ks
-escapingNamesProducer (Lambda _ names stmt) = freeVarsStatement stmt Set.\\ Set.fromList names
-escapingNamesProducer (Object _ fields) =
-  Set.unions [freeVarsStatement stmt Set.\\ Set.singleton ret | (ret, stmt) <- Map.elems fields]
-escapingNamesProducer (Mu _ name stmt) = Set.delete name (freeVarsStatement stmt)
-escapingNamesProducer (Cocase _ branches) =
-  Set.unions [freeVarsStatement stmt Set.\\ Set.fromList vars | (_, vars, stmt) <- branches]
+escapingNamesProducer p@(Lambda {}) = freeVarsProducer p
+escapingNamesProducer p@(Object {}) = freeVarsProducer p
+escapingNamesProducer p@(Mu {}) = freeVarsProducer p
+escapingNamesProducer p@(Cocase {}) = freeVarsProducer p
 
 escapingNamesConsumer :: Consumer -> Set Name
 escapingNamesConsumer (Label _ _) = Set.empty -- eliminated by Normalize; kept total defensively.
@@ -215,15 +218,39 @@ collectJoinsConsumer (Destructor _ _ ps _) = concatMap collectJoinsProducer ps
 -- | The direct-escaping rule alone (see 'classifyJoins' for why this is not
 -- the whole story).
 initialClassifyJoins :: Statement -> Map Name Ownership
-initialClassifyJoins (Cut p _) = initialClassifyJoinsProducer p
-initialClassifyJoins (Join _ name consumer stmt) =
-  let ownership = if name `Set.member` escapingNamesStatement stmt then Escaping else Local
-   in Map.insert name ownership (initialClassifyJoinsConsumer consumer <> initialClassifyJoins stmt)
-initialClassifyJoins (Primitive _ _ ps _) = Map.unions (map initialClassifyJoinsProducer ps)
-initialClassifyJoins (Invoke _ _ _) = Map.empty
-initialClassifyJoins (ExternalCall _ _ ps _) = Map.unions (map initialClassifyJoinsProducer ps)
-initialClassifyJoins (BinOp _ _ lhs rhs _) = initialClassifyJoinsProducer lhs <> initialClassifyJoinsProducer rhs
-initialClassifyJoins (Ifz _ cond t e) = initialClassifyJoinsProducer cond <> initialClassifyJoins t <> initialClassifyJoins e
+initialClassifyJoins = fst . initialClassifyJoinsWithEscaping
+
+-- | 'initialClassifyJoins' fused with 'escapingNamesStatement' of the same
+-- statement: a chain of nested 'Join's calling 'escapingNamesStatement'
+-- freshly on its own (shrinking) continuation at every node would
+-- re-traverse that continuation once per enclosing 'Join', making
+-- classification quadratic in the chain's length. Computing both bottom-up
+-- in one traversal instead means each node's escaping-name set is built
+-- once, from its already-computed children, not re-walked from scratch.
+initialClassifyJoinsWithEscaping :: Statement -> (Map Name Ownership, Set Name)
+initialClassifyJoinsWithEscaping (Cut p _) =
+  (initialClassifyJoinsProducer p, escapingNamesProducer p)
+initialClassifyJoinsWithEscaping (Join _ name consumer stmt) =
+  let (m, esc) = initialClassifyJoinsWithEscaping stmt
+      ownership = if name `Set.member` esc then Escaping else Local
+   in ( Map.insert name ownership (initialClassifyJoinsConsumer consumer <> m),
+        escapingNamesConsumer consumer <> esc
+      )
+initialClassifyJoinsWithEscaping (Primitive _ _ ps _) =
+  (Map.unions (map initialClassifyJoinsProducer ps), Set.unions (map escapingNamesProducer ps))
+initialClassifyJoinsWithEscaping (Invoke _ _ k) = (Map.empty, Set.singleton k)
+initialClassifyJoinsWithEscaping (ExternalCall _ _ ps _) =
+  (Map.unions (map initialClassifyJoinsProducer ps), Set.unions (map escapingNamesProducer ps))
+initialClassifyJoinsWithEscaping (BinOp _ _ lhs rhs _) =
+  ( initialClassifyJoinsProducer lhs <> initialClassifyJoinsProducer rhs,
+    escapingNamesProducer lhs <> escapingNamesProducer rhs
+  )
+initialClassifyJoinsWithEscaping (Ifz _ cond t e) =
+  let (mt, escT) = initialClassifyJoinsWithEscaping t
+      (me, escE) = initialClassifyJoinsWithEscaping e
+   in ( initialClassifyJoinsProducer cond <> mt <> me,
+        escapingNamesProducer cond <> escT <> escE
+      )
 
 -- | Only descends into a nested closure's free variables for escaping
 -- analysis, but its *own* join structure still needs classifying once it is

--- a/src/Malgo/Backend/Zig/Emit.hs
+++ b/src/Malgo/Backend/Zig/Emit.hs
@@ -87,21 +87,26 @@ emitFunc fn =
         ]
 
 emitBlock :: (Name -> Text) -> Text -> Ir.Block -> Text
-emitBlock pv funcName (Ir.Block stmts0 terminator) = go stmts0
+emitBlock pv funcName (Ir.Block stmts0 terminator) = go (Ir.suffixFreeVars stmts0 terminator) stmts0
   where
-    go [] = emitTerminator pv funcName terminator
+    go _ [] = emitTerminator pv funcName terminator
     -- 'Ir.PanicExpr' is noreturn: nothing after it in this block is
     -- reachable, and Zig rejects unreachable statements, so printing
     -- truncates here.
-    go (Ir.Let _ (Ir.PanicExpr what) : _) = "rt.panicUnimplemented(" <> zigStringLit what <> ");\n"
-    go (Ir.Let x e : rest) =
-      let usedLater = x `Set.member` Ir.freeVarsBlock (Ir.Block rest terminator)
+    go _ (Ir.Let _ (Ir.PanicExpr what) : _) = "rt.panicUnimplemented(" <> zigStringLit what <> ");\n"
+    -- 'liveAfter' (the free variables of everything from `rest` on) is read
+    -- off 'Ir.suffixFreeVars' rather than a fresh 'Ir.freeVarsBlock' call on
+    -- `rest`, so this walk stays linear in block length instead of
+    -- quadratic (a fresh scan per binding would re-walk every remaining
+    -- statement at every position).
+    go (_ : liveAfter : lives) (Ir.Let x e : rest) =
+      let usedLater = x `Set.member` liveAfter
           discard = if usedLater then "" else "_ = " <> pv x <> ";\n"
-       in "const " <> pv x <> " = " <> emitExpr pv funcName e <> ";\n" <> discard <> go rest
-    go (Ir.Dup x : rest) = "rt.dupNamed(" <> pv x <> ", " <> nameLit x <> ", " <> funcName <> ");\n" <> go rest
-    go (Ir.Drop x : rest) = "rt.dropNamed(" <> pv x <> ", " <> nameLit x <> ", " <> funcName <> ");\n" <> go rest
-    go (Ir.DropReuse tok x arity : rest) =
-      let usedLater = tok `Set.member` Ir.freeVarsBlock (Ir.Block rest terminator)
+       in "const " <> pv x <> " = " <> emitExpr pv funcName e <> ";\n" <> discard <> go (liveAfter : lives) rest
+    go (_ : lives) (Ir.Dup x : rest) = "rt.dupNamed(" <> pv x <> ", " <> nameLit x <> ", " <> funcName <> ");\n" <> go lives rest
+    go (_ : lives) (Ir.Drop x : rest) = "rt.dropNamed(" <> pv x <> ", " <> nameLit x <> ", " <> funcName <> ");\n" <> go lives rest
+    go (_ : liveAfter : lives) (Ir.DropReuse tok x arity : rest) =
+      let usedLater = tok `Set.member` liveAfter
           discard = if usedLater then "" else "_ = " <> pv tok <> ";\n"
        in "const "
             <> pv tok
@@ -115,7 +120,8 @@ emitBlock pv funcName (Ir.Block stmts0 terminator) = go stmts0
             <> funcName
             <> ");\n"
             <> discard
-            <> go rest
+            <> go (liveAfter : lives) rest
+    go _ (_ : _) = error "Malgo.Backend.Zig.Emit: suffixFreeVars shorter than stmts (invariant violation)"
 
 emitTerminator :: (Name -> Text) -> Text -> Ir.Terminator -> Text
 emitTerminator pv funcName = \case

--- a/src/Malgo/Backend/Zig/Emit.hs
+++ b/src/Malgo/Backend/Zig/Emit.hs
@@ -56,6 +56,15 @@ emitProgram program = do
         "}"
       ]
 
+-- | @_ = name;@ when @isUsed@ is 'False', else nothing -- see the module
+-- haddock on why an unused binding must be explicitly discarded.
+discardUnless :: Text -> Bool -> Text
+discardUnless name isUsed = if isUsed then "" else "_ = " <> name <> ";\n"
+
+-- | @const name = rhs;@ followed by 'discardUnless' for that same name.
+declareConst :: Text -> Text -> Bool -> Text
+declareConst name rhs isUsed = "const " <> name <> " = " <> rhs <> ";\n" <> discardUnless name isUsed
+
 emitFunc :: Ir.Func -> Text
 emitFunc fn =
   "fn "
@@ -73,16 +82,11 @@ emitFunc fn =
     -- Zig-IR Func an event came from.
     funcNameLit = zigStringLit (idToText fn.name)
     bodyFree = Ir.freeVarsBlock fn.body
-    discardSelf = if fn.selfVar `Set.member` bodyFree then "" else "_ = self;\n"
+    discardSelf = discardUnless "self" (fn.selfVar `Set.member` bodyFree)
     discardArgs = if null fn.params then "_ = args;\n" else ""
     paramBinds =
       T.concat
-        [ "const "
-            <> pv p
-            <> " = args["
-            <> convertString (show i)
-            <> "];\n"
-            <> (if p `Set.member` bodyFree then "" else "_ = " <> pv p <> ";\n")
+        [ declareConst (pv p) ("args[" <> convertString (show i) <> "]") (p `Set.member` bodyFree)
         | (i, p) <- zip [0 :: Int ..] fn.params
         ]
 
@@ -100,17 +104,13 @@ emitBlock pv funcName (Ir.Block stmts0 terminator) = go (Ir.suffixFreeVars stmts
     -- quadratic (a fresh scan per binding would re-walk every remaining
     -- statement at every position).
     go (_ : liveAfter : lives) (Ir.Let x e : rest) =
-      let usedLater = x `Set.member` liveAfter
-          discard = if usedLater then "" else "_ = " <> pv x <> ";\n"
-       in "const " <> pv x <> " = " <> emitExpr pv funcName e <> ";\n" <> discard <> go (liveAfter : lives) rest
+      declareConst (pv x) (emitExpr pv funcName e) (x `Set.member` liveAfter) <> go (liveAfter : lives) rest
     go (_ : lives) (Ir.Dup x : rest) = "rt.dupNamed(" <> pv x <> ", " <> nameLit x <> ", " <> funcName <> ");\n" <> go lives rest
     go (_ : lives) (Ir.Drop x : rest) = "rt.dropNamed(" <> pv x <> ", " <> nameLit x <> ", " <> funcName <> ");\n" <> go lives rest
     go (_ : liveAfter : lives) (Ir.DropReuse tok x arity : rest) =
-      let usedLater = tok `Set.member` liveAfter
-          discard = if usedLater then "" else "_ = " <> pv tok <> ";\n"
-       in "const "
-            <> pv tok
-            <> " = rt.dropReuseNamed("
+      declareConst
+        (pv tok)
+        ( "rt.dropReuseNamed("
             <> pv x
             <> ", "
             <> convertString (show arity)
@@ -118,9 +118,10 @@ emitBlock pv funcName (Ir.Block stmts0 terminator) = go (Ir.suffixFreeVars stmts
             <> nameLit x
             <> ", "
             <> funcName
-            <> ");\n"
-            <> discard
-            <> go (liveAfter : lives) rest
+            <> ")"
+        )
+        (tok `Set.member` liveAfter)
+        <> go (liveAfter : lives) rest
     go _ (_ : _) = error "Malgo.Backend.Zig.Emit: suffixFreeVars shorter than stmts (invariant violation)"
 
 emitTerminator :: (Name -> Text) -> Text -> Ir.Terminator -> Text

--- a/src/Malgo/Backend/Zig/Ir.hs
+++ b/src/Malgo/Backend/Zig/Ir.hs
@@ -29,6 +29,7 @@ module Malgo.Backend.Zig.Ir
     freeVarsTerminator,
     freeVarsExpr,
     freeVarsGuard,
+    suffixFreeVars,
     pathRoot,
     termOperands,
   )
@@ -185,6 +186,21 @@ freeVarsBlock (Block stmts terminator) = go stmts
     go (Dup x : rest) = Set.insert x (go rest)
     go (Drop x : rest) = Set.insert x (go rest)
     go (DropReuse tok x _ : rest) = Set.insert x (Set.delete tok (go rest))
+
+-- | @suffixFreeVars stmts term !! i == freeVarsBlock (Block (drop i stmts) term)@
+-- for every @i@ in @[0 .. length stmts]@, computed in one bottom-up pass.
+-- Callers that walk a statement list and, at each position, need the free
+-- variables of everything from there on (e.g. an unused-binding check)
+-- would otherwise call 'freeVarsBlock' afresh on each shrinking suffix,
+-- making that walk quadratic in the block's length; indexing into this
+-- list instead keeps it linear.
+suffixFreeVars :: [Stmt] -> Terminator -> [Set Name]
+suffixFreeVars stmts term = scanr step (freeVarsTerminator term) stmts
+  where
+    step (Let x e) live = freeVarsExpr e <> Set.delete x live
+    step (Dup x) live = Set.insert x live
+    step (Drop x) live = Set.insert x live
+    step (DropReuse tok x _) live = Set.insert x (Set.delete tok live)
 
 freeVarsStmt :: Stmt -> Set Name
 freeVarsStmt (Let _ e) = freeVarsExpr e

--- a/src/Malgo/Backend/Zig/Perceus.hs
+++ b/src/Malgo/Backend/Zig/Perceus.hs
@@ -47,22 +47,26 @@ perceusFunc fn = fn {body = insertBlock delta0 fn.body}
 -- in scope. Invariant: each Δ variable holds exactly one owned reference.
 insertBlock :: Set Name -> Block -> Block
 insertBlock delta (Block stmts term) =
-  let (stmts', term') = goStmts delta stmts term
+  let (stmts', term') = goStmts delta (suffixFreeVars stmts term) stmts term
    in Block stmts' term'
 
-goStmts :: Set Name -> [Stmt] -> Terminator -> ([Stmt], Terminator)
+-- 'goStmts'\/'goLive' thread 'suffixFreeVars' through their recursion so
+-- they never re-scan a statement suffix they have already scanned (each
+-- recursive step would otherwise redo the whole remaining 'freeVarsBlock'
+-- walk, making the pass quadratic in block length).
+goStmts :: Set Name -> [Set Name] -> [Stmt] -> Terminator -> ([Stmt], Terminator)
 -- A bare panic block is RC-exempt (the process exits): no drops before it.
-goStmts _ [] (TPanic msg) = ([], TPanic msg)
-goStmts delta stmts term =
+goStmts _ _ [] (TPanic msg) = ([], TPanic msg)
+goStmts delta (live : lives) stmts term =
   -- (D) Eagerly drop every owned variable that is dead from here on.
-  let live = freeVarsBlock (Block stmts term)
-      deadNow = Set.toList (delta Set.\\ live)
-      (rest, term') = goLive (delta `Set.intersection` live) stmts term
+  let deadNow = Set.toList (delta Set.\\ live)
+      (rest, term') = goLive (delta `Set.intersection` live) (live : lives) stmts term
    in (map Drop deadNow <> rest, term')
+goStmts _ [] _ _ = error "Malgo.Backend.Zig.Perceus: liveSets shorter than stmts (invariant violation)"
 
-goLive :: Set Name -> [Stmt] -> Terminator -> ([Stmt], Terminator)
-goLive delta [] term = insertTerminator delta term
-goLive delta (stmt : rest) term = case stmt of
+goLive :: Set Name -> [Set Name] -> [Stmt] -> Terminator -> ([Stmt], Terminator)
+goLive delta _ [] term = insertTerminator delta term
+goLive delta (_ : liveAfter : lives) (stmt : rest) term = case stmt of
   Dup _ -> error "Malgo.Backend.Zig.Perceus: input already contains Dup"
   Drop _ -> error "Malgo.Backend.Zig.Perceus: input already contains Drop"
   DropReuse {} -> error "Malgo.Backend.Zig.Perceus: input already contains DropReuse (Reuse runs after Perceus)"
@@ -87,14 +91,13 @@ goLive delta (stmt : rest) term = case stmt of
     Force v _ -> owningLet [v]
     MkStructReuse {} -> error "Malgo.Backend.Zig.Perceus: input already contains MkStructReuse (Reuse runs after Perceus)"
     where
-      liveAfter = freeVarsBlock (Block rest term)
       -- A borrowed read creates no reference: promote the binding to owned
       -- with a Dup when it is live, elide it entirely when it is dead.
       borrowedLet
         | x `Set.member` liveAfter =
-            let (rest', term') = goStmts (Set.insert x delta) rest term
+            let (rest', term') = goStmts (Set.insert x delta) (liveAfter : lives) rest term
              in (stmt : Dup x : rest', term')
-        | otherwise = goStmts delta rest term
+        | otherwise = goStmts delta (liveAfter : lives) rest term
       -- (Let) The expression moves one reference per operand occurrence;
       -- an operand still live afterwards keeps its own reference, so it
       -- needs one Dup per occurrence, else one fewer (its reference moves).
@@ -107,8 +110,9 @@ goLive delta (stmt : rest) term = case stmt of
               | otherwise = replicate (n - 1) (Dup y)
             consumedAway = Set.fromList [y | (y, _) <- counts, y `Set.notMember` liveAfter]
             delta' = Set.insert x (delta Set.\\ consumedAway)
-            (rest', term') = goStmts delta' rest term
+            (rest', term') = goStmts delta' (liveAfter : lives) rest term
          in (concatMap dupsFor counts <> (stmt : rest'), term')
+goLive _ _ (_ : _) _ = error "Malgo.Backend.Zig.Perceus: liveSets shorter than stmts (invariant violation)"
 
 insertTerminator :: Set Name -> Terminator -> ([Stmt], Terminator)
 insertTerminator delta = \case

--- a/src/Malgo/Driver.hs
+++ b/src/Malgo/Driver.hs
@@ -20,6 +20,7 @@ import Malgo.Query
 import Malgo.Query.Database
 import Malgo.Query.Engine
 import Malgo.Sequent.BigStepEval (BigStepEvalPass (..))
+import Malgo.Sequent.Core.Join qualified as Join
 import Malgo.Sequent.Eval (EvalPass (..), Handlers (..))
 import Malgo.Syntax qualified as Syntax
 import Malgo.Syntax.Extension
@@ -58,11 +59,7 @@ compileFromAST ::
 compileFromAST srcPath parsedAst = do
   flags <- ask @Flag
   let modName = parsedAst.moduleName
-  registerModule modName srcPath
-  db <- liftIO newDatabase
-  -- Pre-populate the parse cache so the query engine reuses this result.
-  liftIO $ modifyIORef db.cacheParsedModule $ Map.insert modName parsedAst
-  core <- runQueryDB db $ fetch (LinkedProgram modName)
+  core <- fetchLinkedCore srcPath parsedAst
   case flags.target of
     TargetScheme -> do
       schemeCode <- runReader modName $ runPass SchemePass core
@@ -78,6 +75,27 @@ compileFromAST srcPath parsedAst = do
       case flags.evalMode of
         EvalBigStep -> runPass BigStepEvalPass (modName, Handlers {..}, core)
         EvalSmallStep -> runPass EvalPass (modName, Handlers {..}, core)
+
+-- | Register the module and run the query pipeline through linking --
+-- shared by every 'compileFromAST' target and by 'compileToExecutable'.
+fetchLinkedCore ::
+  ( Reader Flag :> es,
+    Error CompileError :> es,
+    IOE :> es,
+    State Uniq :> es,
+    Workspace :> es,
+    Features :> es
+  ) =>
+  ArtifactPath ->
+  Syntax.Module (Malgo Parse) ->
+  Eff es Join.Program
+fetchLinkedCore srcPath parsedAst = do
+  let modName = parsedAst.moduleName
+  registerModule modName srcPath
+  db <- liftIO newDatabase
+  -- Pre-populate the parse cache so the query engine reuses this result.
+  liftIO $ modifyIORef db.cacheParsedModule $ Map.insert modName parsedAst
+  runQueryDB db $ fetch (LinkedProgram modName)
 
 -- | Compile a source file to Zig, then invoke the @zig@ toolchain to
 -- produce a native executable at @outPath@. Used by the @malgo compile@
@@ -100,12 +118,8 @@ compileToExecutable srcPath outPath optMode = do
   save srcModulePath ".mlg" src
   zigText <- runCompileError do
     parsedAst <- runPass ParserPass (srcPath, convertString @BS.ByteString src)
-    let modName = parsedAst.moduleName
-    registerModule modName srcModulePath
-    db <- liftIO newDatabase
-    liftIO $ modifyIORef db.cacheParsedModule $ Map.insert modName parsedAst
-    core <- runQueryDB db $ fetch (LinkedProgram modName)
-    runReader modName $ runPass ZigPass core
+    core <- fetchLinkedCore srcModulePath parsedAst
+    runReader parsedAst.moduleName $ runPass ZigPass core
   save srcModulePath ".zig" (convertString @Text @BS.ByteString zigText)
   workspace <- getWorkspace
   let zigPath = outPath <> ".zig"

--- a/src/Malgo/Driver.hs
+++ b/src/Malgo/Driver.hs
@@ -15,6 +15,7 @@ import Malgo.Features
 import Malgo.Module
 import Malgo.Parser (ParserPass (..))
 import Malgo.Pass (CompileError, Pass (..), runCompileError)
+import Malgo.Path (toFilePath)
 import Malgo.Prelude
 import Malgo.Query
 import Malgo.Query.Database
@@ -121,7 +122,7 @@ compileToExecutable srcPath outPath optMode = do
     core <- fetchLinkedCore srcModulePath parsedAst
     runReader parsedAst.moduleName $ runPass ZigPass core
   save srcModulePath ".zig" (convertString @Text @BS.ByteString zigText)
-  workspace <- getWorkspace
+  workspace <- toFilePath <$> getWorkspaceAbs
   let zigPath = outPath <> ".zig"
   liftIO $ BS.writeFile zigPath (convertString zigText)
   liftIO $ Zig.buildExecutable workspace zigPath outPath optMode

--- a/src/Malgo/Module.hs
+++ b/src/Malgo/Module.hs
@@ -5,6 +5,7 @@ module Malgo.Module
     HasModuleName,
     Workspace,
     getWorkspace,
+    getWorkspaceAbs,
     registerModule,
     getModulePath,
     runWorkspaceOnPwd,


### PR DESCRIPTION
## Summary

Works through the 10 deferred cleanup findings from the #351/#352/#353 code
reviews (the user asked to continue fixing directly rather than file an
issue). 9 of 10 are fixed here; 1 is explicitly skipped (see below).

- **perf**: fix O(n²) free-variable/escaping-name recomputation in
  `Perceus.goStmts`/`goLive`, `Emit.emitBlock`, and
  `ClosureConv.initialClassifyJoins` — each re-scanned a shrinking statement
  suffix from scratch at every recursion step. Added `Ir.suffixFreeVars`
  (shared by Perceus and Emit) and a fused
  `initialClassifyJoinsWithEscaping` for ClosureConv, both computing the
  needed sets in one bottom-up pass instead.
- **refactor**: `escapingNamesProducer`'s `Lambda`/`Object`/`Mu`/`Cocase`
  cases now delegate to `freeVarsProducer` instead of duplicating its rules.
- **refactor**: `Driver.compileToExecutable` reused `compileFromAST`'s
  already-shared register/query-db/link pipeline (factored out as
  `fetchLinkedCore`) instead of re-implementing it.
- **fix**: `compileToExecutable` was the sole production caller of the
  WARNING-flagged `Malgo.Module.getWorkspace`; switched to the existing
  (and already-used-everywhere-else-in-Module.hs) `getWorkspaceAbs`.
- **refactor**: extracted `declareConst`/`discardUnless` helpers in
  `Emit.hs` instead of hand-writing the "const x = ...; discard if unused"
  idiom at each of 3 call sites.
- **fix**: `mkStructReuse`'s sole safety check was `std.debug.assert`, which
  ReleaseFast/ReleaseSmall compile out entirely. Replaced with an
  unconditional check that panics, as a last line of defense behind
  RcCheck's static verification. Verified with an actual `--opt
  release-fast` build + run.
- **fix**: `traceLine`/`traceAddr`/`traceSlots` silently dropped RC-trace
  events (`catch return`/`catch continue`) when a compiler-generated
  name/func string overflowed their fixed 256-byte buffers — a per-slot
  `catch continue` could also desync the enclosing JSON array. Bumped
  buffers to 512 bytes and emit an explicit `trace_overflow` marker /
  placeholder slot on the (now much rarer) remaining overflow instead of
  dropping silently.

**Skipped**: making `Perceus.hs`/`RcCheck.hs` qualify their `Ir` import
(matching `ClosureConv.hs`/`Emit.hs`'s `qualified as Ir`) for style
consistency. Both files' Haddock comments already reference constructors via
fully-qualified links like `'Malgo.Backend.Zig.Ir.Program'`; a mechanical
rename risks corrupting those (turning them into
`Ir.Malgo.Backend.Zig.Ir.Program`-style garbage) without any build-time
signal, for a change with zero behavioral payoff. Left as-is.

## Test plan

- [x] `cabal build lib:malgo exe:malgo` — clean, no new warnings
- [x] `cabal test --test-show-details=direct` — 1444 examples, 0 failures
- [x] `bash scripts/zig-golden.sh` — 73/73 passed, 0 leaks (re-run after every commit)
- [x] `zig test runtime/zig/runtime.zig` — 14/14 passed
- [x] `--opt release-fast` build of TreeInsert.mlg run directly, confirming reuse hits happen and the mkStructReuse safety check doesn't fire spuriously
- [x] `MALGO_RC_TRACE=1` run of a compiled binary, confirming real trace output (8562 lines) parses correctly with the new buffer sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)