### PR TITLE
docs: add Zig backend, Perceus GC, and MET tool documentation

### DIFF
--- a/docs/met-tool.md
+++ b/docs/met-tool.md
@@ -1,0 +1,111 @@
+# MET — M-exp-Tracer
+
+MET is a browser-based tool (`app/met`) that runs a `.mlg` file through the full
+compilation pipeline — Parse through the Zig backend's `Reuse` pass — and renders
+every stage's intermediate representation in a Malgo-ish ASCII notation, for
+side-by-side or unified-diff comparison between adjacent stages. It exists to make
+the effect of a specific pass on a specific program visible without instrumenting
+the compiler or reading raw IR dumps by hand.
+
+## Running it
+
+```
+mise run met --option source="path/to/file.mlg"
+mise run met --option source="path/to/file.mlg" --option port=9090
+mise run met --option source="path/to/file.mlg" --option flags="--infer --malgo2025"
+```
+
+`mise run met` depends on `mise run build` and then runs
+`cabal exec met -- SOURCE --port PORT [flags]`. The two flags MET's own CLI accepts:
+
+- `--infer`: also run `InferPass` (mirrors `malgo eval --infer`), adding an
+  `Elaborate` stage's input to type-checking.
+- `--malgo2025`: also run `ElaboratePass` (mirrors the `malgo2025` feature flag),
+  inserting an `Elaborate` stage between `Rename` and `ToFun`.
+
+The server prints `MET: traced <path> (<N> stages). Listening on
+http://localhost:<port>` and stays up until killed; every compiler effect needed to
+produce the trace runs exactly once, before the HTTP server starts — page handlers
+are pure functions over the resulting `[Stage]` list.
+
+## What it shows
+
+The home page (`/`) lists every adjacent stage transition as a link. Each stage
+transition page (`/stage/<i>`) offers two views of the same pair of stages:
+
+- **Side-by-side** (default): a two-column table, line-aligned, with word-level
+  highlighting on lines that changed.
+- **Diff patch** (`?view=diff`): a unified-diff-style rendering, added/removed lines
+  highlighted, again with word-level sub-highlighting within a paired
+  removed/added line.
+
+The word-level highlighting matters more than it might sound: a single renamed
+identifier or a single inserted `dup` no longer paints its whole line red/green —
+only the token that actually changed does. This is implemented as a two-pass diff
+(`Malgo.Debug.DiffView`, via the `Diff` library): first line-by-line, then, for a
+same-position "replace" (a run of removed lines immediately followed by a run of
+added lines — the shape every changed statement takes in this renderer), word-by-word
+within each paired line.
+
+A sidebar on every page is a legend for MET's own notation — it is explicitly *not*
+real Malgo syntax, since several stages (Core IR sequent-calculus notation, the Zig
+backend's ANF IR) have no surface-syntax equivalent at all.
+
+## The stages traced
+
+`Malgo.Debug.Pipeline.runTrace` mirrors the exact pass sequence
+`Malgo.Query.Engine`'s `LinkedProgram` query and `Malgo.Backend.Zig`'s `ZigPass` run
+in production, just without discarding the intermediate values, and without linking
+in `Builtin`/`Prelude` (linking every dependency's definitions in would bury the
+interesting diff in Prelude noise; every pass rewrites definitions independently of
+its imports anyway). In order:
+
+| Stage | Producing pass | Notes |
+|---|---|---|
+| `Parse` | `ParserPass` | Surface syntax |
+| `Rename` | `RenamePass` | |
+| `Elaborate` | `ElaboratePass` | Only with `--malgo2025` |
+| `ToFun` | `ToFunPass` | Fun IR |
+| `SaturateCtor` | `Malgo.Sequent.SaturateCtor` | Inlines saturated constructor calls |
+| `ReuseSpecialize` | `Malgo.Sequent.ReuseSpecialize` | Inserts `reuseHint` calls |
+| `ToCore` | `toCore` | Core IR (sequent calculus) |
+| `Flat` | `flatProgram` | Flat IR |
+| `Join` | `joinProgram` | Join IR |
+| `ClosureConv` | `ClosureConv.convertProgram` | Zig backend's own ANF IR |
+| `Peephole` | `peepholeProgram` | Scrutinee-tuple elimination |
+| `Perceus` | `perceusProgram` | `dup`/`drop` insertion |
+| `Reuse` | `reuseProgram` | FBIP reuse-token pairing; also runs `RcCheck` and prepends any violation as a comment |
+
+Only `InferPass` is conditionally run (`--infer`) *without* a dedicated stage of its
+own — its output feeds `ToFunPass` the same way `RefinePass`'s would in the
+production pipeline, but MET does not currently render a `Refine`/typed-AST stage.
+
+See [`zig-backend.md`](zig-backend.md) for what each pass after `Join` actually
+does, and [`perceus-gc.md`](perceus-gc.md) for `Perceus`/`Reuse`/`RcCheck` in detail.
+
+## Architecture
+
+- **`Malgo.Debug.Pipeline`** (`src/Malgo/Debug/Pipeline.hs`) drives a single module
+  through every pass above, capturing each stage's rendered text into a `Stage {name,
+  rendered}` list. This is also used directly by MET's own golden tests
+  (`Malgo.Debug.PrettyIRSpec`), independent of the web server.
+- **`Malgo.Debug.PrettyIR`** (`src/Malgo/Debug/PrettyIR.hs`) is a best-effort,
+  non-round-trippable renderer for every IR from surface syntax through
+  `Core.Full`/`Flat`/`Join` to the Zig backend's own IR — the source of the ASCII
+  notation the sidebar legend explains.
+- **`Malgo.Debug.DiffView`** (`src/Malgo/Debug/DiffView.hs`) implements the
+  line-then-word diffing described above, independent of HTML rendering.
+- **`app/met`** (`Main.hs` + `Server.hs`) is the CLI entry point (`optparse-applicative`)
+  and the `servant` + `warp` + `lucid` HTTP server. `Server.app` takes the
+  precomputed `[Stage]` and serves two routes: `/` (the stage list) and
+  `/stage/:index` (a transition view, with an optional `?view=diff` query param).
+
+## Known limitations
+
+- Only the target module's own definitions are traced — no `Builtin`/`Prelude`
+  linking — so a stage's rendered output will reference imported names that aren't
+  themselves defined anywhere in the trace.
+- The renderer's notation is invented per IR family and is not parseable back into
+  Malgo source or any IR; it exists purely for human comparison between adjacent
+  stages, not as a serialization format.
+- `RefinePass` has no dedicated rendered stage yet, even under `--infer`.

--- a/docs/perceus-gc.md
+++ b/docs/perceus-gc.md
@@ -1,0 +1,193 @@
+# Perceus Reference Counting
+
+The Zig backend's memory model is Perceus (PLDI 2021), as adapted for compiled
+closures by Lean 4's "Counting Immutable Beans": a pure `Ir.Program -> Ir.Program`
+rewrite (`Malgo.Backend.Zig.Perceus`) that inserts `dup`/`drop` operations so that, on
+every non-panic control-flow path, every owned reference is consumed exactly once.
+No tracing garbage collector runs at any point — every allocation's lifetime is
+determined statically, at compile time, by counting occurrences in the IR.
+
+This document assumes familiarity with the Zig backend's pipeline; see
+[`zig-backend.md`](zig-backend.md) for where Perceus sits relative to `ClosureConv`,
+`Peephole`, `Reuse`, `RcCheck`, and `Emit`.
+
+## Ownership discipline
+
+Ownership rules, matching the runtime's actual behavior (`runtime/zig/runtime.zig`):
+
+- A function owns its parameters, and — for closure/field functions — its `self`
+  closure object.
+- Captures are borrowed reads out of `self` (`ReadCapture`), promoted to owned by a
+  `Dup` if still live afterwards; `self` is dropped as soon as it is dead (right
+  after the last capture read — the required dup-captures-before-drop-self ordering
+  falls out of plain liveness, not a special case).
+- `MkStruct`/`MkClosure`/`MkRecord` move one reference per operand into the new
+  object; `Force` moves one reference of the record (the field function drops it as
+  its own `self`); every operand of a consuming terminator moves into the call.
+- `Prim` operands, `ReadPath`/`ReadCapture` sources, and guard tests only borrow —
+  they read a value without taking ownership of it.
+
+At every insertion point, all `Dup`s precede any `Drop` of the same statement
+position (garbage-free ordering): a struct's live fields are duplicated by their
+borrowed-let bindings before liveness kills the struct itself, so a value is never
+observably at refcount zero while a sibling binding still needs to read it.
+
+## How `dup`/`drop` get inserted
+
+`Perceus.insertBlock` walks a `Block`'s statement list with a set Δ of owned
+variables currently in scope (the invariant: each Δ variable holds exactly one
+owned reference at that point). Two rules combine at each statement:
+
+- **(D) Eager drop.** Before processing a statement, drop every Δ variable that is
+  dead from this point on (not in `freeVarsBlock` of the remaining statements and
+  terminator).
+- **(Let) Owning-let / borrowed-let.** A binding that borrows (`ReadPath`,
+  `ReadCapture`) is promoted to owned by a `Dup` if it survives past this point, or
+  simply elided if it's immediately dead. A binding that consumes operands
+  (`MkStruct`, `MkClosure`, `MkRecord`, `Force`, most `Prim`s) needs one `Dup` per
+  operand occurrence that is still live afterwards (an operand occurring twice needs
+  one dup for the second occurrence, since one reference already moves with the
+  first) — an operand that dies exactly here needs no dup at all, since its own
+  reference moves into the new binding.
+- **(T) Consuming terminators** apply the same "one dup per live-afterwards repeat
+  occurrence" rule to a terminator's operands, after (D) has already reduced Δ down
+  to exactly that operand set.
+
+`reuseHint` (inserted by `Malgo.Sequent.ReuseSpecialize`, see
+[`zig-backend.md`](zig-backend.md)) is the one primitive that *consumes* its operand
+rather than borrowing it — marking that operand's last use immediately before a
+reconstruction, for the `Reuse` pass below to recognize.
+
+### Why this can't be quadratic by accident
+
+Both (D) and (Let) need "the free variables of everything from here on" at every
+statement position. Computing that with a fresh `freeVarsBlock` call on each
+shrinking suffix, at every recursive step, would make one pass over an
+`n`-statement block cost `O(n²)`. `Ir.suffixFreeVars` instead computes every
+suffix's free-variable set in a single bottom-up `scanr`, and `Perceus`/`Emit`
+thread the resulting list alongside their recursion instead of recomputing.
+
+## Reuse tokens (FBIP)
+
+`Malgo.Backend.Zig.Reuse` runs after Perceus (it needs Perceus's `Drop` placement)
+and before `RcCheck`. Within one straight-line statement list (never crossing an
+`if`'s branches — those are separate `Block`s, recursed into independently), it
+pairs the nearest preceding `Drop` with a later `MkStruct`, LIFO — the same pairing
+order Koka's own reuse analysis uses — rewriting both into `DropReuse`/
+`MkStructReuse`.
+
+At runtime, `rt.dropReuse` recycles the dropped Object in place when it was
+uniquely referenced (struct, closure, and scalar payloads are all eligible — not
+just literal cell reuse of the same shape), falling back to an ordinary drop and a
+null token otherwise. `rt.mkStructReuse` then either overwrites that recycled Object
+or allocates fresh from a null token. No static arity check is needed at this
+level: every pairing is only a candidate, verified dynamically per call, and a
+rewritten-but-never-taken fallback path is exactly as correct (if less cheap) as the
+original `Drop`/`MkStruct` pair would have been.
+
+Object reuse only ever recycles a *single* backing array per Object — a `record`'s
+separate fields array, a `codata`'s separate branches array, and a `string`'s bytes
+all fall back to an ordinary drop/allocate pair rather than adding another
+bookkeeping case to `dropReuse`.
+
+`MALGO_RC_STATS=1` on a compiled binary reports `reuse_hits` alongside
+`total_allocs` at exit, to measure this pass's effect.
+
+## `RcCheck`: static verification, not just documentation
+
+`Malgo.Backend.Zig.RcCheck.checkProgram` symbolically executes the RC-annotated
+program Perceus + Reuse produced, counting each variable's owned references along
+every control-flow path, and reports any path where a reference is:
+
+- consumed twice, or used after being consumed (`UseAfterConsume`),
+- never consumed (`UnconsumedAtExit`),
+- `Dup`'d or `Drop`'d while already dead (`DupOfDead`/`DropOfDead`), or
+- a reuse token (`MkStructReuse`) referencing a token that was never produced by a
+  `DropReuse`, or was already consumed (`TokenUnavailable`/`TokenUnconsumed`).
+
+`Malgo.Backend.Zig`'s `runPassImpl` runs this check unconditionally — on every
+compile, not just in an hspec suite or behind a debug flag — turning any
+Perceus/Reuse bug into a *compile-time* error (`ZigError`) rather than a
+use-after-free or a leak in the produced binary. The golden-test corpus also runs it
+directly on every testcase with no Zig toolchain needed at all, since it's pure
+Haskell over the IR.
+
+`RcCheck`'s model is deliberately stricter than heap reachability: a borrowed alias
+(a `ReadPath`/`ReadCapture` result) is only accessible while its root still holds a
+reference *in this scope*, or the alias was itself promoted by a `Dup` — exactly
+Perceus's own local ownership discipline, which is what makes it a useful oracle for
+Perceus's output specifically, rather than a general-purpose verifier.
+
+## Runtime implementation
+
+`runtime/zig/runtime.zig` backs all of the above:
+
+- Every `Value` is a `*Object { rc: u32, kind: Kind, payload: Payload }`. `IMMORTAL`
+  (`0xFFFF_FFFF`) marks a value that lives for the whole process (`rt.no_self`);
+  `dup`/`drop` are no-ops on it.
+- `dup`/`drop` are the primitive ops the compiler inserts directly.
+  `drop` decrements and, at zero, queues the Object onto a deferred free worklist
+  (`g_free_worklist`) rather than recursing immediately — so dropping a deep
+  structure (a 100k-element cons list) never recurses on the native stack.
+- Two heaps: `g_value` (Objects, their fields/captures backing arrays, string
+  payload bytes — individually freed, and what the leak check below covers) and a
+  scratch arena (transient non-`Value` bytes: print formatting, parse/encode
+  buffers, the free worklist's own storage) — bulk-freed at process exit, exempt
+  from the leak check.
+- `g_value` is `std.heap.DebugAllocator` in `Debug`/`ReleaseSafe` (catching
+  non-`Object` leaks, use-after-free, and double-frees with per-allocation stack
+  traces) and `std.heap.smp_allocator` in `ReleaseFast`/`ReleaseSmall`, where
+  `g_live_objects` alone still provides the zero-leak invariant, build-mode
+  independent.
+- `exitWithLeakCheck` (the generated `main`'s last statement) checks
+  `g_live_objects != 0` — any leftover live Object means Perceus under-dropped
+  somewhere — printing `MALGO-LEAK: <N> objects` and exiting 83 (the zig-golden
+  harness's dedicated leak bucket) rather than exiting 0 through a corrupted or
+  simply-wrong program.
+
+### A note on `std.debug.assert` vs. explicit checks
+
+`std.debug.assert` is compiled out entirely in `ReleaseFast`/`ReleaseSmall` — it is
+the right tool for internal invariants where a violation always indicates a compiler
+bug and a full stack trace during development is the priority (e.g. `drop`'s
+underflow check). But `mkStructReuse`'s token-safety check
+(`obj.rc == 1 and obj.kind == .strukt`) is the *last* line of defense behind
+`RcCheck`'s static verification — if RcCheck ever has a false negative, this is what
+stands between a malformed token and silently overwriting memory that was never
+actually vacated. It therefore runs both ways: `std.debug.assert` first, for a full
+stack trace in `Debug`/`ReleaseSafe`, followed by an explicit `if`/`panic` that is
+never compiled out, as the actual guard in `ReleaseFast`/`ReleaseSmall` (at the cost
+of only a one-line message there, not a trace).
+
+## Debugging: `MALGO_RC_TRACE` and `scripts/rctrace.py`
+
+Every `dup`/`drop`/`dropReuse`/`mkStruct`/`mkClosure`/`mkStructReuse` the compiler
+emits actually calls a `*Named` wrapper (`dupNamed`, `dropNamed`, ...) that performs
+the exact same RC operation, then — only when the `MALGO_RC_TRACE` environment
+variable is set — emits one JSON-lines event to stderr carrying the compile-time
+symbolic name and enclosing function `Malgo.Backend.Zig.Emit` threads through from
+the IR. Tracing is purely additive: the plain, untraced operations are what every
+`zig test` block in `runtime.zig` exercises directly, so tracing can never perturb
+the RC decisions those tests check.
+
+```
+MALGO_RC_TRACE=1 ./some_compiled_binary 2>trace.jsonl
+python3 scripts/rctrace.py trace.jsonl                    # first dropReuse_miss
+python3 scripts/rctrace.py trace.jsonl --target 0x104d604c0
+python3 scripts/rctrace.py trace.jsonl --target 0x104d604c0 --at-line 812
+```
+
+`rctrace.py` replays the log to answer "who still holds a reference to this object
+right now" — resolving an address to a *generation* (the heap reuses freed
+addresses, so a `dropReuse_miss` needs scoping to the construction event at or
+before the line in question, not every event that ever touched that address), then
+listing the (container, slot) pairs that captured it and were never released by a
+matching `decChild`.
+
+Because `name`/`func` are compiler-generated, theoretically unbounded-length
+strings formatted into fixed-size stack buffers in the runtime's tracing code, an
+unusually long identifier can overflow the buffer; rather than silently dropping
+that event, the runtime emits a `{"ev":"trace_overflow"}` marker in its place, and
+`rctrace.py` surfaces a warning (both globally and at the specific
+live-referrers lookup) whenever such a marker falls within the range it's
+analyzing — a bit of trace loss is visible, not a silently wrong conclusion.

--- a/docs/zig-backend.md
+++ b/docs/zig-backend.md
@@ -1,0 +1,157 @@
+# The Zig Backend
+
+`malgo compile SOURCE [-o OUT] [--opt debug|release-safe|release-fast]` compiles a
+`.mlg` module to a native executable by generating Zig source text and invoking the
+`zig` toolchain (Zig 0.16, pinned in `mise.toml`). This document covers the backend's
+pipeline, generated-code conventions, and the tools available for inspecting and
+debugging it. For the reference-counting memory model specifically, see
+[`perceus-gc.md`](perceus-gc.md).
+
+## Where it sits in the compiler
+
+Every backend (interpreter, Scheme, Zig) shares the same front end and the same Join
+IR. `Malgo.Driver.compileFromAST`'s `TargetZig` branch, and `compileToExecutable`
+(used by `malgo compile`), both run:
+
+```
+Source (.mlg)
+  -> ParserPass -> RenamePass -> [InferPass] -> [RefinePass]
+  -> ToFunPass -> ToCorePass -> FlatPass -> JoinPass
+  -> ZigPass
+```
+
+`ToCorePass` runs `Malgo.Sequent.SaturateCtor.saturateProgram` and
+`Malgo.Sequent.ReuseSpecialize.specializeProgram` before CPS conversion — both operate
+on Fun IR and are shared by every backend, not Zig-specific:
+
+- **SaturateCtor** inlines a fully- (or over-) saturated call of a data constructor
+  (`Cons x xs`) directly into a `Construct` producer, instead of invoking the
+  constructor's own curried closure. Arguments need not be immediate values.
+- **ReuseSpecialize** inserts a `reuseHint scrutinee` primitive call immediately
+  before a reconstruction that rebuilds a value of the same shape it just matched
+  against (the classic "insert x into a list, rebuilding one cons cell" pattern) —
+  the hint marks the scrutinee's last use for the Zig backend's `Reuse` pass (below)
+  to recognize, without affecting any other backend's semantics.
+
+`ZigPass` (`Malgo.Backend.Zig`, `src/Malgo/Backend/Zig/`) then takes Join IR and
+produces Zig source text:
+
+```
+Join IR
+  -> Normalize (Mu/Label elimination)
+  -> ClosureConv.convertProgram (closure conversion, produces the backend's own ANF IR)
+  -> Peephole (scrutinee-tuple elimination)
+  -> Perceus (dup/drop insertion)
+  -> Reuse (Drop/MkStruct -> reuse-token pairing)
+  -> RcCheck (linearity + reuse-token static verification)
+  -> Emit (Zig text; runtime embedded via file-embed from runtime/zig/runtime.zig)
+```
+
+Each stage is a pure `Ir.Program -> Ir.Program` (or `-> Text`) function; `Malgo.Backend.Zig`'s
+`runPassImpl` just threads the program through them in order, wrapping any
+`RcCheck` violation as a compile error rather than emitting broken code.
+
+## The backend's own IR
+
+`Malgo.Backend.Zig.ClosureConv.convertProgram` translates Join IR into a first-order,
+ANF IR (`Malgo.Backend.Zig.Ir`) that closure conversion has already normalized:
+
+- Every value is produced by a named `Let`; every operand position is a variable.
+- Captures are explicit index reads (`ReadCapture`) against a function's own closure
+  object — the self-passing calling convention below — rather than free variables.
+- Every nested `Lambda`/escaping join/`Object` field has been lifted into its own
+  top-level `Func`.
+
+This is exactly the shape Perceus needs: with every operand a bare variable and every
+binding named, reference counting reduces to counting occurrences (see
+[`perceus-gc.md`](perceus-gc.md)).
+
+`ClosureConv`'s escaping-join analysis (`classifyJoins`) decides, for each Join-IR
+`Join`-bound consumer, whether it can be compiled as a same-function inline
+substitution (`Local`) or must be reified as a heap-allocated closure (`Escaping`):
+a name escapes if any use of it crosses into a separately-compiled unit — passed to
+`Invoke`, an `Apply`'s return continuation, a `Destructor`'s or `Project`'s
+continuation, or free in a nested `Lambda`/`Object` field/`Cocase` branch/`Mu` body
+that gets lifted into its own function. `initialClassifyJoinsWithEscaping` computes
+both the ownership map and each node's escaping-name set in one bottom-up traversal —
+computing them as two separate top-down-recursive functions (as the direct-escaping
+rule's most naive form would) re-scans a chain of nested `Join`s' shrinking
+continuation once per enclosing `Join`, which is quadratic in the chain's length.
+`Ir.suffixFreeVars` gives the analogous "each shrinking suffix's free variables in one
+pass" primitive over the backend IR itself, used by `Perceus` and `Emit`.
+
+## Calling convention
+
+Every generated Zig function shares one signature,
+`fn (self: rt.Value, args: []const rt.Value) rt.Value`:
+
+- A closure or record field or codata branch receives the closure/record/codata
+  object itself as `self` and reads its captures out of it
+  (`rt.capturesOf(self)` under the hood, `ReadCapture` in the IR).
+- A top-level definition is called directly with `rt.no_self` (an immortal sentinel)
+  and ignores it.
+
+Self-passing is what makes Perceus's "a call consumes one reference of the callee"
+rule implementable: the callee dups the captures it still needs, then drops `self`
+itself — the caller has no post-call point to do either, since every call in this IR
+is a tail call.
+
+## Data representation
+
+Every value at runtime is a `*Object` (`runtime/zig/runtime.zig`): a reference count,
+a `Kind` tag, and a `Payload` union covering unboxed scalars (`int32`/`int64`/`float`/
+`double`/`char`/`unit`) and heap-shaped payloads (`string`, `strukt` — tagged tuples
+and data constructors, `closure`, `record`, `codata`). A `Tag` is either an anonymous
+tuple marker or a `[]const u8` pointing at the generated code's own `.rodata` (a
+constructor name never needs a heap allocation of its own).
+
+## Building and testing
+
+- `mise run build` runs `hpack && cabal build`, covering the compiler itself.
+- `zig test -lc runtime/zig/runtime.zig` runs the runtime's own unit tests
+  (`-lc` links libc explicitly; required on Linux since the runtime calls
+  `std.c.write`/`std.c.getenv` directly — masked on macOS, where libc is always
+  linked via libSystem).
+- `bash scripts/zig-golden.sh` (CI job `zig-golden`) compiles every golden testcase
+  through `malgo compile` and diffs its stdout byte-for-byte against the
+  interpreter's own golden output for the same program, failing the whole run on any
+  mismatch or reported leak. `Malgo.Sequent.Eval` (the interpreter) is the semantic
+  oracle for the compiler as a whole: any observable divergence between it and the
+  Zig backend is a Zig-backend bug, not a spec ambiguity to resolve in the backend's
+  favor.
+- Hspec unit tests for the individual passes live under
+  `test/Malgo/Backend/Zig/*Spec.hs` (`Malgo.Backend.Zig.PeepholeSpec`,
+  `PerceusSpec`, `ReuseSpec`) plus `Malgo.Backend.ZigSpec` for the pass composition
+  end-to-end and `Malgo.Debug.PrettyIRSpec` for the renderer used by MET (below).
+
+## Debugging tools
+
+- **MET** (`app/met`, `mise run met --option source=path/to/file.mlg`): a browser UI
+  that traces a `.mlg` file through every stage above (and the front-end stages
+  before it) and renders each one for side-by-side or unified diffing. See
+  [`met-tool.md`](met-tool.md).
+- **`scripts/rctrace.py`**: correlates a `MALGO_RC_TRACE=1` run's JSON-lines trace
+  log with the compile-time symbolic names the trace carries, to answer "who still
+  holds a reference to this object right now" without manually grepping raw
+  pointer addresses. See the "Debugging" section of [`perceus-gc.md`](perceus-gc.md).
+- **`MALGO_RC_STATS=1`** on a compiled binary prints
+  `MALGO-STATS: total_allocs=<N> reuse_hits=<N>` to stderr at exit — a quick way to
+  measure the `Reuse` pass's effect on allocation count without full tracing.
+- **`RcCheck`** runs unconditionally on every compile (see
+  [`perceus-gc.md`](perceus-gc.md)) — no flag is needed to catch a Perceus/Reuse bug
+  as a compile error rather than a runtime use-after-free.
+- **`Malgo.Debug.Pipeline.runTrace`** (MET's own machinery, `runTrace srcPath
+  useInfer malgo2025 :: IO [Stage]`) can be driven directly from a REPL or a
+  one-off script when a browser isn't convenient — it returns every stage's
+  rendered text as a plain list, with no HTTP server involved.
+
+## Known limitations
+
+- The Malgo evaluator written in Malgo (`runtime/malgo/compiler/`, exercised by
+  `scripts/selfhost-golden.sh`) targets the interpreter's semantics; it does not
+  itself compile through the Zig backend.
+- `Object` reuse (the `Reuse` pass) only ever recycles a single backing array per
+  Object — a `record`'s separate fields array, a `codata`'s separate branches array,
+  and a `string`'s byte buffer all fall back to an ordinary drop/allocate pair rather
+  than being recycled in place. See [`perceus-gc.md`](perceus-gc.md) for why this is
+  a deliberate scope limit, not a bug.


### PR DESCRIPTION
## Summary

Adds three new reference docs under `docs/`, describing subsystems that
previously had no dedicated documentation outside `CLAUDE.md`'s terse
orientation summary and source-level comments:

- **`docs/zig-backend.md`** — the `malgo compile` pipeline end to end:
  where `SaturateCtor`/`ReuseSpecialize` fit (shared by every backend, not
  Zig-specific), the Zig-only stages (`ClosureConv` → `Peephole` →
  `Perceus` → `Reuse` → `RcCheck` → `Emit`), the backend's own ANF IR, the
  self-passing calling convention, runtime data representation, build/test
  commands, and the available debugging tools.
- **`docs/perceus-gc.md`** — the Perceus reference-counting memory model:
  ownership discipline, the `dup`/`drop` insertion rules (D/Let/T), why a
  naive implementation of those rules is quadratic and how
  `Ir.suffixFreeVars` avoids it, FBIP reuse tokens, `RcCheck`'s static
  verification (confirmed it runs unconditionally on every compile, not
  behind any flag), the runtime's heap/leak-check implementation, and
  `MALGO_RC_TRACE`/`scripts/rctrace.py`.
- **`docs/met-tool.md`** — the MET (M-exp-Tracer) pipeline visualizer:
  how to run it, the exact stage list it traces and how that maps to the
  production pipeline, its side-by-side/unified-diff views, and its module
  architecture (`Malgo.Debug.Pipeline`/`PrettyIR`/`DiffView`, `app/met`).

All three cross-link each other where relevant.

## Verification

Documentation-only change (no source/build files touched). Every specific
claim (pass ordering, CI job names, format strings, effect requirements,
build-mode behavior) was checked against the current `master` source
directly rather than written from memory — this caught and corrected one
inaccuracy in an earlier draft (`RcCheck` does **not** run only under
`--debug-mode`; it runs unconditionally on every compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)