### PR TITLE
fix(zig): address max-effort architecture review follow-ups

### DIFF
--- a/app/met/Main.hs
+++ b/app/met/Main.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import Malgo.Debug.Pipeline (runTrace)
 import Malgo.Prelude
-import Network.Wai.Handler.Warp (run)
+import Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
 import Options.Applicative
 import Server (app)
 
@@ -37,4 +37,4 @@ main = do
     <> show (length stages)
     <> " stages). Listening on http://localhost:"
     <> show opt.port
-  run opt.port (app stages)
+  runSettings (setHost "127.0.0.1" $ setPort opt.port defaultSettings) (app stages)

--- a/docs/perceus-gc.md
+++ b/docs/perceus-gc.md
@@ -161,7 +161,7 @@ of only a one-line message there, not a trace).
 
 ## Debugging: `MALGO_RC_TRACE` and `scripts/rctrace.py`
 
-Every `dup`/`drop`/`dropReuse`/`mkStruct`/`mkClosure`/`mkStructReuse` the compiler
+Every `dup`/`drop`/`dropReuse`/`mkStruct`/`mkClosure`/`mkStructReuse`/`mkRecord` the compiler
 emits actually calls a `*Named` wrapper (`dupNamed`, `dropNamed`, ...) that performs
 the exact same RC operation, then — only when the `MALGO_RC_TRACE` environment
 variable is set — emits one JSON-lines event to stderr carrying the compile-time

--- a/runtime/zig/runtime.zig
+++ b/runtime/zig/runtime.zig
@@ -135,19 +135,35 @@ fn alloc(kind: Kind, payload: Payload) Value {
 
 // ===== Reference counting =====
 
+/// A heap-corruption invariant shared by every RC bookkeeping site that
+/// guards against over-drop / reuse-token misuse: fail at the exact
+/// faulty call rather than silently corrupting the heap. In
+/// Debug/ReleaseSafe, `std.debug.assert` gives a full stack trace via
+/// Zig's safety-checked `unreachable`. In ReleaseFast/ReleaseSmall,
+/// `assert` compiles to `unreachable` as a pure optimizer hint with no
+/// runtime check -- worse, if a plain `if (!cond) panic(...)` followed
+/// it, LLVM can use the assert to "prove" that condition dead and elide
+/// the panic entirely, even though `cond` was actually violated at
+/// runtime (verified empirically: an assert immediately followed by the
+/// same check as a plain `if` silently drops the panic branch under
+/// `-O ReleaseFast`). So the two build-mode families get entirely
+/// separate code paths, never both an assert and a check on the same
+/// condition in the same build.
+inline fn rcInvariant(cond: bool, comptime msg: []const u8) void {
+    if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
+        std.debug.assert(cond);
+    } else if (!cond) {
+        panic(msg);
+    }
+}
+
 pub inline fn dup(v: Value) void {
     if (v.rc != IMMORTAL) v.rc += 1;
 }
 
 pub fn drop(v: Value) void {
     if (v.rc == IMMORTAL) return;
-    // An underflow here is an over-drop bug in the Perceus pass; fail at
-    // the exact faulty drop rather than corrupting the heap. The
-    // `std.debug.assert` gives a full stack trace in Debug/ReleaseSafe but is
-    // compiled out in ReleaseFast/ReleaseSmall, so the explicit `panic` after
-    // it is what catches a violation there.
-    std.debug.assert(v.rc > 0);
-    if (v.rc == 0) panic("drop: over-drop of an already-dead Object");
+    rcInvariant(v.rc > 0, "drop: over-drop of an already-dead Object");
     v.rc -= 1;
     if (v.rc == 0) free(v);
 }
@@ -265,20 +281,13 @@ pub fn mkStructReuse(tok: ?Value, tag: Tag, fields: []const Value) Value {
     const obj = tok orelse return mkStruct(tag, fields);
     // A malformed token here would mean overwriting memory `dropReuse` never
     // vacated -- corruption, not a recoverable error, and a last line of
-    // defense behind RcCheck's static token-linearity verification. The
-    // `std.debug.assert` gives a full stack trace pinpointing the call site
-    // in Debug/ReleaseSafe; it is compiled out entirely in
-    // ReleaseFast/ReleaseSmall, so the explicit `panic` after it is what
-    // actually catches a violation there (at the cost of only a one-line
-    // message, not a trace).
-    std.debug.assert(obj.rc == 1 and obj.kind == .strukt);
-    if (obj.rc != 1 or obj.kind != .strukt) panic("mkStructReuse: token does not own a unique strukt Object");
+    // defense behind RcCheck's static token-linearity verification.
+    rcInvariant(obj.rc == 1 and obj.kind == .strukt, "mkStructReuse: token does not own a unique strukt Object");
     if (obj.payload.strukt.fields.len == fields.len) {
         @memcpy(@constCast(obj.payload.strukt.fields), fields);
         obj.payload.strukt.tag = tag;
     } else {
-        std.debug.assert(obj.payload.strukt.fields.len == 0);
-        if (obj.payload.strukt.fields.len != 0) panic("mkStructReuse: arity-mismatched token was not cleared by dropReuse");
+        rcInvariant(obj.payload.strukt.fields.len == 0, "mkStructReuse: arity-mismatched token was not cleared by dropReuse");
         obj.payload.strukt = .{ .tag = tag, .fields = g_value.dupe(Value, fields) catch @panic("Malgo: out of memory") };
     }
     return obj;
@@ -291,8 +300,7 @@ fn decChildren(container: Value, children: []const Value) void {
     for (children, 0..) |c, i| {
         traceDecChild(container, i, c);
         if (c.rc == IMMORTAL) continue;
-        std.debug.assert(c.rc > 0);
-        if (c.rc == 0) panic("decChildren: over-drop of an already-dead child Object");
+        rcInvariant(c.rc > 0, "decChildren: over-drop of an already-dead child Object");
         c.rc -= 1;
         if (c.rc == 0) g_free_worklist.append(scratch(), c) catch @panic("Malgo: out of memory");
     }

--- a/runtime/zig/runtime.zig
+++ b/runtime/zig/runtime.zig
@@ -142,8 +142,12 @@ pub inline fn dup(v: Value) void {
 pub fn drop(v: Value) void {
     if (v.rc == IMMORTAL) return;
     // An underflow here is an over-drop bug in the Perceus pass; fail at
-    // the exact faulty drop rather than corrupting the heap.
+    // the exact faulty drop rather than corrupting the heap. The
+    // `std.debug.assert` gives a full stack trace in Debug/ReleaseSafe but is
+    // compiled out in ReleaseFast/ReleaseSmall, so the explicit `panic` after
+    // it is what catches a violation there.
     std.debug.assert(v.rc > 0);
+    if (v.rc == 0) panic("drop: over-drop of an already-dead Object");
     v.rc -= 1;
     if (v.rc == 0) free(v);
 }
@@ -288,6 +292,7 @@ fn decChildren(container: Value, children: []const Value) void {
         traceDecChild(container, i, c);
         if (c.rc == IMMORTAL) continue;
         std.debug.assert(c.rc > 0);
+        if (c.rc == 0) panic("decChildren: over-drop of an already-dead child Object");
         c.rc -= 1;
         if (c.rc == 0) g_free_worklist.append(scratch(), c) catch @panic("Malgo: out of memory");
     }
@@ -360,9 +365,9 @@ pub fn mkCodata(branches: []const NamedBranch, captures: []const Value) Value {
 // entry in the project's Zig-backend notes).
 //
 // These wrappers are the only thing 'Emit.hs' ever calls; the plain
-// dup/drop/dropReuse/mkStruct/mkClosure/mkStructReuse above are otherwise
-// only exercised directly by this file's own `test` blocks, so tracing
-// cannot perturb the RC decisions those tests already exercise.
+// dup/drop/dropReuse/mkStruct/mkClosure/mkStructReuse/mkRecord above are
+// otherwise only exercised directly by this file's own `test` blocks, so
+// tracing cannot perturb the RC decisions those tests already exercise.
 
 /// `name`\/`func` come from compiler-generated (unbounded-length) Zig-IR
 /// identifiers, so formatting into a fixed stack buffer can in principle
@@ -401,7 +406,8 @@ fn traceAddr(event: []const u8, addr: usize, name: []const u8, func: []const u8)
     ));
 }
 
-/// Traces a construction event (`mkStruct`/`mkClosure`/`mkStructReuse`):
+/// Traces a construction event
+/// (`mkStruct`/`mkClosure`/`mkStructReuse`/`mkRecord`):
 /// records the fresh container's address plus, per slot, the symbolic name
 /// and child address that went into it -- so a later 'traceDecChild' event
 /// against the same (container, slot) pair can be resolved back to a name.
@@ -486,6 +492,12 @@ pub fn mkClosureNamed(code: CodeFn, captures: []const Value, names: []const []co
 pub fn mkStructReuseNamed(tok: ?Value, tag: Tag, fields: []const Value, names: []const []const u8, func: []const u8) Value {
     const v = mkStructReuse(tok, tag, fields);
     traceSlots("mkStructReuse", v, fields, names, func);
+    return v;
+}
+
+pub fn mkRecordNamed(fields: []const NamedField, captures: []const Value, names: []const []const u8, func: []const u8) Value {
+    const v = mkRecord(fields, captures);
+    traceSlots("mkRecord", v, captures, names, func);
     return v;
 }
 
@@ -660,7 +672,7 @@ pub fn exitWithLeakCheck() void {
 /// Reads one byte from stdin, or null at EOF.
 fn readStdinByte() ?u8 {
     var buf: [1]u8 = undefined;
-    const n = std.posix.read(0, &buf) catch return null;
+    const n = std.posix.read(0, &buf) catch panic("stdin read error");
     if (n == 0) return null;
     return buf[0];
 }
@@ -1026,7 +1038,7 @@ pub fn malgo_substring(args: []const Value) Value {
     const rawEnd = asI64(args[2]);
     const len: i64 = @intCast(std.unicode.utf8CountCodepoints(s) catch panic("malformed UTF-8 string"));
     const clampedStart: i64 = clampI64(rawStart, 0, len);
-    const takeCount = rawEnd - rawStart;
+    const takeCount = rawEnd -% rawStart;
     if (takeCount <= 0) return mkString("");
     const clampedEnd: i64 = clampI64(clampedStart + takeCount, clampedStart, len);
     const startByte = utf8ByteOffsetOfScalar(s, @intCast(clampedStart));

--- a/scripts/rctrace.py
+++ b/scripts/rctrace.py
@@ -14,7 +14,7 @@ The trace format (emitted by runtime/zig/runtime.zig's "Named RC tracing"
 section) is one JSON object per line:
   {"ev":"dup"|"drop"|"dropReuse_attempt"|"dropReuse_hit"|"dropReuse_miss",
    "ptr":"0x..","rc":N,"name":"..","func":".."}
-  {"ev":"mkStruct"|"mkClosure"|"mkStructReuse","ptr":"0x..","func":"..",
+  {"ev":"mkStruct"|"mkClosure"|"mkStructReuse"|"mkRecord","ptr":"0x..","func":"..",
    "slots":[{"i":0,"name":"..","child":"0x.."}, ...]}
   {"ev":"decChild","container":"0x..","slot":0,"child":"0x..","rc_before":N}
   {"ev":"trace_overflow"}  -- a name/func string didn't fit runtime.zig's
@@ -27,7 +27,7 @@ import json
 import sys
 
 DIRECT_EVENTS = {"dup", "drop", "dropReuse_attempt", "dropReuse_hit", "dropReuse_miss"}
-CONSTRUCT_EVENTS = {"mkStruct", "mkClosure", "mkStructReuse"}
+CONSTRUCT_EVENTS = {"mkStruct", "mkClosure", "mkStructReuse", "mkRecord"}
 
 
 def load_events(path):

--- a/src/Malgo/Backend/Zig.hs
+++ b/src/Malgo/Backend/Zig.hs
@@ -33,14 +33,18 @@ instance Pass ZigPass where
   type Effects ZigPass es = (Reader ModuleName :> es, State Uniq :> es)
 
   runPassImpl _ program = do
-    stages <- runZigStages program
+    -- Only the final stage is needed here (unlike the MET tracer and the
+    -- corpus test, which inspect every intermediate); binding just that
+    -- field, rather than keeping the whole 'ZigStages' around, lets the
+    -- earlier stages be collected before 'emitProgram' runs.
+    ZigStages {reuse} <- runZigStages program
     -- The linearity check is pure and fast relative to the rest of the
     -- pipeline; running it unconditionally turns any Perceus bug into a
     -- compile-time error instead of a use-after-free in the produced
     -- binary. It also verifies reuse-token linearity, so a Reuse bug is
     -- caught the same way.
-    case checkProgram stages.reuse of
-      Right () -> emitProgram stages.reuse
+    case checkProgram reuse of
+      Right () -> emitProgram reuse
       Left violations ->
         throwError (ZigError $ "Perceus produced a non-linear program: " <> convertString (show violations))
 

--- a/src/Malgo/Backend/Zig.hs
+++ b/src/Malgo/Backend/Zig.hs
@@ -2,6 +2,8 @@
 -- 'Malgo.Backend.Scheme.SchemePass'\'s shape exactly.
 module Malgo.Backend.Zig
   ( ZigPass (..),
+    ZigStages (..),
+    runZigStages,
   )
 where
 
@@ -12,6 +14,7 @@ import Effectful.Reader.Static (Reader)
 import Effectful.State.Static.Local (State)
 import Malgo.Backend.Zig.ClosureConv (convertProgram)
 import Malgo.Backend.Zig.Emit (emitProgram)
+import Malgo.Backend.Zig.Ir qualified as Ir
 import Malgo.Backend.Zig.Peephole (peepholeProgram)
 import Malgo.Backend.Zig.Perceus (perceusProgram)
 import Malgo.Backend.Zig.RcCheck (checkProgram)
@@ -30,15 +33,14 @@ instance Pass ZigPass where
   type Effects ZigPass es = (Reader ModuleName :> es, State Uniq :> es)
 
   runPassImpl _ program = do
-    ir <- perceusProgram . peepholeProgram <$> convertProgram program
-    ir <- reuseProgram ir
+    stages <- runZigStages program
     -- The linearity check is pure and fast relative to the rest of the
     -- pipeline; running it unconditionally turns any Perceus bug into a
     -- compile-time error instead of a use-after-free in the produced
     -- binary. It also verifies reuse-token linearity, so a Reuse bug is
     -- caught the same way.
-    case checkProgram ir of
-      Right () -> emitProgram ir
+    case checkProgram stages.reuse of
+      Right () -> emitProgram stages.reuse
       Left violations ->
         throwError (ZigError $ "Perceus produced a non-linear program: " <> convertString (show violations))
 
@@ -47,3 +49,23 @@ data ZigError = ZigError Text
 
 instance Exception ZigError where
   displayException (ZigError msg) = "Zig backend error: " <> convertString msg
+
+-- | Every intermediate stage of the Zig backend's post-Join lowering
+-- pipeline, in this fixed order. A single definition shared by production
+-- ('ZigPass' above), the MET debug tracer ('Malgo.Debug.Pipeline'), and the
+-- golden-corpus linearity test ('Malgo.Backend.Zig.PerceusSpec') so the
+-- three can never drift out of sync.
+data ZigStages = ZigStages
+  { closureConv :: Ir.Program,
+    peephole :: Ir.Program,
+    perceus :: Ir.Program,
+    reuse :: Ir.Program
+  }
+
+runZigStages :: (State Uniq :> es, Reader ModuleName :> es) => Join.Program -> Eff es ZigStages
+runZigStages program = do
+  ir <- convertProgram program
+  let peepholed = peepholeProgram ir
+      perceused = perceusProgram peepholed
+  reused <- reuseProgram perceused
+  pure ZigStages {closureConv = ir, peephole = peepholed, perceus = perceused, reuse = reused}

--- a/src/Malgo/Backend/Zig/Emit.hs
+++ b/src/Malgo/Backend/Zig/Emit.hs
@@ -167,10 +167,14 @@ emitExpr pv funcName = \case
   Ir.MkStructReuse tok tag vs -> "rt.mkStructReuseNamed(" <> pv tok <> ", " <> compileTag tag <> ", " <> valueSlice pv vs <> ", " <> nameSlice vs <> ", " <> funcName <> ")"
   Ir.MkClosure fn vs -> "rt.mkClosureNamed(&" <> mangleId fn <> ", " <> valueSlice pv vs <> ", " <> nameSlice vs <> ", " <> funcName <> ")"
   Ir.MkRecord fields vs ->
-    "rt.mkRecord(&[_]rt.NamedField{"
+    "rt.mkRecordNamed(&[_]rt.NamedField{"
       <> T.intercalate ", " [".{ .name = " <> zigStringLit fieldName <> ", .code = &" <> mangleId fn <> " }" | (fieldName, fn) <- fields]
       <> "}, "
       <> valueSlice pv vs
+      <> ", "
+      <> nameSlice vs
+      <> ", "
+      <> funcName
       <> ")"
   Ir.Prim name vs -> "rt." <> name <> "(" <> valueSlice pv vs <> ")"
   Ir.ReadPath p -> emitPath pv p

--- a/src/Malgo/Backend/Zig/Ir.hs
+++ b/src/Malgo/Backend/Zig/Ir.hs
@@ -25,7 +25,6 @@ module Malgo.Backend.Zig.Ir
     Guard (..),
     Test (..),
     freeVarsBlock,
-    freeVarsStmt,
     freeVarsTerminator,
     freeVarsExpr,
     freeVarsGuard,
@@ -201,12 +200,6 @@ suffixFreeVars stmts term = scanr step (freeVarsTerminator term) stmts
     step (Dup x) live = Set.insert x live
     step (Drop x) live = Set.insert x live
     step (DropReuse tok x _) live = Set.insert x (Set.delete tok live)
-
-freeVarsStmt :: Stmt -> Set Name
-freeVarsStmt (Let _ e) = freeVarsExpr e
-freeVarsStmt (Dup x) = Set.singleton x
-freeVarsStmt (Drop x) = Set.singleton x
-freeVarsStmt (DropReuse _ x _) = Set.singleton x
 
 freeVarsExpr :: Expr -> Set Name
 freeVarsExpr (Lit _) = Set.empty

--- a/src/Malgo/Backend/Zig/RcCheck.hs
+++ b/src/Malgo/Backend/Zig/RcCheck.hs
@@ -77,9 +77,15 @@ checkFunc fn = goBlock st0 fn.body
 
     useBorrowed st x = [UseAfterConsume fname x | not (accessible st x)]
 
-    consume st x
-      | ownedCount st x >= 1 = ([], st {counts = Map.adjust (subtract 1) x st.counts})
-      | otherwise = ([UseAfterConsume fname x], st)
+    -- Shared by 'consume', the 'Drop' case, and the 'DropReuse' case below:
+    -- decrement an owned reference count, or report that none was held.
+    decrementOwned st x
+      | ownedCount st x >= 1 = (True, st {counts = Map.adjust (subtract 1) x st.counts})
+      | otherwise = (False, st)
+
+    consume st x =
+      let (ok, st') = decrementOwned st x
+       in ([UseAfterConsume fname x | not ok], st')
 
     consumeMany = foldl' (\(vs, st) x -> first (vs <>) (consume st x)) . ([],)
 
@@ -94,14 +100,13 @@ checkFunc fn = goBlock st0 fn.body
       Dup x
         | accessible st x -> goStmts st {counts = Map.insertWith (+) x 1 st.counts} rest term
         | otherwise -> DupOfDead fname x : goStmts st {counts = Map.insertWith (+) x 1 st.counts} rest term
-      Drop x
-        | ownedCount st x >= 1 -> goStmts st {counts = Map.adjust (subtract 1) x st.counts} rest term
-        | otherwise -> DropOfDead fname x : goStmts st rest term
-      DropReuse tok x _
-        | ownedCount st x >= 1 ->
-            goStmts st {counts = Map.adjust (subtract 1) x st.counts, tokens = Set.insert tok st.tokens} rest term
-        | otherwise ->
-            DropOfDead fname x : goStmts st {tokens = Set.insert tok st.tokens} rest term
+      Drop x ->
+        let (ok, st') = decrementOwned st x
+         in [DropOfDead fname x | not ok] <> goStmts st' rest term
+      DropReuse tok x _ ->
+        let (ok, st') = decrementOwned st x
+            st'' = st' {tokens = Set.insert tok st'.tokens}
+         in [DropOfDead fname x | not ok] <> goStmts st'' rest term
       Let x e -> case e of
         -- noreturn: the path exits the process here; no obligations.
         PanicExpr _ -> []

--- a/src/Malgo/Debug/Pipeline.hs
+++ b/src/Malgo/Debug/Pipeline.hs
@@ -19,11 +19,8 @@ import Data.ByteString qualified as BS
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Effectful.Reader.Static (runReader)
-import Malgo.Backend.Zig.ClosureConv (convertProgram)
-import Malgo.Backend.Zig.Peephole (peepholeProgram)
-import Malgo.Backend.Zig.Perceus (perceusProgram)
+import Malgo.Backend.Zig (ZigStages (..), runZigStages)
 import Malgo.Backend.Zig.RcCheck (checkProgram)
-import Malgo.Backend.Zig.Reuse (reuseProgram)
 import Malgo.Debug.PrettyIR
 import Malgo.Elaborate (ElaboratePass (..))
 import Malgo.Features (Feature (..), FeatureFlags (..))
@@ -40,7 +37,7 @@ import Malgo.Sequent.Core.Flat (flatProgram)
 import Malgo.Sequent.Core.Join (joinProgram)
 import Malgo.Sequent.ReuseSpecialize (specializeProgram)
 import Malgo.Sequent.SaturateCtor (saturateProgram)
-import Malgo.Sequent.ToCore (toCore)
+import Malgo.Sequent.ToCore (toCoreFrom)
 import Malgo.Sequent.ToFun (ToFunPass (..))
 import Malgo.Syntax (Module (..))
 
@@ -72,19 +69,16 @@ runTrace srcPath useInfer malgo2025 = do
       -- Saturated-constructor inlining and reuse-hint insertion now run
       -- first thing inside toCore (shared by every backend), not as
       -- Join-IR-local Zig passes; traced here at the Fun IR level, where
-      -- the rewrites actually happen. `toCore fun` reapplies both
-      -- internally (idempotent, cheap), so `core` reflects the real
-      -- post-specialization pipeline regardless.
+      -- the rewrites actually happen. `toCoreFrom specializedFun` reuses
+      -- this same specialization, so `core` reflects the real
+      -- post-specialization pipeline without re-minting its temporaries.
       let saturatedFun = saturateProgram fun
       specializedFun <- specializeProgram saturatedFun
-      core <- toCore fun
+      core <- toCoreFrom specializedFun
       flat <- flatProgram core
       joined <- joinProgram flat
-      ir <- convertProgram joined
-      let peepholed = peepholeProgram ir
-          perceused = perceusProgram peepholed
-      reused <- reuseProgram perceused
-      let reuseNote = case checkProgram reused of
+      stages <- runZigStages joined
+      let reuseNote = case checkProgram stages.reuse of
             Right () -> ""
             Left violations ->
               "-- RC CHECK VIOLATIONS:\n"
@@ -100,10 +94,10 @@ runTrace srcPath useInfer malgo2025 = do
              Stage "ToCore" (renderCoreFull core),
              Stage "Flat" (renderFlat flat),
              Stage "Join" (renderJoin joined),
-             Stage "ClosureConv" (renderZigIr ir),
-             Stage "Peephole" (renderZigIr peepholed),
-             Stage "Perceus" (renderZigIr perceused),
-             Stage "Reuse" (reuseNote <> renderZigIr reused)
+             Stage "ClosureConv" (renderZigIr stages.closureConv),
+             Stage "Peephole" (renderZigIr stages.peephole),
+             Stage "Perceus" (renderZigIr stages.perceus),
+             Stage "Reuse" (reuseNote <> renderZigIr stages.reuse)
            ]
   where
     flag =

--- a/src/Malgo/Driver.hs
+++ b/src/Malgo/Driver.hs
@@ -121,7 +121,6 @@ compileToExecutable srcPath outPath optMode = do
     parsedAst <- runPass ParserPass (srcPath, convertString @BS.ByteString src)
     core <- fetchLinkedCore srcModulePath parsedAst
     runReader parsedAst.moduleName $ runPass ZigPass core
-  save srcModulePath ".zig" (convertString @Text @BS.ByteString zigText)
   workspace <- toFilePath <$> getWorkspaceAbs
   let zigPath = outPath <> ".zig"
   liftIO $ BS.writeFile zigPath (convertString zigText)

--- a/src/Malgo/Sequent/ToCore.hs
+++ b/src/Malgo/Sequent/ToCore.hs
@@ -1,4 +1,4 @@
-module Malgo.Sequent.ToCore (toCore, ToCorePass (..)) where
+module Malgo.Sequent.ToCore (toCore, toCoreFrom, ToCorePass (..)) where
 
 import Data.Traversable (for)
 import Effectful
@@ -30,8 +30,16 @@ instance Pass ToCorePass where
 -- in their curried form, and self-recursive match-then-rebuild functions
 -- carry a @reuseHint@ marking their about-to-be-discarded scrutinee.
 toCore :: (State Uniq :> es, Reader ModuleName :> es) => Program -> Eff es C.Program
-toCore program = do
-  Program {..} <- specializeProgram (saturateProgram program)
+toCore program = specializeProgram (saturateProgram program) >>= toCoreFrom
+
+-- | The CPS-conversion half of 'toCore', taking a 'Program' that has
+-- already been through 'saturateProgram' and 'specializeProgram'. Exposed
+-- for callers that already computed that pair for their own purposes (e.g.
+-- 'Malgo.Debug.Pipeline' rendering the "ReuseSpecialize" stage) — calling
+-- 'specializeProgram' again on the same input would mint a second,
+-- differently-numbered set of fresh temporaries instead of reusing it.
+toCoreFrom :: (State Uniq :> es, Reader ModuleName :> es) => Program -> Eff es C.Program
+toCoreFrom Program {..} = do
   definitions <- traverse convertDefinition definitions
   pure C.Program {definitions, dependencies}
 

--- a/test/Malgo/Backend/Zig/PerceusSpec.hs
+++ b/test/Malgo/Backend/Zig/PerceusSpec.hs
@@ -12,12 +12,10 @@
 module Malgo.Backend.Zig.PerceusSpec (specWith) where
 
 import Effectful.Reader.Static (runReader)
-import Malgo.Backend.Zig.ClosureConv (convertProgram)
+import Malgo.Backend.Zig (ZigStages (..), runZigStages)
 import Malgo.Backend.Zig.Ir
-import Malgo.Backend.Zig.Peephole (peepholeProgram)
-import Malgo.Backend.Zig.Perceus (perceusFunc, perceusProgram)
+import Malgo.Backend.Zig.Perceus (perceusFunc)
 import Malgo.Backend.Zig.RcCheck (RcViolation (..), checkFunc, checkProgram)
-import Malgo.Backend.Zig.Reuse (reuseProgram)
 import Malgo.Id
 import Malgo.Module (ArtifactPath, ModuleName (..))
 import Malgo.Monad (runMalgoM)
@@ -187,18 +185,15 @@ corpusSpec builtin prelude = describe "corpus linearity (all golden testcases)" 
     it (takeBaseName testcase) do
       -- saturateProgram already ran inside compileTestCase's toCore call.
       (moduleName, program) <- compileTestCase builtin prelude (testcaseDir </> testcase)
-      (ir, final) <- runMalgoM flag $ runReader moduleName do
-        ir <- convertProgram program
-        -- The conversion itself never inserts RC ops...
-        final <- reuseProgram (perceusProgram (peepholeProgram ir))
-        pure (ir, final)
-      for_ ir.funcs \fn ->
+      stages <- runMalgoM flag $ runReader moduleName $ runZigStages program
+      -- The conversion itself never inserts RC ops...
+      for_ stages.closureConv.funcs \fn ->
         hasRcOps fn.body `shouldBe` False
       -- ...and the full pipeline (scrutinee-tuple peephole, Perceus, then
       -- Reuse — mirroring Zig.hs's order) stays linear on every path,
       -- including its new reuse-token obligations.
-      checkProgram final `shouldBe` Right ()
-      when (any (hasReuseOp . (.body)) final.funcs) $ writeIORef reuseFired True
+      checkProgram stages.reuse `shouldBe` Right ()
+      when (any (hasReuseOp . (.body)) stages.reuse.funcs) $ writeIORef reuseFired True
   -- A silent no-op pairing pass (matching nothing corpus-wide) would still
   -- pass every linearity check above; this is the guard against that.
   it "pairs at least one Drop/MkStruct somewhere in the corpus" do

--- a/test/Malgo/Debug/PrettyIRSpec.hs
+++ b/test/Malgo/Debug/PrettyIRSpec.hs
@@ -16,9 +16,6 @@ import Test.Hspec
 -- golden-output blowup already fixed once for the per-pass Spec suites.
 spec :: Spec
 spec = parallel do
-  runIO do
-    setupBuiltin
-    setupPrelude
   testcases <- runIO do
     files <- listDirectory testcaseDir
     pure $ filter (isExtensionOf "mlg") files


### PR DESCRIPTION
## Summary

Follow-up fixes and cleanups from a max-effort architecture-focused code review of the Zig backend (PRs #351, #352, #353, #355, #356: `git diff 29716f43..23bcb45d`).

**Correctness:**
- `malgo_substring`: wrap i64 subtraction (`-%`) instead of trapping on overflow in the default Debug build, matching the interpreter's wraparound semantics.
- `drop()`/`decChildren()`: panic unconditionally on an over-drop instead of relying solely on `std.debug.assert`, which Zig elides in ReleaseFast/ReleaseSmall. Mirrors the `mkStructReuse` hardening from 0359a98b.
- `readStdinByte`: a genuine `posix.read` error no longer masquerades as clean EOF.
- MET: bind the debug server to `127.0.0.1` explicitly; it was binding all interfaces while its own banner claimed "localhost".
- `Emit.hs`/`runtime.zig`: record construction now goes through a traced `mkRecordNamed` wrapper like every sibling construction op, so `MALGO_RC_TRACE`/`rctrace.py` no longer silently miss record objects.
- `ToCore.hs`/`Debug/Pipeline.hs`: split `toCore` into `toCore`/`toCoreFrom` so the MET tracer's "ReuseSpecialize" and "ToCore"+later stages stop diverging in fresh-ID numbering from running `specializeProgram` twice.
- `PrettyIRSpec.hs`: remove `setupBuiltin`/`setupPrelude` calls that were clobbering the Builtin/Prelude test artifacts `test/Spec.hs` already set up for other specs (this spec never links Builtin/Prelude).

**Cleanup:**
- `Driver.hs`: remove a redundant second write of generated Zig source.
- `Ir.hs`: remove dead code (`freeVarsStmt`).
- `RcCheck.hs`: dedup the three copies of "decrement owned refcount or report violation".
- `Zig.hs`/`Debug/Pipeline.hs`/`PerceusSpec.hs`: extract a shared `ZigStages`/`runZigStages` so the pass order (ClosureConv→Peephole→Perceus→Reuse) lives in one place instead of three hand-copied sequences.

**Investigated but not changed:** the review's headline finding claimed codata (`Cocase`) construction silently compiles and panics at runtime. Empirical testing (compiling/running `CodataE2E.mlg`) plus tracing `ToFun.hs`/`Elaborate.hs` showed this doesn't reproduce — every codata surface-syntax path desugars to `Object`/`Lambda`/`Select` before reaching Core IR, so `Cocase` is unreachable dead code, not a live bug.

**Deliberately skipped** (design tradeoffs / accepted architecture, not bugs — see review discussion): a parser-ambiguity edge case in `CStyle.hs`, `ToCore.hs`'s `reuseHint` being forced on every backend (documented M10-era design), and a quadratic-blowup cleanup in `ClosureConv.hs`'s `promoteEscapingCaptures` whose correct fix needs a riskier fixpoint restructure.

## Test plan
- [x] `mise run build` — clean
- [x] `mise run test` — 1444/1444 examples passed
- [x] `zig test -lc runtime/zig/runtime.zig` — 14/14 passed
- [x] `bash scripts/zig-golden.sh` — 73/73 passed, 0 mismatches, 0 leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)