### PR TITLE
feat(lean): first real theorems in the Lean port (IntMap)

### DIFF
--- a/lean/Malgo/Data/IntMap.lean
+++ b/lean/Malgo/Data/IntMap.lean
@@ -28,6 +28,39 @@ def isEmpty : IntMap α → Bool
 private def prefixOf (key msk : Nat) : Nat :=
   key / (2 * msk)
 
+/-- `key` is actually stored somewhere in `t`. -/
+def HasKey (t : IntMap α) (key : Nat) : Prop :=
+  match t with
+  | .nil => False
+  | .tip k _ => key = k
+  | .bin _ _ l r => l.HasKey key ∨ r.HasKey key
+
+/-- Every mask nested inside `t` is strictly below `msk` — masks shrink
+strictly toward the leaves. -/
+def MaskBound (msk : Nat) : IntMap α → Prop
+  | .nil => True
+  | .tip _ _ => True
+  | .bin _ msk' _ _ => msk' < msk
+
+/-- Well-formedness: every `bin pfx msk l r` node's branch bit `msk` is a
+single bit, every key in `l`/`r` agrees with `pfx` above that bit and is
+routed to the correct side by it, and masks strictly shrink toward the
+leaves. Direct formalization of the doc comments on `bin` and `link`. -/
+inductive WF : IntMap α → Prop
+  | nil : WF .nil
+  | tip (k : Nat) (v : α) : WF (.tip k v)
+  | bin (pfx msk : Nat) (l r : IntMap α)
+      (hmsk : ∃ i, msk = 2 ^ i)
+      (hl_pfx : ∀ k, l.HasKey k → prefixOf k msk = pfx)
+      (hl_bit : ∀ k, l.HasKey k → k &&& msk == 0)
+      (hr_pfx : ∀ k, r.HasKey k → prefixOf k msk = pfx)
+      (hr_bit : ∀ k, r.HasKey k → ¬ (k &&& msk == 0))
+      (hl_bound : l.MaskBound msk) (hr_bound : r.MaskBound msk)
+      (hl : l.WF) (hr : r.WF) :
+      WF (.bin pfx msk l r)
+
+theorem wf_empty : (empty : IntMap α).WF := .nil
+
 def lookup? (key : Nat) : IntMap α → Option α
   | .nil => none
   | .tip k v => if key == k then some v else none
@@ -54,6 +87,28 @@ def insert (key : Nat) (val : α) : IntMap α → IntMap α
       .bin pfx msk (l.insert key val) r
     else
       .bin pfx msk l (r.insert key val)
+
+theorem lookup_link_self (p1 : Nat) (t1 : IntMap α) (p2 : Nat) (t2 : IntMap α) :
+    (link p1 t1 p2 t2).lookup? p1 = t1.lookup? p1 := by
+  simp only [link]
+  split <;> simp_all [lookup?, prefixOf]
+
+theorem lookup_insert (key : Nat) (val : α) (m : IntMap α) :
+    (m.insert key val).lookup? key = some val := by
+  induction m with
+  | nil => simp [insert, lookup?]
+  | tip k v =>
+    simp only [insert]
+    split
+    · simp [lookup?]
+    · rw [lookup_link_self]; simp [lookup?]
+  | bin pfx msk l r ihl ihr =>
+    simp only [insert]
+    split
+    · rw [lookup_link_self]; simp [lookup?]
+    · split
+      · simp_all [lookup?]
+      · simp_all [lookup?]
 
 def contains (key : Nat) (t : IntMap α) : Bool :=
   (t.lookup? key).isSome

--- a/lean/README.md
+++ b/lean/README.md
@@ -47,8 +47,14 @@ count for `scripts/lean-parity.sh`'s `fingerprint` mode.
 Conventions:
 - module paths mirror `src/Malgo/*.hs` 1:1 (`Sequent/ToFun.hs` → `Malgo/Sequent/ToFun.lean`);
 - `Std.TreeMap`/`TreeSet` wherever Haskell used `Data.Map`/`Set` and iteration
-  order reaches output; `Malgo.IntMap` (proof-free Patricia trie) inside
-  `Value`'s `Env`; `Std.HashMap` only for order-invisible caches;
-- no proofs: `partial def` where recursion is not structural;
+  order reaches output; `Malgo.IntMap` (a from-scratch Patricia trie, since
+  `Std.HashMap`/`TreeMap` bundle well-formedness proofs rejected in
+  nested-inductive positions) inside `Value`'s `Env`; `Std.HashMap` only for
+  order-invisible caches;
+- incremental proofs: `partial def` where recursion is not structural
+  (unchanged); a small number of hand-picked modules additionally carry
+  real `theorem`s beyond `#guard` spot-checks — see `Data/IntMap.lean`
+  (`lookup_insert`, a `WF` well-formedness invariant) for the current
+  example; opt-in per module, not a blanket requirement;
 - known naming deviation: `Meta.meta` (Haskell) → `Meta.info` (`meta` is a
   Lean keyword).


### PR DESCRIPTION
## Summary
- First real Lean 4 `theorem`s in the port (`lean/` had zero prior — only `#guard` spot-checks), landed on `lean/Malgo/Data/IntMap.lean` since it's already fully structural (zero `partial def`), making it the cheapest genuine induction target.
- Adds `HasKey`/`MaskBound`/`WF`: a well-formedness invariant formalizing the existing `bin`/`link` doc comments (prefix/mask agreement, masks strictly shrinking toward the leaves).
- Adds `lookup_insert`: `lookup? key (insert key val m) = some val`, via a small helper lemma (`lookup_link_self`) plus structural induction on `m` mirroring `insert`'s own match arms.
- Revises `lean/README.md`'s "no proofs: `partial def` where recursion is not structural" line into an incremental policy, per issue #359's own stated requirement for adopting any of its items.

## Scope note (narrowed from issue #359)
Issue #359's Tier 1 list has two bullets targeting `lean/Malgo/LSP/Json.lean` — that file no longer exists (the LSP server was added *and* removed within the same squashed merge that produced #358; see `lean/README.md`'s "LSP removed (2026-07-19)" row). The issue's remaining Tier 1 item, `Sequent/Core/Json.lean`'s mutual `toJson`/`fromJson` roundtrip, needs its `partial def`s de-partialized first (a Tier 3 item in the same issue) before a real induction proof is possible — left for a follow-up. `insert_wf` (proving `insert` preserves `WF`) is also intentionally left unproved here; it needs a mask-monotonicity argument through the whole `WF` derivation of the pre-existing subtree, a substantially harder follow-up. `WF` ships with only a trivial proven inhabitant (`wf_empty`) until that lands — it's documentation-as-a-predicate for now, not a verified-correct claim about `insert`.

## Test plan
- [x] `lake build` (full) — 128/128 jobs succeed
- [x] `lake test` — 532/532 goldens + 94/94 infer, no regressions
- [x] `grep -rn "sorry" lean/Malgo/Data/IntMap.lean` — empty
- [x] Confirmed no new typeclass constraints leaked onto `insert`/`lookup?`'s existing polymorphic signatures (only additions, no signature changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)