### PR TITLE
refactor(lean): de-partialize SExpr.lean's toInter/pp

### DIFF
--- a/lean/Malgo/SExpr.lean
+++ b/lean/Malgo/SExpr.lean
@@ -92,7 +92,7 @@ private def Inter.width : Inter → Nat
   | .empty => 2
   | .list w _ _ => w + 2
 
-private partial def toInter : SExpr → Inter
+private def toInter : SExpr → Inter
   | .atom a => .atom a.render
   | .list [] => .empty
   | .list (x :: xs) =>
@@ -103,7 +103,8 @@ private partial def toInter : SExpr → Inter
 
 /-- s-cargot `indentPrintSExpr'` specialized to `basicPrint`:
 `swingIndent = Swing`, `indentAmount = 2`, `maxWidth = 80`. -/
-private partial def pp (maxWidth ind : Nat) : Inter → String
+private def pp (maxWidth ind : Nat) (i : Inter) : String :=
+  match i with
   | .empty => "()"
   | .atom t => t
   | .list contentWidth hd items =>
@@ -118,6 +119,13 @@ private partial def pp (maxWidth ind : Nat) : Inter → String
       else
         " " ++ " ".intercalate (items.toList.map (pp maxWidth (ind + 1)))
     "(" ++ hdStr ++ body ++ ")"
+termination_by i
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (Array.sizeOf_lt_of_mem (Array.mem_toList_iff.mp h)) (by omega))
 
 /-- s-cargot `encodeOne (basicPrint atomToText)`. -/
 def encodeOne (e : SExpr) : String :=


### PR DESCRIPTION
## Summary
- First of issue #359's Tier 3 "mechanical cleanup" items: converts `SExpr.lean`'s `toInter`/`pp` from `partial def` to plain `def`. Both were `partial` only because Lean's termination checker couldn't see through `List.map`/`Array.toList.map` indirection, even though the recursion is genuinely structural over `SExpr`/`Inter`.
- `toInter` needed no restructuring at all — removing `partial` alone let Lean's automatic structural-recursion checker accept it directly.
- `pp` needed an explicit `termination_by`/`decreasing_by`: naming the `Inter` parameter explicitly let the checker find the right well-founded measure, but it couldn't discharge the two `Array`-member decrease obligations unaided — closed with `Array.sizeOf_lt_of_mem`/`Array.mem_toList_iff`.
- Picked as the smallest, lowest-risk Tier 3 candidate (surveyed via an Explore agent first): both functions are `private`, single self-recursive (no `mutual` block), only 3 match arms each, and have zero callers outside this file.
- No new theorems — Tier 3 is explicitly "no new theorems, just remove unneeded `partial`."

## Test plan
- [x] `lake build` (full) — 128/128 jobs succeed
- [x] `lake test` — 532/532 goldens + 94/94 infer, no regressions (`encodeOne`'s output is byte-compared against golden files everywhere an s-expr gets dumped, so any behavioral drift from the restructuring would have surfaced)
- [x] `grep -n "partial def toInter\|partial def pp\|sorry" lean/Malgo/SExpr.lean` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)