### PR TITLE
refactor(lean): de-partialize Debug/DiffView.lean's Tier 3 items

### DIFF
--- a/lean/Malgo/Debug/DiffView.lean
+++ b/lean/Malgo/Debug/DiffView.lean
@@ -84,7 +84,7 @@ def lcsPath (eq : α → α → Bool) (as bs : List α) : List DI :=
     | _, _ => false
   lcsLoop cd lena lenb [addsnake cd ⟨0, 0, []⟩]
 
-private partial def markup (eq : α → α → Bool) :
+private def markup (eq : α → α → Bool) :
     List α → List α → List DI → List (PolyDiff α α)
   | x :: xs, y :: ys, ds =>
     if eq x y then PolyDiff.both x y :: markup eq xs ys ds
@@ -102,28 +102,67 @@ def getDiffBy (eq : α → α → Bool) (as bs : List α) : List (PolyDiff α α
 def getDiff [BEq α] (as bs : List α) : List (PolyDiff α α) :=
   getDiffBy (· == ·) as bs
 
-private partial def goFirsts : List (PolyDiff α α) → List α × List (PolyDiff α α)
+private def goFirsts : List (PolyDiff α α) → List α × List (PolyDiff α α)
   | PolyDiff.first x :: xs => let (fs, rest) := goFirsts xs; (x :: fs, rest)
   | xs => ([], xs)
 
-private partial def goSeconds : List (PolyDiff α α) → List α × List (PolyDiff α α)
+private def goSeconds : List (PolyDiff α α) → List α × List (PolyDiff α α)
   | PolyDiff.second x :: xs => let (fs, rest) := goSeconds xs; (x :: fs, rest)
   | xs => ([], xs)
 
-private partial def goBoth : List (PolyDiff α α) → List (α × α) × List (PolyDiff α α)
+private def goBoth : List (PolyDiff α α) → List (α × α) × List (PolyDiff α α)
   | PolyDiff.both x y :: xs => let (fs, rest) := goBoth xs; ((x, y) :: fs, rest)
   | xs => ([], xs)
 
-private partial def groupGo : List (PolyDiff α α) → List (PolyDiff (List α) (List α))
+/-- `goFirsts` only ever peels a `first`-tagged prefix off the front and
+returns the untouched remainder — its second component is never bigger
+than the input. Termination-only helper for `groupGo`. -/
+private theorem goFirsts_snd_sizeOf_le : (xs : List (PolyDiff α α)) → sizeOf (goFirsts xs).2 ≤ sizeOf xs
+  | [] => by simp [goFirsts]
+  | .first _ :: xs => by
+    simp only [goFirsts]
+    have := goFirsts_snd_sizeOf_le xs
+    simp_wf
+    omega
+  | .second _ :: _ => by simp [goFirsts]
+  | .both _ _ :: _ => by simp [goFirsts]
+
+private theorem goSeconds_snd_sizeOf_le : (xs : List (PolyDiff α α)) → sizeOf (goSeconds xs).2 ≤ sizeOf xs
+  | [] => by simp [goSeconds]
+  | .first _ :: _ => by simp [goSeconds]
+  | .second _ :: xs => by
+    simp only [goSeconds]
+    have := goSeconds_snd_sizeOf_le xs
+    simp_wf
+    omega
+  | .both _ _ :: _ => by simp [goSeconds]
+
+private theorem goBoth_snd_sizeOf_le : (xs : List (PolyDiff α α)) → sizeOf (goBoth xs).2 ≤ sizeOf xs
+  | [] => by simp [goBoth]
+  | .first _ :: _ => by simp [goBoth]
+  | .second _ :: _ => by simp [goBoth]
+  | .both _ _ :: xs => by
+    simp only [goBoth]
+    have := goBoth_snd_sizeOf_le xs
+    simp_wf
+    omega
+
+private def groupGo : List (PolyDiff α α) → List (PolyDiff (List α) (List α))
   | PolyDiff.first x :: xs =>
-    let (fs, rest) := goFirsts xs; PolyDiff.first (x :: fs) :: groupGo rest
+    PolyDiff.first (x :: (goFirsts xs).1) :: groupGo (goFirsts xs).2
   | PolyDiff.second x :: xs =>
-    let (fs, rest) := goSeconds xs; PolyDiff.second (x :: fs) :: groupGo rest
+    PolyDiff.second (x :: (goSeconds xs).1) :: groupGo (goSeconds xs).2
   | PolyDiff.both x y :: xs =>
-    let (fs, rest) := goBoth xs
-    let (fxs, fys) := fs.unzip
-    PolyDiff.both (x :: fxs) (y :: fys) :: groupGo rest
+    let (fxs, fys) := (goBoth xs).1.unzip
+    PolyDiff.both (x :: fxs) (y :: fys) :: groupGo (goBoth xs).2
   | [] => []
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_le_of_lt (goFirsts_snd_sizeOf_le xs) (by omega)
+    | exact Nat.lt_of_le_of_lt (goSeconds_snd_sizeOf_le xs) (by omega)
+    | exact Nat.lt_of_le_of_lt (goBoth_snd_sizeOf_le xs) (by omega)
 
 def getGroupedDiffBy (eq : α → α → Bool) (as bs : List α) :
     List (PolyDiff (List α) (List α)) :=
@@ -271,7 +310,7 @@ private def pairLines (bs as : List String) : List (LineTag × List Span) :=
     ++ bTail.map (fun l => (LineTag.removed, [⟨.removed, l⟩]))
     ++ aTail.map (fun l => (LineTag.added, [⟨.added, l⟩]))
 
-private partial def pairedGo :
+private def pairedGo :
     List (PolyDiff (List String) (List String)) → List (LineTag × List Span)
   | [] => []
   | .both bs _ :: rest =>
@@ -317,7 +356,7 @@ private def pairRows (bs as : List String) : List SideBySideRow :=
     ++ bTail.map (fun l => ⟨some .removed, some [⟨.removed, l⟩], none, none⟩)
     ++ aTail.map (fun l => ⟨none, none, some .added, some [⟨.added, l⟩]⟩)
 
-private partial def sbsGo :
+private def sbsGo :
     List (PolyDiff (List String) (List String)) → List SideBySideRow
   | [] => []
   | .both bs _ :: rest =>


### PR DESCRIPTION
## Summary
- Fourth of issue #359's Tier 3 "mechanical cleanup" items: converts `Debug/DiffView.lean`'s `markup`, `goFirsts`, `goSeconds`, `goBoth`, `groupGo`, `pairedGo`, `sbsGo` from `partial def` to plain `def`.
- `addsnake`/`lcsLoop` (the actual Myers-diff fixpoint search) correctly stay `partial` — the issue's own "ruled out" list already flags those as non-structural.
- `markup`/`goFirsts`/`goSeconds`/`goBoth`/`pairedGo`/`sbsGo` needed no changes beyond dropping `partial`.
- `groupGo` needed real work: it recurses into whatever `goFirsts`/`goSeconds`/`goBoth` return as their "untouched remainder" second component, and destructuring that via `let (fs, rest) := ...` loses the connection the termination checker needs between `rest` and the original list. Fixed by referencing `(goFirsts xs).2` etc. directly at the recursive call site (computed twice instead of let-bound once — behaviorally identical, these are pure functions), plus three new lemmas (`goFirsts_snd_sizeOf_le` and its `goSeconds`/`goBoth` siblings) proving "the returned remainder is never bigger than the input," and an explicit `termination_by`/`decreasing_by`.
- No behavior change — this is the git-style unified/side-by-side diff renderer gated byte-for-byte by the ~89 `PrettyIR` golden files.

## Test plan
- [x] `lake build` (full) — 128/128 jobs succeed
- [x] `lake test` — 532/532 goldens + 94/94 infer, no regressions
- [x] `grep -n "partial def" lean/Malgo/Debug/DiffView.lean` — only `addsnake`/`lcsLoop` remain, as intended
- [x] `grep -n "sorry" lean/Malgo/Debug/DiffView.lean` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)