### PR TITLE
refactor(lean): de-partialize Debug/PrettyIR.lean

### DIFF
--- a/docs/plans/2026-07-20-prettyir-departial.md
+++ b/docs/plans/2026-07-20-prettyir-departial.md
@@ -1,0 +1,339 @@
+# De-partialize `Debug/PrettyIR.lean` (issue #359, Tier 3)
+
+Date: 2026-07-20
+
+## Context
+
+Issue #359 tracks introducing real proofs into the Lean 4 port and, separately,
+a Tier 3 "mechanical cleanup" bucket: `partial def`s whose recursion is
+actually structural but hidden from Lean's termination checker (usually
+behind `List.map`/tuple-destructuring lambdas), which should become plain
+`def`s with no behavior change and no new theorems.
+
+Three Tier 3 files are already done this session (PRs #364, #365, #366):
+`SExpr.lean`, `Rename/Pass.lean`, `Debug/DiffView.lean`. Each surfaced the
+same two failure modes, now with an established fix:
+
+1. **Plain `.map`/`.foldl` over a `List` of the recursive type** — Lean's
+   automatic structural-recursion checker usually handles this today
+   without any help (confirmed repeatedly: `toInter`, most of
+   `Rename/Pass.lean`, most of `DiffView.lean` needed *no* changes beyond
+   dropping `partial`).
+2. **A pattern-matching lambda destructuring a tuple field**
+   (`fun (_, v) => ... f v ...` over a `List (String × T)`/similar, or a
+   `let (a, b) := f x` destructuring), which loses the connection the
+   termination checker needs between the recursed-into value and its
+   list-membership proof. Fixed by:
+   - Switching to explicit projections (`fun kv => ... f kv.2 ...`, or
+     referencing `(f x).2` directly at the call site instead of
+     `let`-binding it) so the recursed value stays syntactically tied to
+     its enclosing structure.
+   - Adding a small reusable helper theorem for the exact shape needed
+     (`sizeOf_snd_lt_of_mem`-style: "a pair's/`goFirsts`-result's
+     component is never bigger than the list/value it came from").
+   - An explicit `termination_by`/`decreasing_by`, closing the remaining
+     goals via `simp_wf` then `List.sizeOf_lt_of_mem`/the new helper,
+     chained with `Nat.lt_of_lt_of_le`/`omega`.
+
+`Debug/PrettyIR.lean` (~15 functions across 6 groups, 502 lines) is next.
+Attempting a blanket `partial` removal exposed **8 separate termination
+failures**. Two Explore agents read every group's actual current source
+(reported below) and confirmed the failures fall into exactly the two
+known categories above — no new failure mode, no evidence of anything
+`SaturateCtor`/`Query.Engine`-style non-structural. The only genuinely new
+technique needed is **mutual `termination_by`/`decreasing_by`**, since five
+of the six groups are `mutual` blocks (2–4 functions each) rather than
+single self-recursive functions. This was empirically verified this
+session (a throwaway scratch file, not committed) against Lean's actual
+core-library convention (`Init/Data/List/Sort/Impl.lean`):
+
+- **Each function in a `mutual` block gets its own `termination_by <arg> =>
+  <measure>` clause, placed immediately after its own equations** — not
+  clustered at the end of the block, and not using a name-prefixed
+  multi-clause syntax. Example (validated form):
+
+  ```lean
+  mutual
+  def fA : A → Nat
+    | .leaf n => n
+    | .node b => fB b
+  termination_by a => sizeA a
+  decreasing_by simp [sizeA]
+
+  def fB : B → Nat
+    | .wrap a => fA a
+    | .many xs => (xs.map fA).foldl (·+·) 0
+  termination_by b => sizeB b
+  decreasing_by
+    all_goals simp_wf
+    all_goals first
+      | simp [sizeB]
+      | (rename_i h
+         exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
+  end
+  ```
+
+- Each function needs its own **measure function** (`sizeA`/`sizeB`
+  above) — for `Doc`-returning renderers, the natural measure is each
+  mutual group's own `sizeOf` on the IR argument itself (no custom
+  measure function needed, since we're not computing a `Nat` result the
+  way the scratch example did — the target type is `Doc`, and we just
+  need `termination_by <arg> => sizeOf <arg>` for the argument being
+  matched, which is the default WF measure Lean already tries
+  automatically; the value of specifying it explicitly is that it lets
+  us follow up with a targeted `decreasing_by`).
+
+## File-by-file findings (from the Explore survey)
+
+All constructor counts from `lean/Malgo/Sequent/Fun.lean`,
+`Sequent/Core/{Full,Flat,Join}.lean`, `Syntax.lean`.
+
+### Already fine as plain `def` (no work needed)
+
+- `renderPath` (`Ir.Path`, 2 ctors, single function) — direct sub-term
+  recursion only.
+- `renderBlock`/`renderTerm` mutual (`Ir.Block` 1 ctor / `Ir.Terminator` 8
+  ctors) — only recursive calls are direct fields (`.if`'s `t`/`e`);
+  `renderStmt` (called via `stmts.map renderStmt`) is *outside* this
+  mutual group already, so it doesn't affect termination here.
+- Confirmed via the initial blanket-removal test: these compiled with no
+  errors when `partial` was dropped.
+
+### `renderPattern` (`Fun.Pattern`, 4 ctors, single function, line 107)
+
+Every recursive call is `.map`-indirect (`pats.map renderPattern` in
+`.destruct`, `renderPattern v` inside a `fun (k, v) => ...` lambda mapped
+over `.expand`'s `List (String × Fun.Pattern)` field). The `.expand` case
+is the known tuple-lambda failure mode — expect the `.1`/`.2`-projection
+fix plus a `termination_by`/`decreasing_by` (single function, so no
+mutual-block complication).
+
+### `renderExpr`/`renderBranch` mutual (`Fun.Expr` 12 ctors / `Fun.Branch` 1
+ctor, lines 120–145)
+
+Mix of direct sub-term calls (`.let`, `.lambda`, `.apply`'s callee,
+`.project`, `.select`'s scrutinee, `.fix`, `renderBranch`'s body) and safe
+single-var `.map` calls (`.construct`, `.apply`'s args, `.primitive`,
+`.select`'s branches). One tuple-lambda case: `.object`'s
+`fun (k, v) => ... renderExpr v` over `List (String × Fun.Expr)`.
+
+### `renderFullStmt`/`Prod`/`Cons`/`Branch` mutual (Full IR, 6/7/7/1 ctors,
+lines 152–194)
+
+Same shape as `renderExpr`. Tuple-lambda cases: `.object`'s
+`fun (k, ret, stmt) => ...` (a **3-tuple**, `List (String × Id ×
+Statement)`) and `.cocase`'s `fun (d, vs, s) => ...` (`List (String ×
+List Id × Statement)`, and `vs` itself gets `.map renderName`'d inside —
+not a recursive call, so not a termination concern).
+
+### `renderFlatStmt`/`Prod`/`Cons`/`Branch` mutual (Flat IR, 7/6/7/1 ctors,
+lines 202–245)
+
+Structurally identical to the Full-IR block (one extra `Statement`
+constructor, `.join`, which is direct-recursive; `Producer` has one fewer
+constructor, no `.do`). Same two tuple-lambda cases (`.object`, `.cocase`)
+as Full.
+
+### `renderJoinStmt`/`Prod`/`Cons`/`Branch` mutual (Join IR, 7/7/7/1 ctors,
+lines 253–296)
+
+Same shape again. Tuple-lambda cases: `.object`'s `fun (k, ret, stmt) =>
+...` and `.cocase`'s `fun (d, vs, s) => ...`, identical in kind to
+Full/Flat.
+
+### `renderPat`/`renderType` (Syntax, 7/9/10 ctors — `renderType` also
+covers the mutual family below), lines 419–454
+
+Both already flagged in the original failing-build output (the same
+"lost connection" symptom seen in `Rename/Pass.lean`). `renderType`'s
+`.record` (`kvs.map fun (k, v) => ...`) and `.variant` (`cases.map fun
+(k, ts) => ... ts.map renderType`, a **doubly-nested** case — outer
+tuple-lambda, then an inner `.map` over the nested `List (Ty p)`) both
+need the fix. `renderPat`'s `.record` (`kps.map fun (k, pt) => ...`) needs
+it too. `renderPat` itself has **no direct-subterm recursive call at
+all** — every case is `.map`-indirect, but that's fine per the "already
+fine" category above except for `.record`.
+
+### `renderExprSyn`/`renderType`/`renderStmtSyn`/`renderClause`/`renderPat`/
+`renderCoPat` mutual (Syntax, 16/9/4/1/7/3 ctors, lines 397–459) —
+**biggest and most complex group**
+
+This is `renderType`'s actual containing mutual block (so `renderType`'s
+fix above must be done *within* this same block, not standalone).
+`{p : Syntax.Phase} [RenderId (Syntax.XId p)]` are constant across every
+recursive call (never change), so they don't affect the termination
+measure — only the final `Syntax.* p` argument does.
+
+- `renderCoPat` (3 ctors): no indirection at all, purely direct fields —
+  trivial once the rest of the block's measure exists.
+- `renderStmtSyn` (4 ctors): all direct (`renderExprSyn`/`renderPat` on
+  literal fields).
+- `renderClause` (1 ctor): `pats.toList.map renderPat` (safe, single-var)
+  plus a direct `renderExprSyn body`.
+- `renderExprSyn` (16 ctors): mostly direct/safe-map; two tuple-lambda
+  cases — `.record`'s `kvs.map fun (k, v) => ... renderExprSyn v` and
+  `.codata`'s `clauses.map fun (cp, e) => ... renderCoPat cp ...
+  renderExprSyn e` (this one recurses into **two different mutual
+  types** from inside one lambda — both need fixing together).
+- `renderType` (9 ctors, per above): `.record`, `.variant` (doubly
+  nested) tuple-lambda cases.
+- `renderPat` (7 ctors, per above): `.record` tuple-lambda case.
+
+## Design Choices
+
+**Fix order: easiest/most-isolated first, defer the biggest mutual group
+to last.** Each group is independent (no group's fix depends on another
+compiling first, since they're separate `mutual` blocks in the same
+file), so there's no forced ordering — but doing the single-function and
+smaller mutual groups first re-validates the recipe on progressively
+larger cases before committing to the ~6-function Syntax block, which is
+the one most likely to need iteration.
+
+1. `renderPattern` (single function, 1 tuple-lambda fix) — smallest,
+   proves the recipe transfers from `Rename/Pass.lean`/`DiffView.lean`
+   to a `Doc`-returning renderer.
+2. `renderExpr`/`renderBranch` mutual (2 functions, 1 tuple-lambda fix) —
+   first mutual-block test, small.
+3. `renderFullStmt`/`Prod`/`Cons`/`Branch` mutual (4 functions, 2
+   tuple-lambda fixes, one a 3-tuple).
+4. `renderFlatStmt`/`Prod`/`Cons`/`Branch` mutual — structurally identical
+   to Full, should be nearly copy-paste once Full's fix pattern is
+   proven.
+5. `renderJoinStmt`/`Prod`/`Cons`/`Branch` mutual — same shape as
+   Full/Flat again.
+6. `renderPat`/`renderType`/`renderExprSyn`/`renderStmtSyn`/`renderClause`/
+   `renderCoPat` mutual (6 functions, phase-indexed with a typeclass
+   param, 4 tuple-lambda fixes including one doubly-nested and one
+   crossing two mutual types) — last, biggest, most likely to need real
+   iteration.
+
+**Why not a single combined `decreasing_by` tactic reused verbatim
+everywhere:** the established `all_goals simp_wf; all_goals first | omega
+| (rename_i h; exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by
+omega)) | ...` pattern generalizes, but each new tuple-lambda shape needs
+its own alternative added to the `first | ... |` chain (as seen going
+from Rename/Pass.lean's single-tuple case to DiffView.lean's `let`-based
+one) — expect to extend the combinator per group rather than reuse one
+verbatim across all 6, and expect at least one extra `sizeOf`-relating
+helper lemma for the 3-tuple and doubly-nested cases (a 3-tuple's third
+component's `sizeOf` bound follows the same
+`cases p with | mk a b c => simp; omega` pattern already used for pairs,
+just one more projection deep).
+
+**Why mutual `termination_by`/`decreasing_by` per-function rather than
+one shared clause:** confirmed empirically this session against Lean's
+own core-library convention — there is no single combined syntax; each
+function's clause goes immediately after its own equations, inside the
+`mutual...end` block.
+
+## Implementation Plan
+
+Each task is independently assignable (separate mutual blocks, no shared
+state) but should land as **one PR** rather than six, matching this
+session's existing pattern of one Tier 3 file per PR — splitting further
+would just be six small commits inside the same file/PR review, not
+independent worktrees.
+
+### Task 1: `renderPattern`
+
+- **Goal**: de-partialize the single-function case.
+- **Scope**: `lean/Malgo/Debug/PrettyIR.lean`, `renderPattern` (~line
+  107).
+- **Dependencies**: none.
+- **Steps**: drop `partial`; fix `.expand`'s `fun (k, v) => ...` to `fun
+  kv => ... kv.2 ...`; add `termination_by`/`decreasing_by` following the
+  `Rename/Pass.lean` recipe (one `sizeOf_snd_lt_of_mem`-shaped helper if
+  not already reusable from another file — check whether a shared
+  private helper in this file makes sense, since later tasks need the
+  identical lemma shape).
+- **Verification**: `lake build Malgo.Debug.PrettyIR` in isolation before
+  moving on.
+
+### Task 2: `renderExpr`/`renderBranch` mutual
+
+- **Goal**: de-partialize the first mutual block.
+- **Scope**: same file, ~lines 120–145.
+- **Dependencies**: none (independent of Task 1, though reuses its helper
+  lemma if extracted generically).
+- **Steps**: drop `partial` from both; fix `.object`'s tuple lambda; add
+  per-function `termination_by`/`decreasing_by` inside the `mutual`
+  block, one measure per function (`sizeOf` on each function's own IR
+  argument).
+- **Verification**: isolated build.
+
+### Task 3: `renderFullStmt`/`Prod`/`Cons`/`Branch` mutual
+
+- **Goal**: de-partialize the Full-IR renderer family.
+- **Scope**: ~lines 152–194.
+- **Dependencies**: none, but structurally previews Tasks 4–5.
+- **Steps**: drop `partial` from all four; fix `.object`'s 3-tuple lambda
+  (`fun (k, ret, stmt) => ...`) and `.cocase`'s (`fun (d, vs, s) =>
+  ...`); one `termination_by`/`decreasing_by` per function (4 clauses
+  total, each referencing whichever of the other 3 functions it calls
+  mutually).
+- **Verification**: isolated build.
+
+### Task 4: `renderFlatStmt`/`Prod`/`Cons`/`Branch` mutual
+
+- **Goal**: de-partialize the Flat-IR renderer family.
+- **Scope**: ~lines 202–245.
+- **Dependencies**: none functionally, but do after Task 3 — structurally
+  near-identical, so the fix should transfer directly with minimal
+  adaptation (one extra `Statement` ctor `.join`, direct-recursive, no
+  extra work; one fewer `Producer` ctor, nothing to add).
+- **Steps**: same as Task 3, applied to Flat's four functions.
+- **Verification**: isolated build.
+
+### Task 5: `renderJoinStmt`/`Prod`/`Cons`/`Branch` mutual
+
+- **Goal**: de-partialize the Join-IR renderer family.
+- **Scope**: ~lines 253–296.
+- **Dependencies**: none functionally, do after Task 3/4 for the same
+  "structurally identical, fix transfers" reason.
+- **Steps**: same as Task 3, applied to Join's four functions.
+- **Verification**: isolated build.
+
+### Task 6: Syntax mutual block (`renderExprSyn`/`renderType`/`renderStmtSyn`/
+`renderClause`/`renderPat`/`renderCoPat`)
+
+- **Goal**: de-partialize the last and biggest mutual family.
+- **Scope**: ~lines 397–459.
+- **Dependencies**: do last — biggest, most likely to need real
+  iteration (6 functions, one doubly-nested tuple-lambda in `.variant`,
+  one lambda crossing two mutual types in `.codata`).
+- **Steps**: drop `partial` from all six; fix `renderExprSyn`'s `.record`
+  and `.codata` tuple lambdas, `renderType`'s `.record` and `.variant`
+  (doubly-nested — may need an extra helper lemma for "recursing into an
+  element of a list that's itself inside a tuple that's itself inside a
+  list"), `renderPat`'s `.record`; add 6 `termination_by`/`decreasing_by`
+  clauses, one per function, each only measuring the `Syntax.* p`
+  argument (the phase `p` and typeclass instance are constant across all
+  calls and shouldn't enter the measure).
+- **Verification**: isolated build; this is the task most likely to
+  reveal an unanticipated 9th/10th failure mode given its size — if it
+  does, treat that as new information worth a fresh check-in rather than
+  pushing through blindly (consistent with how this session has handled
+  every other unexpected-difficulty discovery).
+
+## Verification (whole-file, after all 6 tasks)
+
+1. `grep -n "^partial def" lean/Malgo/Debug/PrettyIR.lean` → empty.
+2. `grep -n "sorry" lean/Malgo/Debug/PrettyIR.lean` → empty.
+3. `mise run lean-build` (full project) — confirms no downstream callers
+   broke (PrettyIR is used by `malgo debug-trace`/`Debug/MetPage.lean`
+   and the `Malgo.Debug.PrettyIR` golden tests).
+4. `mise run lean-test` — the ~89 `Debug.PrettyIR` golden files (plus any
+   MetPage goldens) byte-compare rendered output; this is the real
+   behavior-preservation check, not just type-checking.
+5. Re-diff the final change to confirm no `render*` function's *output*
+   changed — only its internal recursion structure (i.e. no stray `.1`/
+   `.2` typo silently reordering a tuple, etc.).
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| The doubly-nested `.variant`/`.codata` cases in Task 6 need a genuinely new helper lemma shape (not just a bigger tuple), which could take real iteration | Attempt with the established recipe first; if it doesn't converge in a reasonable number of `lake build` iterations, check in rather than open-endedly iterating (matches this session's established pattern for every prior scope surprise) |
+| Six separate `termination_by`/`decreasing_by` clauses in one `mutual` block (Task 6) is more moving parts than anything attempted so far — a measure mismatch in one function could produce confusing errors attributed to a different function | Add clauses one function at a time, rebuilding after each, rather than writing all 6 up front |
+| `RenderId (Syntax.XId p)` typeclass parameter might interact unexpectedly with `termination_by`'s measure inference (untested combination) | Verify early (Task 6's first function) rather than assuming it's transparent like the scratch test's non-typeclass case |
+| Splitting into 6 tasks but landing as 1 PR risks a large, hard-to-review diff | Keep the PR description structured per-task (mirroring this doc's task list) so review can proceed group-by-group even though it's one changeset |

--- a/lean/Malgo/Debug/PrettyIR.lean
+++ b/lean/Malgo/Debug/PrettyIR.lean
@@ -104,12 +104,67 @@ def blockLines : List Doc → Doc
 def hangEq (pre body : Doc) : Doc :=
   group (pre <+> atom "=" ++ nest 2 (line ++ body))
 
-partial def renderPattern : Fun.Pattern → Doc
+/-- Termination helper: a pair's second component is never bigger than the
+pair itself. Building block for justifying recursion into the value half
+of `(String × _)`/`(String × _ × _)` fields below (every IR's `object`/
+`record`/`variant`/`cocase`-style named-fields list), composed via
+`Nat.le_trans` for triples. -/
+private theorem sizeOf_snd_le {α β : Type} [SizeOf α] [SizeOf β] (p : α × β) :
+    sizeOf p.snd ≤ sizeOf p := by
+  cases p with
+  | mk a b => simp
+
+private theorem sizeOf_snd_lt_of_mem {α β : Type} [SizeOf α] [SizeOf β] {p : α × β}
+    {l : List (α × β)} (h : p ∈ l) : sizeOf p.snd < sizeOf l :=
+  Nat.lt_of_le_of_lt (sizeOf_snd_le p) (List.sizeOf_lt_of_mem h)
+
+private theorem sizeOf_snd_snd_lt_of_mem {α β γ : Type} [SizeOf α] [SizeOf β] [SizeOf γ]
+    {p : α × β × γ} {l : List (α × β × γ)} (h : p ∈ l) : sizeOf p.2.2 < sizeOf l :=
+  Nat.lt_of_le_of_lt (Nat.le_trans (sizeOf_snd_le p.2) (sizeOf_snd_le p)) (List.sizeOf_lt_of_mem h)
+
+private theorem sizeOf_fst_le {α β : Type} [SizeOf α] [SizeOf β] (p : α × β) :
+    sizeOf p.fst ≤ sizeOf p := by
+  cases p with
+  | mk a b => simp <;> omega
+
+private theorem sizeOf_fst_lt_of_mem {α β : Type} [SizeOf α] [SizeOf β] {p : α × β}
+    {l : List (α × β)} (h : p ∈ l) : sizeOf p.fst < sizeOf l :=
+  Nat.lt_of_le_of_lt (sizeOf_fst_le p) (List.sizeOf_lt_of_mem h)
+
+/-- Two-level version of `sizeOf_snd_lt_of_mem`: for a doubly-nested field
+like `variant`'s `List (String × List (Ty p))`, bounds an element of the
+INNER list against the OUTER list's size. -/
+private theorem sizeOf_lt_of_mem_snd_of_mem {α γ : Type} [SizeOf α] [SizeOf γ]
+    {x : γ} {p : α × List γ} {l : List (α × List γ)} (hx : x ∈ p.snd) (hp : p ∈ l) :
+    sizeOf x < sizeOf l :=
+  Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem hx) (Nat.le_trans (sizeOf_snd_le p) (Nat.le_of_lt (List.sizeOf_lt_of_mem hp)))
+
+/-- `NEList.toList`'s recursion target — every element is either the head
+or in the tail, both strictly smaller than the whole `NEList`. Needed since
+`renderExprSyn`'s `.fn`/`.seq` cases recurse via `cs.toList.map _`. -/
+private theorem sizeOf_lt_of_mem_toList {α : Type} [SizeOf α] {x : α} {xs : NEList α}
+    (h : x ∈ xs.toList) : sizeOf x < sizeOf xs := by
+  cases xs with
+  | mk head tail =>
+    simp only [NEList.toList, List.mem_cons] at h
+    cases h with
+    | inl h => subst h; simp; omega
+    | inr h => exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by simp)
+
+def renderPattern : Fun.Pattern → Doc
   | .pvar _ name => renderName name
   | .pliteral _ lit => renderLit lit
   | .destruct _ tag pats => renderTag tag ++ renderArgs (pats.map renderPattern)
   | .expand _ fields =>
-    braceList ((sortAssocAscending fields).map fun (k, v) => fromString k <+> atom "=" <+> renderPattern v)
+    braceList ((sortAssocAscending fields).attach.map fun ⟨kv, hkv⟩ =>
+      fromString kv.1 <+> atom "=" <+> renderPattern kv.2)
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_lt_of_mem (mem_sortAssocAscending hkv)) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
 /-- One blank line between each top-level definition. -/
 def renderDefs (ds : List Doc) : String :=
@@ -119,7 +174,7 @@ def renderDefs (ds : List Doc) : String :=
 
 mutual
 
-partial def renderExpr : Fun.Expr → Doc
+def renderExpr : Fun.Expr → Doc
   | .var _ name => renderName name
   | .literal _ lit => renderLit lit
   | .construct _ tag args => renderTag tag ++ renderArgs (args.map renderExpr)
@@ -130,7 +185,8 @@ partial def renderExpr : Fun.Expr → Doc
   | .lambda _ params body =>
     group (atom "\\" ++ hsep (params.map renderName) <+> atom "->" ++ nest 2 (line ++ renderExpr body))
   | .object _ fields =>
-    braceList ((sortAssocAscending fields).map fun (k, v) => fromString k <+> atom "=" <+> renderExpr v)
+    braceList ((sortAssocAscending fields).attach.map fun ⟨kv, hkv⟩ =>
+      fromString kv.1 <+> atom "=" <+> renderExpr kv.2)
   | .apply _ callee args => renderExpr callee ++ renderArgs (args.map renderExpr)
   | .project _ callee field => renderExpr callee ++ atom "." ++ fromString field
   | .primitive _ op args => atom "#" ++ fromString op ++ renderArgs (args.map renderExpr)
@@ -138,9 +194,18 @@ partial def renderExpr : Fun.Expr → Doc
     atom "case" <+> renderExpr scrutinee <+> atom "of" <+> blockLines (branches.map renderBranch)
   | .invoke _ name => atom "invoke" <+> renderName name
   | .fix _ name body => hangEq (atom "fix" <+> renderName name) (renderExpr body)
+termination_by e => sizeOf e
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_lt_of_mem (mem_sortAssocAscending hkv)) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderBranch : Fun.Branch → Doc
+def renderBranch : Fun.Branch → Doc
   | .branch _ pat body => group (renderPattern pat <+> atom "->" ++ nest 2 (line ++ renderExpr body))
+termination_by b => sizeOf b
 
 end
 
@@ -151,7 +216,7 @@ def renderFun (p : Fun.Program) : String :=
 
 mutual
 
-partial def renderFullStmt : Full.Statement → Doc
+def renderFullStmt : Full.Statement → Doc
   | .cut p c => renderFullProd p <+> atom "~" <+> renderFullCons c
   | .primitive _ name ps c =>
     atom "#" ++ fromString name ++ renderArgs (ps.map renderFullProd) <+> atom "~" <+> renderFullCons c
@@ -162,23 +227,39 @@ partial def renderFullStmt : Full.Statement → Doc
     parens (renderFullProd l <+> fromString op <+> renderFullProd r) <+> atom "~" <+> renderFullCons c
   | .ifz _ cond t e =>
     atom "if0" <+> renderFullProd cond <+> atom "then" <+> block (renderFullStmt t) <+> atom "else" <+> block (renderFullStmt e)
+termination_by s => sizeOf s
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderFullProd : Full.Producer → Doc
+def renderFullProd : Full.Producer → Doc
   | .var _ name => renderName name
   | .literal _ lit => renderLit lit
   | .construct _ tag ps cs => renderTag tag ++ renderArgs ((ps.map renderFullProd) ++ (cs.map renderFullCons))
   | .lambda _ params stmt =>
     group (atom "\\" ++ hsep (params.map renderName) <+> atom "." <+> block (renderFullStmt stmt))
   | .object _ fields =>
-    braceList ((sortAssocAscending fields).map fun (k, ret, stmt) =>
-      fromString k ++ renderArgs [renderName ret] <+> atom "=" <+> block (renderFullStmt stmt))
+    braceList ((sortAssocAscending fields).attach.map fun ⟨krs, hkrs⟩ =>
+      fromString krs.1 ++ renderArgs [renderName krs.2.1] <+> atom "=" <+> block (renderFullStmt krs.2.2))
   | .«do» _ name stmt => atom "do" <+> renderName name <+> atom "." <+> block (renderFullStmt stmt)
   | .mu _ name stmt => atom "mu" <+> renderName name <+> atom "." <+> block (renderFullStmt stmt)
   | .cocase _ branches =>
-    atom "cocase" <+> blockLines (branches.map fun (d, vs, s) =>
-      group (atom "." ++ fromString d ++ renderArgs (vs.map renderName) <+> atom "->" ++ nest 2 (line ++ renderFullStmt s)))
+    atom "cocase" <+> blockLines (branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      group (atom "." ++ fromString dvs.1 ++ renderArgs (dvs.2.1.map renderName) <+> atom "->" ++ nest 2 (line ++ renderFullStmt dvs.2.2)))
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem (mem_sortAssocAscending hkrs)) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderFullCons : Full.Consumer → Doc
+def renderFullCons : Full.Consumer → Doc
   | .label _ name => renderName name
   | .apply _ ps cs => renderArgs ((ps.map renderFullProd) ++ (cs.map renderFullCons))
   | .project _ field c => atom "." ++ fromString field <+> atom "->" <+> renderFullCons c
@@ -187,9 +268,17 @@ partial def renderFullCons : Full.Consumer → Doc
   | .select _ branches => atom "select" <+> blockLines (branches.map renderFullBranch)
   | .destructor _ name ps c =>
     atom "." ++ fromString name ++ renderArgs (ps.map renderFullProd) <+> atom "->" <+> renderFullCons c
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderFullBranch : Full.Branch → Doc
+def renderFullBranch : Full.Branch → Doc
   | .branch _ pat stmt => group (renderPattern pat <+> atom "->" ++ nest 2 (line ++ renderFullStmt stmt))
+termination_by b => sizeOf b
 
 end
 
@@ -201,7 +290,7 @@ def renderCoreFull (p : Full.Program) : String :=
 
 mutual
 
-partial def renderFlatStmt : Flat.Statement → Doc
+def renderFlatStmt : Flat.Statement → Doc
   | .cut p c => renderFlatProd p <+> atom "~" <+> renderFlatCons c
   | .join _ name c s =>
     group (atom "join" <+> renderName name <+> atom "=" <+> renderFlatCons c) ++ line ++ atom "in" <+> renderFlatStmt s
@@ -214,22 +303,38 @@ partial def renderFlatStmt : Flat.Statement → Doc
     parens (renderFlatProd l <+> fromString op <+> renderFlatProd r) <+> atom "~" <+> renderFlatCons c
   | .ifz _ cond t e =>
     atom "if0" <+> renderFlatProd cond <+> atom "then" <+> block (renderFlatStmt t) <+> atom "else" <+> block (renderFlatStmt e)
+termination_by s => sizeOf s
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderFlatProd : Flat.Producer → Doc
+def renderFlatProd : Flat.Producer → Doc
   | .var _ name => renderName name
   | .literal _ lit => renderLit lit
   | .construct _ tag ps cs => renderTag tag ++ renderArgs ((ps.map renderFlatProd) ++ (cs.map renderFlatCons))
   | .lambda _ params stmt =>
     group (atom "\\" ++ hsep (params.map renderName) <+> atom "." <+> block (renderFlatStmt stmt))
   | .object _ fields =>
-    braceList ((sortAssocAscending fields).map fun (k, ret, stmt) =>
-      fromString k ++ renderArgs [renderName ret] <+> atom "=" <+> block (renderFlatStmt stmt))
+    braceList ((sortAssocAscending fields).attach.map fun ⟨krs, hkrs⟩ =>
+      fromString krs.1 ++ renderArgs [renderName krs.2.1] <+> atom "=" <+> block (renderFlatStmt krs.2.2))
   | .mu _ name stmt => atom "mu" <+> renderName name <+> atom "." <+> block (renderFlatStmt stmt)
   | .cocase _ branches =>
-    atom "cocase" <+> blockLines (branches.map fun (d, vs, s) =>
-      group (atom "." ++ fromString d ++ renderArgs (vs.map renderName) <+> atom "->" ++ nest 2 (line ++ renderFlatStmt s)))
+    atom "cocase" <+> blockLines (branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      group (atom "." ++ fromString dvs.1 ++ renderArgs (dvs.2.1.map renderName) <+> atom "->" ++ nest 2 (line ++ renderFlatStmt dvs.2.2)))
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem (mem_sortAssocAscending hkrs)) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderFlatCons : Flat.Consumer → Doc
+def renderFlatCons : Flat.Consumer → Doc
   | .label _ name => renderName name
   | .apply _ ps cs => renderArgs ((ps.map renderFlatProd) ++ (cs.map renderFlatCons))
   | .project _ field c => atom "." ++ fromString field <+> atom "->" <+> renderFlatCons c
@@ -238,9 +343,17 @@ partial def renderFlatCons : Flat.Consumer → Doc
   | .select _ branches => atom "select" <+> blockLines (branches.map renderFlatBranch)
   | .destructor _ name ps c =>
     atom "." ++ fromString name ++ renderArgs (ps.map renderFlatProd) <+> atom "->" <+> renderFlatCons c
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderFlatBranch : Flat.Branch → Doc
+def renderFlatBranch : Flat.Branch → Doc
   | .branch _ pat stmt => group (renderPattern pat <+> atom "->" ++ nest 2 (line ++ renderFlatStmt stmt))
+termination_by b => sizeOf b
 
 end
 
@@ -252,7 +365,7 @@ def renderFlat (p : Flat.Program) : String :=
 
 mutual
 
-partial def renderJoinStmt : Join.Statement → Doc
+def renderJoinStmt : Join.Statement → Doc
   | .cut p ret => renderJoinProd p <+> atom "~" <+> renderName ret
   | .join _ name c s =>
     group (atom "join" <+> renderName name <+> atom "=" <+> renderJoinCons c) ++ line ++ atom "in" <+> renderJoinStmt s
@@ -265,22 +378,38 @@ partial def renderJoinStmt : Join.Statement → Doc
     parens (renderJoinProd l <+> fromString op <+> renderJoinProd r) <+> atom "~" <+> renderName ret
   | .ifz _ cond t e =>
     atom "if0" <+> renderJoinProd cond <+> atom "then" <+> block (renderJoinStmt t) <+> atom "else" <+> block (renderJoinStmt e)
+termination_by s => sizeOf s
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderJoinProd : Join.Producer → Doc
+def renderJoinProd : Join.Producer → Doc
   | .var _ name => renderName name
   | .literal _ lit => renderLit lit
   | .construct _ tag ps rets => renderTag tag ++ renderArgs ((ps.map renderJoinProd) ++ (rets.map renderName))
   | .lambda _ params stmt =>
     group (atom "\\" ++ hsep (params.map renderName) <+> atom "." <+> block (renderJoinStmt stmt))
   | .object _ fields =>
-    braceList ((sortAssocAscending fields).map fun (k, ret, stmt) =>
-      fromString k ++ renderArgs [renderName ret] <+> atom "=" <+> block (renderJoinStmt stmt))
+    braceList ((sortAssocAscending fields).attach.map fun ⟨krs, hkrs⟩ =>
+      fromString krs.1 ++ renderArgs [renderName krs.2.1] <+> atom "=" <+> block (renderJoinStmt krs.2.2))
   | .mu _ name stmt => atom "mu" <+> renderName name <+> atom "." <+> block (renderJoinStmt stmt)
   | .cocase _ branches =>
-    atom "cocase" <+> blockLines (branches.map fun (d, vs, s) =>
-      group (atom "." ++ fromString d ++ renderArgs (vs.map renderName) <+> atom "->" ++ nest 2 (line ++ renderJoinStmt s)))
+    atom "cocase" <+> blockLines (branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      group (atom "." ++ fromString dvs.1 ++ renderArgs (dvs.2.1.map renderName) <+> atom "->" ++ nest 2 (line ++ renderJoinStmt dvs.2.2)))
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem (mem_sortAssocAscending hkrs)) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderJoinCons : Join.Consumer → Doc
+def renderJoinCons : Join.Consumer → Doc
   | .label _ name => renderName name
   | .apply _ ps rets => renderArgs ((ps.map renderJoinProd) ++ (rets.map renderName))
   | .project _ field ret => atom "." ++ fromString field <+> atom "->" <+> renderName ret
@@ -289,9 +418,17 @@ partial def renderJoinCons : Join.Consumer → Doc
   | .select _ branches => atom "select" <+> blockLines (branches.map renderJoinBranch)
   | .destructor _ name ps ret =>
     atom "." ++ fromString name ++ renderArgs (ps.map renderJoinProd) <+> atom "->" <+> renderName ret
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderJoinBranch : Join.Branch → Doc
+def renderJoinBranch : Join.Branch → Doc
   | .branch _ pat stmt => group (renderPattern pat <+> atom "->" ++ nest 2 (line ++ renderJoinStmt stmt))
+termination_by b => sizeOf b
 
 end
 
@@ -301,7 +438,7 @@ def renderJoin (p : Join.Program) : String :=
 
 /-! ## Zig backend ANF IR -/
 
-partial def renderPath : Ir.Path → Doc
+def renderPath : Ir.Path → Doc
   | .root n => renderName n
   | .field p i => renderPath p ++ atom "." ++ atom (toString i)
 
@@ -337,10 +474,10 @@ def renderStmt : Ir.Stmt → Doc
 
 mutual
 
-partial def renderBlock : Ir.Block → Doc
+def renderBlock : Ir.Block → Doc
   | .mk stmts term => vsepHard ((stmts.map renderStmt) ++ [renderTerm term])
 
-partial def renderTerm : Ir.Terminator → Doc
+def renderTerm : Ir.Terminator → Doc
   | .applyCo k v => atom "return" <+> renderName k ++ renderArgs [renderName v]
   | .callClosure f args => atom "return" <+> renderName f ++ renderArgs (args.map renderName)
   | .staticCall fn args => atom "return" <+> renderName fn ++ renderArgs (args.map renderName)
@@ -396,65 +533,108 @@ def renderImport (m : ModuleName) (importList : Syntax.ImportList) : Doc :=
 
 mutual
 
-partial def renderExprSyn {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Expr p → Doc
+def renderExprSyn {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Expr p → Doc
   | .var _ id => renderId id
   | .unboxed _ l => renderSynLit l
   | .boxed _ l => renderSynLit l
   | .apply _ e1 e2 => renderExprSyn e1 ++ renderArgs [renderExprSyn e2]
   | .opApp _ op e1 e2 => renderExprSyn e1 <+> renderId op <+> renderExprSyn e2
   | .project _ e k => renderExprSyn e ++ atom "." ++ fromString k
-  | .fn _ cs => atom "fn" <+> blockLines (punctuate (atom " |") (cs.toList.map renderClause))
+  | .fn _ cs =>
+    atom "fn" <+> blockLines (punctuate (atom " |") (cs.toList.attach.map fun ⟨c, hc⟩ => renderClause c))
   | .tuple _ es => renderArgs (es.map renderExprSyn)
-  | .record _ kvs => braceList (kvs.map fun (k, v) => fromString k <+> atom "=" <+> renderExprSyn v)
+  | .record _ kvs =>
+    braceList (kvs.attach.map fun ⟨kv, hkv⟩ => fromString kv.1 <+> atom "=" <+> renderExprSyn kv.2)
   | .list _ es => list (es.map renderExprSyn)
   | .ann _ e t => renderExprSyn e <+> atom ":" <+> renderType t
-  | .seq _ ss => blockLines (ss.toList.map renderStmtSyn)
+  | .seq _ ss => blockLines (ss.toList.attach.map fun ⟨s, hs⟩ => renderStmtSyn s)
   | .parens _ e => parens (renderExprSyn e)
   | .codata _ clauses =>
-    atom "codata" <+> blockLines (clauses.map fun (cp, e) =>
-      group (renderCoPat cp <+> atom "->" ++ nest 2 (line ++ renderExprSyn e)))
+    atom "codata" <+> blockLines (clauses.attach.map fun ⟨ce, hce⟩ =>
+      group (renderCoPat ce.1 <+> atom "->" ++ nest 2 (line ++ renderExprSyn ce.2)))
   | .label _ name body => atom "label" <+> renderId name <+> atom "." <+> renderExprSyn body
   | .goto _ value label => atom "goto" <+> renderExprSyn value <+> renderExprSyn label
+termination_by e => sizeOf e
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_lt_of_mem hkv) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_fst_lt_of_mem hce) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_lt_of_mem hce) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_lt_of_mem_toList hc) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_lt_of_mem_toList hs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderType {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Ty p → Doc
+def renderType {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Ty p → Doc
   | .app _ t ts => renderType t ++ renderArgs (ts.map renderType)
   | .var _ v => renderId v
   | .con _ c => renderId c
   | .arr _ t1 t2 => renderType t1 <+> atom "->" <+> renderType t2
   | .tuple _ ts => renderArgs (ts.map renderType)
   | .record _ kvs rowTail =>
-    braceList ((kvs.map fun (k, v) => fromString k <+> atom ":" <+> renderType v) ++
+    braceList ((kvs.attach.map fun ⟨kv, hkv⟩ => fromString kv.1 <+> atom ":" <+> renderType kv.2) ++
       (match rowTail with | some r => [atom "|" <+> renderType r] | none => []))
   | .block _ t => block (renderType t)
   | .bottom _ => atom "!"
   | .tilde _ t => atom "~" ++ renderType t
   | .variant _ cases rowTail =>
-    list ((cases.map fun (k, ts) => fromString k ++ renderArgs (ts.map renderType)) ++
+    list ((cases.attach.map fun ⟨kts, hkts⟩ =>
+        fromString kts.1 ++ renderArgs (kts.2.attach.map fun ⟨t, ht⟩ => renderType t)) ++
       (match rowTail with | some r => [atom "|" <+> renderType r] | none => []))
+termination_by t => sizeOf t
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_lt_of_mem hkv) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_lt_of_mem_snd_of_mem ht hkts) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderStmtSyn {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Stmt p → Doc
+def renderStmtSyn {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Stmt p → Doc
   | .letS _ var body => hangEq (atom "let" <+> renderId var) (renderExprSyn body)
   | .letPS _ pat body => hangEq (atom "let" <+> renderPat pat) (renderExprSyn body)
   | .withS _ none body => atom "with" <+> renderExprSyn body
   | .withS _ (some var) body => hangEq (atom "with" <+> renderId var) (renderExprSyn body)
   | .noBind _ body => renderExprSyn body
+termination_by s => sizeOf s
 
-partial def renderClause {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Clause p → Doc
-  | .mk _ pats body => group (hsep (pats.toList.map renderPat) <+> atom "->" ++ nest 2 (line ++ renderExprSyn body))
+def renderClause {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Clause p → Doc
+  | .mk _ pats body =>
+    group (hsep (pats.toList.attach.map fun ⟨pt, hpt⟩ => renderPat pt) <+> atom "->" ++
+      nest 2 (line ++ renderExprSyn body))
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_lt_of_mem_toList hpt) (by omega)
 
-partial def renderPat {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Pat p → Doc
+def renderPat {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.Pat p → Doc
   | .var _ id => renderId id
   | .con _ id ps => renderId id ++ renderArgs (ps.map renderPat)
   | .tuple _ ps => renderArgs (ps.map renderPat)
-  | .record _ kps => braceList (kps.map fun (k, pt) => fromString k <+> atom "=" <+> renderPat pt)
+  | .record _ kps =>
+    braceList (kps.attach.map fun ⟨kp, hkp⟩ => fromString kp.1 <+> atom "=" <+> renderPat kp.2)
   | .list _ ps => list (ps.map renderPat)
   | .unboxed _ l => renderSynLit l
   | .boxed _ l => renderSynLit l
+termination_by pt => sizeOf pt
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_lt_of_mem hkp) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def renderCoPat {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.CoPat p → Doc
+def renderCoPat {p : Syntax.Phase} [RenderId (Syntax.XId p)] : Syntax.CoPat p → Doc
   | .hole _ => atom "#"
   | .apply _ cp pt => renderCoPat cp ++ renderArgs [renderPat pt]
   | .project _ cp field => renderCoPat cp ++ atom "." ++ fromString field
+termination_by cp => sizeOf cp
 
 end
 

--- a/lean/Malgo/Prelude.lean
+++ b/lean/Malgo/Prelude.lean
@@ -69,6 +69,47 @@ Lean (a `Std.TreeMap` cannot nest inside a recursive inductive). -/
 def sortAssocAscending [Ord κ] (xs : List (κ × α)) : List (κ × α) :=
   xs.foldr insertAssocAscending []
 
+private theorem mem_insertAssocAscending {κ α : Type} [Ord κ] (x : κ × α) :
+    ∀ (ys : List (κ × α)) {y}, y ∈ insertAssocAscending x ys → y = x ∨ y ∈ ys
+  | [], y, h => by
+    simp only [insertAssocAscending, List.mem_singleton] at h
+    exact Or.inl h
+  | y' :: ys, y, h => by
+    simp only [insertAssocAscending] at h
+    cases hc : compare x.1 y'.1 with
+    | gt =>
+      rw [hc] at h
+      cases h with
+      | head => exact Or.inr (List.mem_cons.mpr (Or.inl rfl))
+      | tail _ h =>
+        cases mem_insertAssocAscending x ys h with
+        | inl h' => exact Or.inl h'
+        | inr h' => exact Or.inr (List.mem_cons.mpr (Or.inr h'))
+    | eq =>
+      rw [hc] at h
+      cases h with
+      | head => exact Or.inr (List.mem_cons.mpr (Or.inl rfl))
+      | tail _ h => exact Or.inr (List.mem_cons.mpr (Or.inr h))
+    | lt =>
+      rw [hc] at h
+      cases h with
+      | head => exact Or.inl rfl
+      | tail _ h => exact Or.inr h
+
+/-- `sortAssocAscending` only ever keeps or drops elements of its input
+(dropping shadowed duplicate keys) — it never invents a new pair. Lets a
+termination proof recurse into a `sortAssocAscending`-filtered field
+exactly as if it had recursed into the field directly. -/
+theorem mem_sortAssocAscending {κ α : Type} [Ord κ] {xs : List (κ × α)} {p : κ × α}
+    (h : p ∈ sortAssocAscending xs) : p ∈ xs := by
+  induction xs with
+  | nil => simp [sortAssocAscending] at h
+  | cons x xs ih =>
+    simp only [sortAssocAscending, List.foldr_cons] at h
+    cases mem_insertAssocAscending x (xs.foldr insertAssocAscending []) h with
+    | inl h' => exact List.mem_cons.mpr (Or.inl h')
+    | inr h' => exact List.mem_cons.mpr (Or.inr (ih h'))
+
 /-- Haskell `Data.List.NonEmpty`. -/
 structure NEList (α : Type u) where
   head : α


### PR DESCRIPTION
## Summary
- The last and biggest Tier 3 item from issue #359: ~15 `render*` functions across 6 groups (Fun, Full/Flat/Join Core IR, the Zig backend IR, and the Syntax family), all `partial def` only because Lean's termination checker couldn't see through `List.map`/tuple-destructuring/mutual recursion that's actually structural. Design doc: `docs/plans/2026-07-20-prettyir-departial.md`.
- Most groups needed the same recipe already established in `Rename/Pass.lean`/`Debug/DiffView.lean`: explicit `termination_by`/`decreasing_by` per function in each `mutual` block, plus a couple of new tuple-projection helpers (`sizeOf_fst_le`/`sizeOf_snd_le`-derived `sizeOf_snd_lt_of_mem`, `sizeOf_snd_snd_lt_of_mem`, `sizeOf_fst_lt_of_mem`) for the `object`/`cocase`/`record` 2- and 3-tuple fields.
- Found two genuinely new wrinkles, both because a value gets routed through an **opaque function call** before the `.map` that recurses into it — this doesn't just weaken the termination checker's connection (like a tuple-destructuring lambda does), it loses the membership hypothesis *entirely*:
  - `sortAssocAscending` (used by every IR's `object`/`record`/`cocase` field) can drop shadowed duplicate keys, so its output isn't literally a sub-list of its input — needed a real lemma, `mem_sortAssocAscending` in `Prelude.lean` (plus a private `mem_insertAssocAscending` helper).
  - `NEList.toList` (used by `.fn`/`.seq`/`Clause`'s pattern list) has the same shape — fixed with `sizeOf_lt_of_mem_toList`.
  - Both needed `.attach` at the call site (not just a `.1`/`.2` projection) so the membership witness exists at all.
  - `renderType`'s `.variant` case is doubly-nested (`List (String × List (Ty p))`) — needed one more two-level helper, `sizeOf_lt_of_mem_snd_of_mem`.
- The Syntax mutual family also needed `sizeOf_fst_lt_of_mem` for `.codata`'s lambda that recurses into **two different mutual types** from one pair (`CoPat` and `Expr`).
- No new theorems beyond the termination-only helper lemmas, no behavior change — this is a pure text-formatting/debug-tracer module.

## Test plan
- [x] `lake build` (full) — 128/128 jobs succeed
- [x] `lake test` — 532/532 goldens + 94/94 infer, no regressions (the ~89 `Debug.PrettyIR` golden files byte-compare rendered output, the real behavior-preservation check for this change)
- [x] `grep -n "^partial def" lean/Malgo/Debug/PrettyIR.lean` — empty
- [x] `grep -n "sorry" lean/Malgo/Debug/PrettyIR.lean` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)