### PR TITLE
refactor(lean): de-partialize Sequent/Core/Full.lean's toSExpr family (#359, Tier 3)

### DIFF
--- a/lean/Malgo/Debug/PrettyIR.lean
+++ b/lean/Malgo/Debug/PrettyIR.lean
@@ -104,53 +104,6 @@ def blockLines : List Doc → Doc
 def hangEq (pre body : Doc) : Doc :=
   group (pre <+> atom "=" ++ nest 2 (line ++ body))
 
-/-- Termination helper: a pair's second component is never bigger than the
-pair itself. Building block for justifying recursion into the value half
-of `(String × _)`/`(String × _ × _)` fields below (every IR's `object`/
-`record`/`variant`/`cocase`-style named-fields list), composed via
-`Nat.le_trans` for triples. -/
-private theorem sizeOf_snd_le {α β : Type} [SizeOf α] [SizeOf β] (p : α × β) :
-    sizeOf p.snd ≤ sizeOf p := by
-  cases p with
-  | mk a b => simp
-
-private theorem sizeOf_snd_lt_of_mem {α β : Type} [SizeOf α] [SizeOf β] {p : α × β}
-    {l : List (α × β)} (h : p ∈ l) : sizeOf p.snd < sizeOf l :=
-  Nat.lt_of_le_of_lt (sizeOf_snd_le p) (List.sizeOf_lt_of_mem h)
-
-private theorem sizeOf_snd_snd_lt_of_mem {α β γ : Type} [SizeOf α] [SizeOf β] [SizeOf γ]
-    {p : α × β × γ} {l : List (α × β × γ)} (h : p ∈ l) : sizeOf p.2.2 < sizeOf l :=
-  Nat.lt_of_le_of_lt (Nat.le_trans (sizeOf_snd_le p.2) (sizeOf_snd_le p)) (List.sizeOf_lt_of_mem h)
-
-private theorem sizeOf_fst_le {α β : Type} [SizeOf α] [SizeOf β] (p : α × β) :
-    sizeOf p.fst ≤ sizeOf p := by
-  cases p with
-  | mk a b => simp <;> omega
-
-private theorem sizeOf_fst_lt_of_mem {α β : Type} [SizeOf α] [SizeOf β] {p : α × β}
-    {l : List (α × β)} (h : p ∈ l) : sizeOf p.fst < sizeOf l :=
-  Nat.lt_of_le_of_lt (sizeOf_fst_le p) (List.sizeOf_lt_of_mem h)
-
-/-- Two-level version of `sizeOf_snd_lt_of_mem`: for a doubly-nested field
-like `variant`'s `List (String × List (Ty p))`, bounds an element of the
-INNER list against the OUTER list's size. -/
-private theorem sizeOf_lt_of_mem_snd_of_mem {α γ : Type} [SizeOf α] [SizeOf γ]
-    {x : γ} {p : α × List γ} {l : List (α × List γ)} (hx : x ∈ p.snd) (hp : p ∈ l) :
-    sizeOf x < sizeOf l :=
-  Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem hx) (Nat.le_trans (sizeOf_snd_le p) (Nat.le_of_lt (List.sizeOf_lt_of_mem hp)))
-
-/-- `NEList.toList`'s recursion target — every element is either the head
-or in the tail, both strictly smaller than the whole `NEList`. Needed since
-`renderExprSyn`'s `.fn`/`.seq` cases recurse via `cs.toList.map _`. -/
-private theorem sizeOf_lt_of_mem_toList {α : Type} [SizeOf α] {x : α} {xs : NEList α}
-    (h : x ∈ xs.toList) : sizeOf x < sizeOf xs := by
-  cases xs with
-  | mk head tail =>
-    simp only [NEList.toList, List.mem_cons] at h
-    cases h with
-    | inl h => subst h; simp; omega
-    | inr h => exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by simp)
-
 def renderPattern : Fun.Pattern → Doc
   | .pvar _ name => renderName name
   | .pliteral _ lit => renderLit lit

--- a/lean/Malgo/Prelude.lean
+++ b/lean/Malgo/Prelude.lean
@@ -110,6 +110,48 @@ theorem mem_sortAssocAscending {κ α : Type} [Ord κ] {xs : List (κ × α)} {p
     | inl h' => exact List.mem_cons.mpr (Or.inl h')
     | inr h' => exact List.mem_cons.mpr (Or.inr (ih h'))
 
+/-! ## `sizeOf`/termination helpers
+
+Reused across every hand-written `termination_by`/`decreasing_by` proof
+for a `partial def` whose recursion is hidden behind a pair/triple
+destructuring lambda (`fun (k, v) => ...`) or an opaque function call
+before a `.map` (`sortAssocAscending`/`NEList.toList`) — both patterns
+recur throughout the sequent IRs' `object`/`record`/`cocase`-style
+named-fields lists. -/
+
+/-- A pair's second component is never bigger than the pair itself. -/
+theorem sizeOf_snd_le {α β : Type} [SizeOf α] [SizeOf β] (p : α × β) :
+    sizeOf p.snd ≤ sizeOf p := by
+  cases p with
+  | mk a b => simp
+
+theorem sizeOf_snd_lt_of_mem {α β : Type} [SizeOf α] [SizeOf β] {p : α × β}
+    {l : List (α × β)} (h : p ∈ l) : sizeOf p.snd < sizeOf l :=
+  Nat.lt_of_le_of_lt (sizeOf_snd_le p) (List.sizeOf_lt_of_mem h)
+
+/-- Composed via `Nat.le_trans` for the third component of a triple. -/
+theorem sizeOf_snd_snd_lt_of_mem {α β γ : Type} [SizeOf α] [SizeOf β] [SizeOf γ]
+    {p : α × β × γ} {l : List (α × β × γ)} (h : p ∈ l) : sizeOf p.2.2 < sizeOf l :=
+  Nat.lt_of_le_of_lt (Nat.le_trans (sizeOf_snd_le p.2) (sizeOf_snd_le p)) (List.sizeOf_lt_of_mem h)
+
+theorem sizeOf_fst_le {α β : Type} [SizeOf α] [SizeOf β] (p : α × β) :
+    sizeOf p.fst ≤ sizeOf p := by
+  cases p with
+  | mk a b => simp <;> omega
+
+theorem sizeOf_fst_lt_of_mem {α β : Type} [SizeOf α] [SizeOf β] {p : α × β}
+    {l : List (α × β)} (h : p ∈ l) : sizeOf p.fst < sizeOf l :=
+  Nat.lt_of_le_of_lt (sizeOf_fst_le p) (List.sizeOf_lt_of_mem h)
+
+/-- Two-level version of `sizeOf_snd_lt_of_mem`: for a doubly-nested field
+like `List (String × List α)`, bounds an element of the INNER list
+against the OUTER list's size. -/
+theorem sizeOf_lt_of_mem_snd_of_mem {α γ : Type} [SizeOf α] [SizeOf γ]
+    {x : γ} {p : α × List γ} {l : List (α × List γ)} (hx : x ∈ p.snd) (hp : p ∈ l) :
+    sizeOf x < sizeOf l :=
+  Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem hx)
+    (Nat.le_trans (sizeOf_snd_le p) (Nat.le_of_lt (List.sizeOf_lt_of_mem hp)))
+
 /-- Haskell `Data.List.NonEmpty`. -/
 structure NEList (α : Type u) where
   head : α
@@ -133,6 +175,17 @@ def ofList : List α → Option (NEList α)
 instance [Inhabited α] : Inhabited (NEList α) := ⟨⟨default, []⟩⟩
 
 end NEList
+
+/-- `NEList.toList`'s recursion target — every element is either the head
+or in the tail, both strictly smaller than the whole `NEList`. -/
+theorem sizeOf_lt_of_mem_toList {α : Type} [SizeOf α] {x : α} {xs : NEList α}
+    (h : x ∈ xs.toList) : sizeOf x < sizeOf xs := by
+  cases xs with
+  | mk head tail =>
+    simp only [NEList.toList, List.mem_cons] at h
+    cases h with
+    | inl h => subst h; simp; omega
+    | inr h => exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by simp)
 
 /-- Replaces Haskell's `prettyprinter`-based `Pretty`. Rendering is plain
 `String`; layout combinators are introduced only if a golden demands them. -/

--- a/lean/Malgo/Sequent/Core/Full.lean
+++ b/lean/Malgo/Sequent/Core/Full.lean
@@ -82,7 +82,7 @@ private def sym (s : String) : SExpr := .atom (.symbol s)
 
 mutual
 
-partial def Producer.toSExpr : Producer → SExpr
+def Producer.toSExpr : Producer → SExpr
   | .var _ name => Malgo.toSExpr name
   | .literal _ literal => Malgo.toSExpr literal
   | .construct _ tag producers consumers =>
@@ -91,15 +91,24 @@ partial def Producer.toSExpr : Producer → SExpr
   | .lambda _ names statement =>
     .list [sym "lambda", .list (names.map Malgo.toSExpr), statement.toSExpr]
   | .object _ kvs =>
-    .list ((sortAssocAscending kvs).map fun (k, name, statement) =>
-      .list [sym k, .list [Malgo.toSExpr name, statement.toSExpr]])
+    .list ((sortAssocAscending kvs).attach.map fun ⟨kns, hkns⟩ =>
+      .list [sym kns.1, .list [Malgo.toSExpr kns.2.1, kns.2.2.toSExpr]])
   | .«do» _ name statement => .list [sym "do", Malgo.toSExpr name, statement.toSExpr]
   | .mu _ name statement => .list [sym "mu", Malgo.toSExpr name, statement.toSExpr]
   | .cocase _ branches =>
-    .list (sym "cocase" :: branches.map fun (d, vars, s) =>
-      .list [Malgo.toSExpr d, .list (vars.map Malgo.toSExpr), s.toSExpr])
+    .list (sym "cocase" :: branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      .list [Malgo.toSExpr dvs.1, .list (dvs.2.1.map Malgo.toSExpr), dvs.2.2.toSExpr])
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem (mem_sortAssocAscending hkns)) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Consumer.toSExpr : Consumer → SExpr
+def Consumer.toSExpr : Consumer → SExpr
   | .label _ name => Malgo.toSExpr name
   | .apply _ producers consumers =>
     .list [sym "apply", .list (producers.map Producer.toSExpr), .list (consumers.map Consumer.toSExpr)]
@@ -109,8 +118,15 @@ partial def Consumer.toSExpr : Consumer → SExpr
   | .select _ branches => .list (sym "select" :: branches.map Branch.toSExpr)
   | .destructor _ name producers consumer =>
     .list [sym "destructor", Malgo.toSExpr name, .list (producers.map Producer.toSExpr), consumer.toSExpr]
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Statement.toSExpr : Statement → SExpr
+def Statement.toSExpr : Statement → SExpr
   | .cut producer consumer => .list [sym "cut", producer.toSExpr, consumer.toSExpr]
   | .primitive _ name producers consumer =>
     .list [sym "prim", Malgo.toSExpr name, .list (producers.map Producer.toSExpr), consumer.toSExpr]
@@ -120,9 +136,17 @@ partial def Statement.toSExpr : Statement → SExpr
   | .binOp _ op lhs rhs consumer =>
     .list [sym "binop", Malgo.toSExpr op, lhs.toSExpr, rhs.toSExpr, consumer.toSExpr]
   | .ifz _ cond thenS elseS => .list [sym "ifz", cond.toSExpr, thenS.toSExpr, elseS.toSExpr]
+termination_by s => sizeOf s
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Branch.toSExpr : Branch → SExpr
+def Branch.toSExpr : Branch → SExpr
   | .branch _ pattern statement => .list [Malgo.toSExpr pattern, statement.toSExpr]
+termination_by b => sizeOf b
 
 end
 


### PR DESCRIPTION
## Summary
- Removes `partial` from `Sequent/Core/Full.lean`'s mutual `Producer.toSExpr`/`Consumer.toSExpr`/`Statement.toSExpr`/`Branch.toSExpr` block, the next Tier 3 item from #359 after Debug/PrettyIR.lean (#367).
- Same underlying shape as `renderFullProd`/`renderFullBranch` already fixed in #367: `.object`'s `sortAssocAscending`-filtered triple-destructuring lambda and `.cocase`'s plain triple-destructuring lambda both hid the recursive call from the termination checker. Fixed with `.attach` + explicit projections and per-function `termination_by`/`decreasing_by`, reusing `mem_sortAssocAscending`/`sizeOf_snd_snd_lt_of_mem`.
- Also lands a previously-uncommitted follow-up to #367: moves the `sizeOf_*`/`mem_sortAssocAscending`/`sizeOf_lt_of_mem_toList` helper lemmas from `Debug/PrettyIR.lean` (where they were `private`) into `Prelude.lean` as public theorems, since this file and remaining Tier 3 files need the same toolkit.
- No new behavior, no new proof obligations beyond termination — mechanical Tier 3 cleanup.

## Test plan
- [x] `lake build Malgo.Sequent.Core.Full` (isolated)
- [x] `lake build` (full, 128/128)
- [x] `lake test` (532/532 goldens + 94/94 infer)
- [x] `grep -n "partial def\|sorry" lean/Malgo/Sequent/Core/Full.lean` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)