### PR TITLE
refactor(lean): de-partialize Flat.lean and Join.lean's toSExpr families (#359, Tier 3)

### DIFF
--- a/lean/Malgo/Sequent/Core/Flat.lean
+++ b/lean/Malgo/Sequent/Core/Flat.lean
@@ -92,7 +92,7 @@ private def sym (s : String) : SExpr := .atom (.symbol s)
 
 mutual
 
-partial def Producer.toSExpr : Producer → SExpr
+def Producer.toSExpr : Producer → SExpr
   | .var _ name => Malgo.toSExpr name
   | .literal _ literal => Malgo.toSExpr literal
   | .construct _ tag producers consumers =>
@@ -101,14 +101,23 @@ partial def Producer.toSExpr : Producer → SExpr
   | .lambda _ names statement =>
     .list [sym "lambda", .list (names.map Malgo.toSExpr), statement.toSExpr]
   | .object _ kvs =>
-    .list ((sortAssocAscending kvs).map fun (k, name, statement) =>
-      .list [sym k, .list [Malgo.toSExpr name, statement.toSExpr]])
+    .list ((sortAssocAscending kvs).attach.map fun ⟨kns, hkns⟩ =>
+      .list [sym kns.1, .list [Malgo.toSExpr kns.2.1, kns.2.2.toSExpr]])
   | .mu _ name statement => .list [sym "mu", Malgo.toSExpr name, statement.toSExpr]
   | .cocase _ branches =>
-    .list (sym "cocase" :: branches.map fun (d, vars, s) =>
-      .list [Malgo.toSExpr d, .list (vars.map Malgo.toSExpr), s.toSExpr])
+    .list (sym "cocase" :: branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      .list [Malgo.toSExpr dvs.1, .list (dvs.2.1.map Malgo.toSExpr), dvs.2.2.toSExpr])
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem (mem_sortAssocAscending hkns)) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Consumer.toSExpr : Consumer → SExpr
+def Consumer.toSExpr : Consumer → SExpr
   | .label _ name => Malgo.toSExpr name
   | .apply _ producers consumers =>
     .list [sym "apply", .list (producers.map Producer.toSExpr), .list (consumers.map Consumer.toSExpr)]
@@ -118,8 +127,15 @@ partial def Consumer.toSExpr : Consumer → SExpr
   | .select _ branches => .list (sym "select" :: branches.map Branch.toSExpr)
   | .destructor _ name producers consumer =>
     .list [sym "destructor", Malgo.toSExpr name, .list (producers.map Producer.toSExpr), consumer.toSExpr]
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Statement.toSExpr : Statement → SExpr
+def Statement.toSExpr : Statement → SExpr
   | .cut producer consumer => .list [sym "cut", producer.toSExpr, consumer.toSExpr]
   | .join _ name consumer statement =>
     .list [sym "join", Malgo.toSExpr name, consumer.toSExpr, statement.toSExpr]
@@ -131,9 +147,17 @@ partial def Statement.toSExpr : Statement → SExpr
   | .binOp _ op lhs rhs consumer =>
     .list [sym "binop", Malgo.toSExpr op, lhs.toSExpr, rhs.toSExpr, consumer.toSExpr]
   | .ifz _ cond thenS elseS => .list [sym "ifz", cond.toSExpr, thenS.toSExpr, elseS.toSExpr]
+termination_by s => sizeOf s
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Branch.toSExpr : Branch → SExpr
+def Branch.toSExpr : Branch → SExpr
   | .branch _ pattern statement => .list [Malgo.toSExpr pattern, statement.toSExpr]
+termination_by b => sizeOf b
 
 end
 

--- a/lean/Malgo/Sequent/Core/Join.lean
+++ b/lean/Malgo/Sequent/Core/Join.lean
@@ -93,7 +93,7 @@ private def sym (s : String) : SExpr := .atom (.symbol s)
 
 mutual
 
-partial def Producer.toSExpr : Producer → SExpr
+def Producer.toSExpr : Producer → SExpr
   | .var _ name => Malgo.toSExpr name
   | .literal _ literal => Malgo.toSExpr literal
   | .construct _ tag producers consumers =>
@@ -102,14 +102,23 @@ partial def Producer.toSExpr : Producer → SExpr
   | .lambda _ names statement =>
     .list [sym "lambda", .list (names.map Malgo.toSExpr), statement.toSExpr]
   | .object _ kvs =>
-    .list ((sortAssocAscending kvs).map fun (k, name, statement) =>
-      .list [sym k, .list [Malgo.toSExpr name, statement.toSExpr]])
+    .list ((sortAssocAscending kvs).attach.map fun ⟨kns, hkns⟩ =>
+      .list [sym kns.1, .list [Malgo.toSExpr kns.2.1, kns.2.2.toSExpr]])
   | .mu _ name statement => .list [sym "mu", Malgo.toSExpr name, statement.toSExpr]
   | .cocase _ branches =>
-    .list (sym "cocase" :: branches.map fun (d, vars, s) =>
-      .list [Malgo.toSExpr d, .list (vars.map Malgo.toSExpr), s.toSExpr])
+    .list (sym "cocase" :: branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      .list [Malgo.toSExpr dvs.1, .list (dvs.2.1.map Malgo.toSExpr), dvs.2.2.toSExpr])
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem (mem_sortAssocAscending hkns)) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Consumer.toSExpr : Consumer → SExpr
+def Consumer.toSExpr : Consumer → SExpr
   | .label _ name => Malgo.toSExpr name
   | .apply _ producers consumers =>
     .list [sym "apply", .list (producers.map Producer.toSExpr), .list (consumers.map Malgo.toSExpr)]
@@ -119,8 +128,15 @@ partial def Consumer.toSExpr : Consumer → SExpr
   | .select _ branches => .list (sym "select" :: branches.map Branch.toSExpr)
   | .destructor _ name producers consumer =>
     .list [sym "destructor", Malgo.toSExpr name, .list (producers.map Producer.toSExpr), Malgo.toSExpr consumer]
+termination_by c => sizeOf c
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Statement.toSExpr : Statement → SExpr
+def Statement.toSExpr : Statement → SExpr
   | .cut producer consumer => .list [sym "cut", producer.toSExpr, Malgo.toSExpr consumer]
   | .join _ name consumer statement =>
     .list [sym "join", Malgo.toSExpr name, consumer.toSExpr, statement.toSExpr]
@@ -132,9 +148,17 @@ partial def Statement.toSExpr : Statement → SExpr
   | .binOp _ op lhs rhs consumer =>
     .list [sym "binop", Malgo.toSExpr op, lhs.toSExpr, rhs.toSExpr, Malgo.toSExpr consumer]
   | .ifz _ cond thenS elseS => .list [sym "ifz", cond.toSExpr, thenS.toSExpr, elseS.toSExpr]
+termination_by s => sizeOf s
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def Branch.toSExpr : Branch → SExpr
+def Branch.toSExpr : Branch → SExpr
   | .branch _ pattern statement => .list [Malgo.toSExpr pattern, statement.toSExpr]
+termination_by b => sizeOf b
 
 end
 


### PR DESCRIPTION
## Summary
- Removes `partial` from the mutual `Producer.toSExpr`/`Consumer.toSExpr`/`Statement.toSExpr`/`Branch.toSExpr` blocks in both `Sequent/Core/Flat.lean` and `Sequent/Core/Join.lean`, following #368's fix for `Full.lean`.
- Same root cause both times: `.object`/`.cocase` triple-destructuring lambdas hid the recursive call from the termination checker. Fixed with `.attach` + explicit projections and per-function `termination_by`/`decreasing_by`, reusing `mem_sortAssocAscending`/`sizeOf_snd_snd_lt_of_mem` from `Prelude.lean`.
- Closes out the "`Sequent/Core/{Full,Flat,Join}.lean`'s mutual toSExpr families" item from #359's remaining Tier 3 list.
- The larger `flatStatement`/`flatProducer`/`flatConsumer` (Flat.lean) and `joinStatement`/`joinProducer`/`joinConsumer` (Join.lean) mutual passes intentionally stay `partial` — their recursive calls reconstruct rewritten terms (e.g. substituting a fresh var for a non-value producer) rather than recursing into a structural sub-term, so they'd need a real decreasing-measure argument, out of scope for Tier 3's "no new theorems, mechanical cleanup only."

## Test plan
- [x] `lake build Malgo.Sequent.Core.Flat` / `Malgo.Sequent.Core.Join` (isolated)
- [x] `lake build` (full, 128/128)
- [x] `lake test` (532/532 goldens + 94/94 infer)
- [x] `grep` confirms the four toSExpr functions are no longer `partial` in either file; no `sorry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)