### PR TITLE
ci(actions): add actions-timeline job to build and lean workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,3 +238,12 @@ jobs:
           # which is slower than the arena the timeout was first tuned for.
           CASE_TIMEOUT: 30
         run: scripts/zig-golden.sh
+
+  actions-timeline:
+    needs: [build, selfhost-golden, selfhost-level2, zig-golden]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -141,3 +141,12 @@ jobs:
         run: |
           MALGO=lean/.lake/build/bin/malgo MALGO_WORK_DIR=.malgo-work-lean \
           bash scripts/zig-golden.sh
+
+  actions-timeline:
+    needs: [gates, lean-build, lean-parity, lean-selfhost, lean-zig-golden]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: Kesin11/actions-timeline@7bf79990b7c09f5dfb570ac30b814ca597bd538e # v3.1.1


### PR DESCRIPTION
## Summary
- Add an aggregator `actions-timeline` job to `build.yml` and `lean.yml`, depending on all existing jobs via `needs:`, that runs [Kesin11/actions-timeline](https://github.com/Kesin11/actions-timeline) (`v3.1.1`, pinned by SHA) to render a mermaid-gantt job/step timeline in the workflow run summary
- Both workflows run multiple long (30–60min) parallel/gated jobs, so per-run timing visibility helps spot bottlenecks (cf. #370's selfhost-level2 parallelization)
- `if: always()` on the new job so it still runs when an upstream job is *skipped* (e.g. `lean.yml`'s milestone-gated jobs), not just when one fails
- Only the new job gets `permissions: actions: read` (the permission the action's README calls out as required) — no existing job is touched

## Test plan
- [x] `actionlint` (via `mise x actionlint -- actionlint -shellcheck= .github/workflows/build.yml .github/workflows/lean.yml`) passes on both modified files
- [ ] After merge/on this PR's CI run, confirm the `actions-timeline` job appears in both `build` and `lean` workflow runs and its Summary tab shows the mermaid gantt timeline
- [ ] Confirm the `lean` workflow's `actions-timeline` job still runs (and renders a timeline) on a run where a milestone-gated job (`lean-parity`/`lean-selfhost`/`lean-zig-golden`) is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)