### PR TITLE
refactor(lean): de-partialize Normalize.lean's substStatement family (#359)

### DIFF
--- a/lean/Malgo/Backend/Zig/Normalize.lean
+++ b/lean/Malgo/Backend/Zig/Normalize.lean
@@ -33,7 +33,7 @@ private def substName (src tgt n : Name) : Name :=
 mutual
 
 /-- Substitute one `Name` for another throughout a `Statement`. -/
-partial def substStatement (src tgt : Name) : Statement → Statement
+def substStatement (src tgt : Name) : Statement → Statement
   | .cut p k => .cut (substProducer src tgt p) (substName src tgt k)
   -- `name` is a fresh binder here; it can never equal `src` because `src`
   -- was already bound (and eliminated) further out.
@@ -48,20 +48,32 @@ partial def substStatement (src tgt : Name) : Statement → Statement
     .binOp range op (substProducer src tgt lhs) (substProducer src tgt rhs) (substName src tgt k)
   | .ifz range cond t e =>
     .ifz range (substProducer src tgt cond) (substStatement src tgt t) (substStatement src tgt e)
+termination_by s => sizeOf s
 
-partial def substProducer (src tgt : Name) : Producer → Producer
+def substProducer (src tgt : Name) : Producer → Producer
   | .var range n => .var range (substName src tgt n)
   | .literal range lit => .literal range lit
   | .construct range tag ps ks =>
     .construct range tag (ps.map (substProducer src tgt)) (ks.map (substName src tgt))
   | .lambda range names stmt => .lambda range names (substStatement src tgt stmt)
   | .object range fields =>
-    .object range (fields.map (fun (k, ret, s) => (k, ret, substStatement src tgt s)))
+    .object range (fields.attach.map fun ⟨krs, hkrs⟩ =>
+      (krs.1, krs.2.1, substStatement src tgt krs.2.2))
   | .mu range name stmt => .mu range name (substStatement src tgt stmt)
   | .cocase range branches =>
-    .cocase range (branches.map (fun (d, vs, s) => (d, vs, substStatement src tgt s)))
+    .cocase range (branches.attach.map fun ⟨dvs, hdvs⟩ =>
+      (dvs.1, dvs.2.1, substStatement src tgt dvs.2.2))
+termination_by p => sizeOf p
+decreasing_by
+  all_goals simp_wf
+  all_goals first
+    | omega
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hkrs) (by omega)
+    | exact Nat.lt_of_lt_of_le (sizeOf_snd_snd_lt_of_mem hdvs) (by omega)
+    | (rename_i h
+       exact Nat.lt_of_lt_of_le (List.sizeOf_lt_of_mem h) (by omega))
 
-partial def substConsumer (src tgt : Name) : Consumer → Consumer
+def substConsumer (src tgt : Name) : Consumer → Consumer
   | .label range n => .label range (substName src tgt n)
   | .apply range ps ks =>
     .apply range (ps.map (substProducer src tgt)) (ks.map (substName src tgt))
@@ -71,9 +83,11 @@ partial def substConsumer (src tgt : Name) : Consumer → Consumer
   | .select range branches => .select range (branches.map (substBranch src tgt))
   | .destructor range name ps k =>
     .destructor range name (ps.map (substProducer src tgt)) (substName src tgt k)
+termination_by c => sizeOf c
 
-partial def substBranch (src tgt : Name) : Branch → Branch
+def substBranch (src tgt : Name) : Branch → Branch
   | .branch range pat stmt => .branch range pat (substStatement src tgt stmt)
+termination_by b => sizeOf b
 
 end
 


### PR DESCRIPTION
## Summary
- Removes `partial` from `Normalize.lean`'s pure substitution mutual (`substStatement`/`substProducer`/`substConsumer`/`substBranch`) — same recipe as this session's other Tier 3 fixes.
- `normalizeStatement`/`normalizeProducer`/`normalizeConsumer`/`normalizeBranch` (the actual Mu/Label-forwarding-Join elimination pass) deliberately stay `partial`: they recurse on `substStatement x k s`, a rewritten term rather than a structural sub-term. A naive `sizeOf`-based measure may be outright false here, not just hard to prove — `sizeOf (5 : Nat) = 5` (confirmed empirically: `Nat`'s `sizeOf` is the identity), so any structure holding a monotonically-growing uniq counter (which `Id.sort`'s `.internal`/`.temporal` variants do) can have its `sizeOf` *increase* after substitution swaps an early name for a later one. A real termination argument would need a custom substitution-invariant node-count measure — meaningfully more machinery than anything else in Tier 3, closer to the already-ruled-out `flatStatement`/`joinStatement` passes. Scoped out, not silently dropped — recorded in the commit message and will be reflected in the issue.

## Test plan
- [x] `lake build Malgo.Backend.Zig.Normalize` (isolated)
- [x] `lake build` (full, 128/128)
- [x] `lake test` (532/532 goldens + 94/94 infer)
- [x] `grep -n "partial def"` shows only the four `normalize*` functions remain `partial`

🤖 Generated with [Claude Code](https://claude.com/claude-code)