### PR TITLE
feat(lean): give ModuleName a Std.TransCmp instance (#359, Tier 2 foundational gap)

### DIFF
--- a/lean/Malgo/Module.lean
+++ b/lean/Malgo/Module.lean
@@ -29,6 +29,11 @@ instance : BEq ArtifactPath := ⟨fun a b => a.relPath == b.relPath⟩
 
 instance : Ord ArtifactPath := ⟨fun a b => compare a.relPath b.relPath⟩
 
+/-- Same "compare via a projection" trick as `Path`'s `Std.TransOrd`
+instance: `ArtifactPath`'s `Ord` is exactly `compareOn relPath`. -/
+instance : Std.TransOrd ArtifactPath :=
+  inferInstanceAs (Std.TransCmp (compareOn ArtifactPath.relPath))
+
 end ArtifactPath
 
 inductive ModuleName where
@@ -42,6 +47,43 @@ inductive ModuleName where
   deriving BEq, Ord, Repr
 
 namespace ModuleName
+
+/-- `deriving Ord`'s generated `compare` is a plain `match` on both
+constructors, so it iota-reduces under `cases <;> simp` exactly like
+`Option`'s hand-written instance (Std's own template for a small sum
+type) — the ordering laws hold for the same reason `Option`'s do,
+falling through to `String`'s/`ArtifactPath`'s `Std.TransOrd` on the
+three same-constructor cases.
+
+Lean's typeclass search indexes instances by their literal head symbol,
+not up to unfolding: `Std.TransOrd String`'s registered head is
+`@Ord.compare String _`, so once `Ord.compare`'s cascading unfold (below)
+reduces every same-constructor case down to a raw `String.compare` call
+(`ModuleName`/`ArtifactPath`'s fields all bottom out at `String`),
+searches for `Std.TransCmp String.compare` miss it even though the two
+are definitionally identical. These two instances re-register the same
+proof under the head that's actually needed. -/
+instance : Std.OrientedCmp String.compare :=
+  inferInstanceAs (Std.OrientedCmp (compare : String → String → Ordering))
+
+instance : Std.TransCmp String.compare :=
+  inferInstanceAs (Std.TransCmp (compare : String → String → Ordering))
+
+instance : Std.OrientedOrd ModuleName where
+  eq_swap {a b} := by
+    cases a <;> cases b <;>
+      simp only [Ord.compare, instOrdModuleName.ord, Ordering.then_eq] <;>
+      first
+        | rfl
+        | exact Std.OrientedCmp.eq_swap
+
+instance : Std.TransOrd ModuleName where
+  isLE_trans {a b c} hab hbc := by
+    cases a <;> cases b <;> cases c <;>
+      (try (simp_all [Ord.compare, instOrdModuleName.ord, Ordering.then_eq]; done))
+    all_goals
+      simp only [Ord.compare, instOrdModuleName.ord, Ordering.then_eq] at *
+      apply Std.TransCmp.isLE_trans <;> assumption
 
 def toStr : ModuleName → String
   | .moduleName raw => raw

--- a/lean/Malgo/Path.lean
+++ b/lean/Malgo/Path.lean
@@ -25,6 +25,14 @@ instance : BEq (Path b t) := ⟨fun a b => a.toFilePath == b.toFilePath⟩
 
 instance : Ord (Path b t) := ⟨fun a b => compare a.toFilePath.toString b.toFilePath.toString⟩
 
+/-- `Path`'s `Ord` is exactly `compareOn (·.toFilePath.toString)`, so its
+`Std.TransCmp` proof obligations are inherited for free from `String`'s
+(via `Std`'s generic "compare via a projection" combinator) — riding on
+this unblocks any `Std.TreeMap`/`TreeSet` proof keyed by `Path`,
+`ArtifactPath`, or (transitively) `ModuleName`. -/
+instance : Std.TransOrd (Path b t) :=
+  inferInstanceAs (Std.TransCmp (compareOn (fun p : Path b t => p.toFilePath.toString)))
+
 instance : ToString (Path b t) := ⟨fun p => p.toFilePath.toString⟩
 
 private def dropTrailingPathSeparator (fp : System.FilePath) : System.FilePath :=


### PR DESCRIPTION
## Summary
- Closes the foundational gap #359 flagged: `ModuleName` (the `Std.TreeMap`/`TreeSet` key type used throughout the compiler) had none of the ordering typeclasses (`Std.TransCmp`/`Std.OrientedCmp`) that Std's container lemmas require — blocking any proof over `Std.TreeSet`/`TreeMap`-keyed data project-wide, not just `Query/Engine.lean`'s `reverseDepClosure`.
- `Path b t` → `ArtifactPath` → `ModuleName`, each link riding on an existing Std combinator: the first two are `compareOn`-shaped projections (one-liners via `inferInstanceAs`), and `ModuleName`'s 3-constructor derived `Ord` gets a genuine (mechanical) case-split proof following `Option`'s hand-written instance as the in-tree template.
- Non-obvious wrinkle found and fixed along the way: once `Ord.compare` unfolds every same-constructor case down to a raw `String.compare` call, typeclass search for `Std.TransCmp String.compare` misses the existing `Std.TransOrd String` instance (discrimination-tree indexing is by literal head symbol, not up to unfolding). Fixed with two one-line bridging instances re-registering the same proof under the head that's actually needed.
- Verified beyond build/test: a real `Std.TreeMap` lemma requiring `[TransCmp cmp]` (`getElem?_insert_self`) now type-checks against a `ModuleName`-keyed `Std.TreeMap`.

This only clears the typeclass prerequisite — `Query/Engine.lean`'s actual invariant (monotonicity + termination on cyclic graphs) still needs its own termination argument for the BFS fixpoint, tracked separately in #359.

## Test plan
- [x] `lake build Malgo.Path` / `Malgo.Module` (isolated)
- [x] `lake build` (full, 128/128)
- [x] `lake test` (532/532 goldens + 94/94 infer)
- [x] Standalone check: `Std.TreeMap.getElem?_insert_self` type-checks for a `ModuleName`-keyed map
- [x] `grep -n "sorry"` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)