### PR TITLE
feat(lean): prove reverseDepClosureGo termination (#359, Tier 2)

### DIFF
--- a/lean/Malgo/Prelude.lean
+++ b/lean/Malgo/Prelude.lean
@@ -1,3 +1,5 @@
+import Std.Data.TreeSet
+
 /-! Port of `src/Malgo/Prelude.hs`: source positions, ranges, the `Pretty`
 class, and the compiler-wide `Flag` record. The Haskell module is mostly
 re-exports; only the project-defined pieces are ported. -/
@@ -109,6 +111,108 @@ theorem mem_sortAssocAscending {κ α : Type} [Ord κ] {xs : List (κ × α)} {p
     cases mem_insertAssocAscending x (xs.foldr insertAssocAscending []) h with
     | inl h' => exact List.mem_cons.mpr (Or.inl h')
     | inr h' => exact List.mem_cons.mpr (Or.inr (ih h'))
+
+/-! ## `Std.TreeSet` size/membership helpers
+
+`Std.TreeSet`/`TreeMap` expose no direct "membership-subset implies size
+monotonicity" lemma (`s ⊆ t → s.size ≤ t.size`), and no `TreeSet`-level
+extensionality principle usable without `LawfulEqCmp` (which a key type
+like `ModuleName` can genuinely fail — two `ModuleName.artifact` values
+with the same `relPath` but different other `ArtifactPath` fields compare
+`.eq` without being `=`). Both facts below are derived purely from
+existing size/diff/inter identities (`isEmpty_diff_iff`,
+`size_diff_add_size_inter_eq_size_left`, `size_inter_le_size_right`,
+`size_erase`), so they need only `[Std.TransCmp cmp]`. -/
+
+theorem Std.TreeSet.size_le_of_forall_mem {α : Type} {cmp : α → α → Ordering}
+    [Std.TransCmp cmp] {s t : Std.TreeSet α cmp} (h : ∀ x, x ∈ s → x ∈ t) :
+    s.size ≤ t.size := by
+  have hempty : (s \ t).isEmpty = true := Std.TreeSet.isEmpty_diff_iff.mpr h
+  have hsize0 : (s \ t).size = 0 := by
+    have hb := Std.TreeSet.isEmpty_eq_size_eq_zero (t := s \ t)
+    rw [hempty] at hb
+    simpa using hb.symm
+  have heq := Std.TreeSet.size_diff_add_size_inter_eq_size_left (t₁ := s) (t₂ := t)
+  rw [hsize0, Nat.zero_add] at heq
+  calc s.size = (s ∩ t).size := heq.symm
+    _ ≤ t.size := Std.TreeSet.size_inter_le_size_right
+
+/-- Strict version: needed whenever a decreasing measure is a `TreeSet`
+size that must shrink by at least the one known witness `x`. -/
+theorem Std.TreeSet.size_lt_of_forall_mem_of_not_mem {α : Type} {cmp : α → α → Ordering}
+    [Std.TransCmp cmp] {s t : Std.TreeSet α cmp} {x : α}
+    (h : ∀ y, y ∈ s → y ∈ t) (hx : x ∈ t) (hxs : x ∉ s) :
+    s.size < t.size := by
+  have hle : s.size ≤ (t.erase x).size := by
+    apply Std.TreeSet.size_le_of_forall_mem
+    intro y hy
+    rw [Std.TreeSet.mem_erase]
+    refine ⟨?_, h y hy⟩
+    intro hceq
+    exact hxs ((Std.TreeSet.mem_congr hceq).mpr hy)
+  have hcontains : t.contains x = true := Std.TreeSet.mem_iff_contains.mp hx
+  have herase : (t.erase x).size < t.size := by
+    rw [Std.TreeSet.size_erase, if_pos hcontains]
+    have hpos : 0 < t.size := by
+      rcases Nat.eq_zero_or_pos t.size with h0 | hpos
+      · exfalso
+        have hempty : t.isEmpty = true := by
+          simp [Std.TreeSet.isEmpty_eq_size_eq_zero, h0]
+        rw [Std.TreeSet.isEmpty_iff_forall_not_mem] at hempty
+        exact hempty x hx
+      · exact hpos
+    omega
+  omega
+
+/-- Membership in a `cond`-filtered insert-`foldl` (the
+`depsOf.foldl (init:={}) fun s m ds => if cond m ds then s.insert m else
+s` shape `Query.Engine.reverseDepClosureGo` and similar passes build a
+result set with) implies membership in the seed set or a witness pair
+from the source list — analogous to `mem_sortAssocAscending` above, but
+for `Std.TreeMap.foldl`/`Std.TreeSet.insert` instead of `List`. -/
+theorem mem_foldl_filter_insert {α β : Type} {cmp : α → α → Ordering} [Std.TransCmp cmp]
+    (cond : α × β → Bool) (x : α) :
+    ∀ (xs : List (α × β)) (s0 : Std.TreeSet α cmp),
+      x ∈ xs.foldl (fun s p => if cond p then s.insert p.1 else s) s0 →
+      x ∈ s0 ∨ ∃ p ∈ xs, cond p = true ∧ cmp p.1 x = .eq
+  | [], s0, h => Or.inl h
+  | p :: rest, s0, h => by
+    simp only [List.foldl_cons] at h
+    rcases mem_foldl_filter_insert cond x rest _ h with h1 | h2
+    · by_cases hc : cond p = true
+      · simp only [hc, if_true] at h1
+        rw [Std.TreeSet.mem_insert] at h1
+        rcases h1 with h1 | h1
+        · exact Or.inr ⟨p, List.mem_cons_self .., hc, h1⟩
+        · exact Or.inl h1
+      · simp only [hc] at h1
+        exact Or.inl h1
+    · obtain ⟨q, hq, hqc, hqx⟩ := h2
+      exact Or.inr ⟨q, List.mem_cons_of_mem _ hq, hqc, hqx⟩
+
+theorem mem_foldl_insert_of_mem_init {α β : Type} {cmp : α → α → Ordering} [Std.TransCmp cmp] :
+    ∀ (xs : List (α × β)) (s0 : Std.TreeSet α cmp) (x : α), x ∈ s0 →
+      x ∈ xs.foldl (fun s p => s.insert p.1) s0
+  | [], s0, x, h => h
+  | p :: rest, s0, x, h => by
+    simp only [List.foldl_cons]
+    exact mem_foldl_insert_of_mem_init rest (s0.insert p.1) x
+      (by rw [Std.TreeSet.mem_insert]; exact Or.inr h)
+
+/-- Companion to `mem_foldl_filter_insert`: a plain (unfiltered)
+insert-`foldl` carries every key from its source list forward. -/
+theorem mem_foldl_insert_forward {α β : Type} {cmp : α → α → Ordering} [Std.TransCmp cmp]
+    (x : α) :
+    ∀ (xs : List (α × β)) (s0 : Std.TreeSet α cmp) (p : α × β), p ∈ xs → cmp p.1 x = .eq →
+      x ∈ xs.foldl (fun s p => s.insert p.1) s0
+  | p :: rest, s0, q, hq, heq => by
+    rcases List.mem_cons.mp hq with hq | hq
+    · simp only [List.foldl_cons]
+      apply mem_foldl_insert_of_mem_init rest (s0.insert p.1) x
+      rw [Std.TreeSet.mem_insert]
+      exact Or.inl (hq ▸ heq)
+    · simp only [List.foldl_cons]
+      exact mem_foldl_insert_forward x rest (s0.insert p.1) q hq heq
 
 /-! ## `sizeOf`/termination helpers
 

--- a/lean/Malgo/Query/Engine.lean
+++ b/lean/Malgo/Query/Engine.lean
@@ -247,17 +247,148 @@ def updateSource (db : QueryDB) (modName : ModuleName) (path : System.FilePath) 
     IO Unit :=
   db.sourceMap.modify (·.insert modName (path, text))
 
+/-- Every key `depsOf` maps. `reverseDepClosureGo`'s `acc`/`frontier`/`next`
+sets are always drawn from this fixed universe, which is what makes
+termination provable: `acc`'s complement within it can only shrink. -/
+private def depsUniverse (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName)) :
+    Std.TreeSet ModuleName :=
+  depsOf.foldl (init := (∅ : Std.TreeSet ModuleName)) fun s m _ => s.insert m
+
+/-- One step of the reverse-dependency BFS: every module (other than
+`target`, not already in `acc`) whose own deps intersect `frontier`.
+Factored out of `reverseDepClosureGo` so its termination proof can name
+this computation directly instead of re-deriving it from an inline
+`let`. -/
+private def nextOf (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
+    (target : ModuleName) (acc frontier : Std.TreeSet ModuleName) : Std.TreeSet ModuleName :=
+  depsOf.foldl (init := (∅ : Std.TreeSet ModuleName)) fun s m ds =>
+    if m != target && !acc.contains m && ds.toList.any frontier.contains
+    then s.insert m else s
+
+private theorem mem_nextOf_elim (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
+    (target : ModuleName) (acc frontier : Std.TreeSet ModuleName) {x : ModuleName}
+    (hx : x ∈ nextOf depsOf target acc frontier) :
+    ∃ p ∈ depsOf.toList,
+      (p.1 != target && !acc.contains p.1 && p.2.toList.any frontier.contains) = true ∧
+        compare p.1 x = .eq := by
+  unfold nextOf at hx
+  rw [Std.TreeMap.foldl_eq_foldl_toList] at hx
+  rcases mem_foldl_filter_insert _ x depsOf.toList (∅ : Std.TreeSet ModuleName) hx with h1 | h2
+  · simp at h1
+  · exact h2
+
+/-- Every module `nextOf` adds is a key of `depsOf`, hence in
+`depsUniverse`. -/
+private theorem next_subset_universe (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
+    (target : ModuleName) (acc frontier : Std.TreeSet ModuleName) {x : ModuleName}
+    (hx : x ∈ nextOf depsOf target acc frontier) :
+    x ∈ depsUniverse depsOf := by
+  obtain ⟨p, hp, _hpc, hpx⟩ := mem_nextOf_elim depsOf target acc frontier hx
+  have hkey : p.1 ∈ depsUniverse depsOf := by
+    unfold depsUniverse
+    rw [Std.TreeMap.foldl_eq_foldl_toList]
+    exact mem_foldl_insert_forward p.1 depsOf.toList (∅ : Std.TreeSet ModuleName) p hp
+      Std.ReflCmp.compare_self
+  exact (Std.TreeSet.mem_congr hpx).mp hkey
+
+/-- Every module `nextOf` adds is disjoint from the current `acc` (the
+filter's own `!acc.contains m` guard). -/
+private theorem next_disjoint_acc (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
+    (target : ModuleName) (acc frontier : Std.TreeSet ModuleName) {x : ModuleName}
+    (hx : x ∈ nextOf depsOf target acc frontier) :
+    x ∉ acc := by
+  obtain ⟨p, _hp, hpc, hpx⟩ := mem_nextOf_elim depsOf target acc frontier hx
+  have hnc : ¬ acc.contains p.1 := by
+    have h := hpc
+    simp only [Bool.and_eq_true, Bool.not_eq_true'] at h
+    simp [h.1.2]
+  rw [Std.TreeSet.mem_iff_contains, ← Std.TreeSet.contains_congr hpx]
+  simpa using hnc
+
+/-- The decreasing measure `reverseDepClosureGo`'s termination proof
+needs: adding a nonempty, `acc`-disjoint `next` (drawn from the fixed
+`depsUniverse`) strictly shrinks `acc`'s complement within that universe.
+Built from `Std.TreeSet.size_lt_of_forall_mem_of_not_mem` (`Prelude.lean`)
+with `next`'s own witness element as the one known shrinking point. -/
+private theorem depsUniverse_diff_acc_union_next_lt
+    (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
+    (target : ModuleName) (acc frontier : Std.TreeSet ModuleName)
+    (hne : ¬ (nextOf depsOf target acc frontier).isEmpty) :
+    (depsUniverse depsOf \ (acc.union (nextOf depsOf target acc frontier))).size <
+      (depsUniverse depsOf \ acc).size := by
+  have hne' : (nextOf depsOf target acc frontier).isEmpty = false := by
+    cases h : (nextOf depsOf target acc frontier).isEmpty with
+    | true => exact absurd h hne
+    | false => rfl
+  obtain ⟨x, hxnext⟩ := Std.TreeSet.isEmpty_eq_false_iff_exists_mem.mp hne'
+  have hxu : x ∈ depsUniverse depsOf := next_subset_universe depsOf target acc frontier hxnext
+  have hxacc : x ∉ acc := next_disjoint_acc depsOf target acc frontier hxnext
+  have hxdiff : x ∈ depsUniverse depsOf \ acc := Std.TreeSet.mem_diff_iff.mpr ⟨hxu, hxacc⟩
+  refine Std.TreeSet.size_lt_of_forall_mem_of_not_mem
+    (s := depsUniverse depsOf \ (acc.union (nextOf depsOf target acc frontier)))
+    (t := depsUniverse depsOf \ acc) (x := x) ?_ hxdiff ?_
+  · intro y hy
+    rw [Std.TreeSet.mem_diff_iff] at hy ⊢
+    refine ⟨hy.1, ?_⟩
+    intro hyacc
+    exact hy.2 (Std.TreeSet.mem_union_of_left hyacc)
+  · rw [Std.TreeSet.mem_diff_iff]
+    intro hcon
+    exact hcon.2 (Std.TreeSet.mem_union_of_right hxnext)
+
 /-- Transitive set of modules depending on `target`, from a forward dep-edge
 map `M ↦ M's deps`. Excludes `target`. Pure — unit-testable without a
-populated `QueryDB` (port of `reverseDepClosure`). -/
-private partial def reverseDepClosureGo (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
+populated `QueryDB` (port of `reverseDepClosure`).
+
+Terminates because `depsUniverse depsOf \ acc` strictly shrinks whenever
+`nextOf` is nonempty (`depsUniverse_diff_acc_union_next_lt`), and
+`frontier.size` strictly shrinks to 0 on the one further step where
+`nextOf` is empty (`acc` unchanged, `frontier` becomes that empty
+`next`) — a lexicographic pair of the two. -/
+private def reverseDepClosureGo (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
     (target : ModuleName) (acc frontier : Std.TreeSet ModuleName) : Std.TreeSet ModuleName :=
   if frontier.isEmpty then acc
   else
-    let next : Std.TreeSet ModuleName := depsOf.foldl (init := {}) fun s m ds =>
-      if m != target && !acc.contains m && ds.toList.any frontier.contains
-      then s.insert m else s
+    let next := nextOf depsOf target acc frontier
     reverseDepClosureGo depsOf target (acc.union next) next
+termination_by ((depsUniverse depsOf \ acc).size, frontier.size)
+decreasing_by
+  rename_i hfrontier
+  simp only [Bool.not_eq_true] at hfrontier
+  cases hemp : (nextOf depsOf target acc frontier).isEmpty with
+  | false =>
+    apply Prod.Lex.left
+    exact depsUniverse_diff_acc_union_next_lt depsOf target acc frontier (by simp [hemp])
+  | true =>
+    have hle1 : (depsUniverse depsOf \ (acc.union (nextOf depsOf target acc frontier))).size ≤
+        (depsUniverse depsOf \ acc).size := by
+      apply Std.TreeSet.size_le_of_forall_mem
+      intro y hy
+      rw [Std.TreeSet.mem_diff_iff] at hy ⊢
+      exact ⟨hy.1, fun hcon => hy.2 (Std.TreeSet.mem_union_of_left hcon)⟩
+    have hle2 : (depsUniverse depsOf \ acc).size ≤
+        (depsUniverse depsOf \ (acc.union (nextOf depsOf target acc frontier))).size := by
+      apply Std.TreeSet.size_le_of_forall_mem
+      intro y hy
+      rw [Std.TreeSet.mem_diff_iff] at hy ⊢
+      refine ⟨hy.1, ?_⟩
+      intro hcon
+      rcases Std.TreeSet.mem_union_iff.mp hcon with hcon | hcon
+      · exact hy.2 hcon
+      · rw [Std.TreeSet.isEmpty_iff_forall_not_mem] at hemp
+        exact hemp y hcon
+    have heq : (depsUniverse depsOf \ (acc.union (nextOf depsOf target acc frontier))).size =
+        (depsUniverse depsOf \ acc).size := Nat.le_antisymm hle1 hle2
+    rw [heq]
+    apply Prod.Lex.right
+    have hnsize : (nextOf depsOf target acc frontier).size = 0 := by
+      rw [Std.TreeSet.isEmpty_eq_size_eq_zero] at hemp
+      simpa using hemp
+    have hfsize : frontier.size ≠ 0 := by
+      intro hz
+      rw [Std.TreeSet.isEmpty_eq_size_eq_zero, hz] at hfrontier
+      simp at hfrontier
+    omega
 
 def reverseDepClosure (depsOf : Std.TreeMap ModuleName (Std.TreeSet ModuleName))
     (target : ModuleName) : Std.TreeSet ModuleName :=


### PR DESCRIPTION
## Summary

Closes one of the four remaining Tier 2 items tracked in #359:
`Query/Engine.lean`'s `reverseDepClosureGo` (the reverse
dependency-closure BFS) is de-partialized with a real termination proof
instead of `partial def`.

- Termination measure: a lexicographic pair
  `((depsUniverse depsOf \ acc).size, frontier.size)`. The first
  component strictly decreases whenever the per-step `next` set is
  nonempty; the second strictly decreases to 0 on the one further step
  where `next` is empty.
- The blocking gap from earlier investigation (recorded in #359) was
  that `Std.TreeSet` exposes no direct "membership-subset implies size
  monotonicity" lemma, and no usable extensionality principle without
  `LawfulEqCmp` — which `ModuleName` genuinely fails (two `.artifact`
  values with the same `relPath` but different other `ArtifactPath`
  fields compare `.eq` without being `=`, by design, per the traversal-route
  comment on that instance). It turns out there's a path through
  existing `Std.TreeSet` identities alone (`isEmpty_diff_iff`,
  `size_diff_add_size_inter_eq_size_left`, `size_inter_le_size_right`),
  needing only `Std.TransCmp`, no `LawfulEqCmp`/extensionality at all.
- Landed as two reusable `Prelude.lean` lemmas
  (`size_le_of_forall_mem`, `size_lt_of_forall_mem_of_not_mem`)
  alongside a small `mem_foldl_filter_insert` family, generalizing this
  session's prior scratch-only proof attempt so future
  `Std.TreeSet`/`TreeMap` proofs in this port can reuse them directly.
- `Engine.lean` gains `depsUniverse`/`nextOf` (`nextOf` factored out of
  the previous inline `let` so the termination proof can name it
  directly) plus three `ModuleName`-specific supporting lemmas
  (`next_subset_universe`, `next_disjoint_acc`,
  `depsUniverse_diff_acc_union_next_lt`). Pure refactor of the
  recursion shape — `reverseDepClosureGo`'s observable behavior is
  unchanged.

## Test plan

- [x] `lake build` — full Lean project builds clean
- [x] `lake test` — 532/532 goldens + 94/94 infer + LSP session gate
- [x] `bash scripts/lean-parity.sh` — 292/292 (eval/bigstep/fingerprint)
- [x] `#print axioms` on every new theorem shows only
      `[propext, Classical.choice, Quot.sound]` (no `sorry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)