### PR TITLE
ci(release): match the actual release commit in the skip guard

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,7 +23,8 @@ jobs:
         id: check-release-commit
         run: |
           latest_commit_message=$(git log -1 --pretty=%B)
-          if echo "$latest_commit_message" | grep -q "chore: release v"; then
+          # Must match create-or-update-pr.js's commit message, not the PR title.
+          if echo "$latest_commit_message" | grep -qF "chore(release): prepare v"; then
             echo "skip_release_pr=true" >> $GITHUB_OUTPUT
           else
             echo "skip_release_pr=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

`create-release-pr.yml`'s `skip-if-released` guard greps the latest commit for `chore: release v` — but that string is the release **PR title** (`create-or-update-pr.js:84`). The commit that actually lands on master is `chore(release): prepare <version>` (`create-or-update-pr.js:37`), and the squash merge preserves that form:

```
47f4012b chore(release): prepare v3.0.0 (#361)
846e56f0 chore(release): prepare v2.3.0 (#283)
```

So the guard has never matched. Every release merge re-runs `create-release-pr`, which then computes `LATEST_TAG` as the tag `release.yml` just pushed, finds no labelled PRs merged since it, and fails on `compute-next-version.js`'s `No version-related labels (breaking, feat, fix) found` check.

Observed on the v3.0.0 merge: [run 30147302275](https://github.com/takoeight0821/malgo/actions/runs/30147302275). No release PR should exist at that moment, so the effect is only a spurious red X — but it's a red X on every single release.

## Fix

Grep for the commit message the script actually writes, with `-F` since the pattern now contains parentheses.

Verified against the two real release commits (both → skip) and a normal merge (`docs: ... (#380)` → run).

## Known, not addressed here

`compute-next-version.js` exits 1 whenever the labels accumulated since the last tag contain none of `breaking`/`feat`/`fix`. This guard fix covers the release-merge case, but the same failure still fires if the first PRs merged after a release carry only non-version labels (`docs`, `chore`, `perf`, `ci`). Deciding whether that should be a skip rather than an error is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)