### PR TITLE
ci(lean): rebuild the embedded Zig runtime before the Lean sweep

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -128,10 +128,32 @@ jobs:
           build: true
           test: false
 
+      # Lake's tracking of `include_str` is not reliable: measured on one edit,
+      # changing runtime.zig rebuilt Runtime.olean but reverting that change did
+      # not, and `lake build` reported success while the binary kept embedding
+      # the old runtime text. Combined with lean-action's .lake cache, a PR that
+      # touches only runtime.zig would otherwise compile all 73 cases against
+      # the PREVIOUS runtime and report green. Runs after lean-action because
+      # that is what restores the cache; rebuilding one module is negligible
+      # against this job's Zig toolchain time. Unconditional on purpose — a
+      # "did runtime.zig change?" guard reintroduces the bug it fixes.
+      # See lean/Malgo/Backend/Zig/Runtime.lean.
+      - name: Rebuild the embedded Zig runtime
+        run: |
+          rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
+                lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.trace \
+                lean/.lake/build/ir/Malgo/Backend/Zig/Runtime.c
+          cd lean && lake build malgo
+
       # Also caches Zig's own global cache directory, keyed on the Zig version.
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: '0.16.0'
+
+      # runtime.zig is shared by both implementations but its unit tests only
+      # ran in build.yml, which will not survive the Haskell retirement.
+      - name: Run Zig runtime unit tests
+        run: zig test -lc runtime/zig/runtime.zig
 
       - name: Zig backend golden parity sweep (Lean malgo compile)
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,11 @@ Join IR (already saturated — see SaturateCtor above) → Normalize (Mu/Label e
 - Runtime unit tests: `zig test -lc runtime/zig/runtime.zig` (`-lc` is required on
   Linux since the runtime calls `std.c.write`/`std.c.getenv` directly; macOS
   masks this because it always links libc via libSystem).
+- **After editing `runtime/zig/runtime.zig`, run `mise run lean-bust-runtime`
+  before rebuilding the Lean port.** Lake does not reliably track the
+  `include_str` that embeds it, so `lake build` can report success while the
+  binary keeps emitting the previous runtime text. Haskell's `embedStringFile`
+  has no such problem. CI does this unconditionally in `lean-zig-golden`.
 - The interpreter (`Malgo.Sequent.Eval`) is the semantic oracle: any observable
   divergence in the Zig backend is a bug, matched against Eval.hs, not Scheme.
 

--- a/lean/Malgo/Backend/Zig/Runtime.lean
+++ b/lean/Malgo/Backend/Zig/Runtime.lean
@@ -8,11 +8,13 @@ Haskell uses Template Haskell's `embedStringFile`; Lean uses the builtin
 (`lean/Malgo/Backend/Zig/`), four levels up to the repo root, then into
 `runtime/zig/runtime.zig`.
 
-**Lake does not track `include_str` as a build dependency** (verified: editing
-`runtime.zig` and rebuilding leaves this module's `.olean` untouched, so the
-compiler keeps emitting the *previous* runtime text). Haskell has no such
-problem — `embedStringFile` calls `addDependentFile`. After changing
-`runtime.zig`, force this module to rebuild:
+**Lake's tracking of `include_str` is not reliable.** Measured on the same
+edit, twice: changing `runtime.zig` rebuilt this module, but *reverting* that
+change did not — `lake build` reported success while the produced binary went
+on embedding the previous runtime text. Haskell has no such problem;
+`embedStringFile` calls `addDependentFile`, and the same revert rebuilt and
+cleared correctly there. After changing `runtime.zig`, force this module to
+rebuild rather than trusting the build to notice:
 
 ```
 rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
@@ -22,7 +24,9 @@ rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
 
 `touch`ing this file is *not* enough. A change that touches `runtime.zig` and
 nothing else is the dangerous case: a stale build produces a green
-`lean-zig-golden` run that tested the old runtime. -/
+`lean-zig-golden` run that tested the old runtime. CI does the removal
+unconditionally before its sweep (see `.github/workflows/lean.yml`), and
+`mise run lean-bust-runtime` does the same locally. -/
 
 namespace Malgo.Backend.Zig
 

--- a/mise.toml
+++ b/mise.toml
@@ -42,6 +42,14 @@ run = [
 description = "Install elan (Lean toolchain manager); the toolchain itself is pinned by lean/lean-toolchain"
 run = "command -v elan >/dev/null 2>&1 || curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none"
 
+[tasks.lean-bust-runtime]
+description = "Force the Lean port to re-embed runtime/zig/runtime.zig (Lake does not reliably track include_str)"
+run = """
+rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
+      lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.trace \
+      lean/.lake/build/ir/Malgo/Backend/Zig/Runtime.c
+"""
+
 [tasks.lean-build]
 description = "Build the Lean 4 port (lean/)"
 dir = "lean"


### PR DESCRIPTION
Lean + Zig を正式採用し Haskell と Scheme を退役させるロードマップの Phase 1。
`runtime/zig/runtime.zig` を安全に触れる状態を先に作る。

**#382 の上に積んでいる。** 同じ3ファイル（`lean.yml`、`mise.toml`、`AGENTS.md`）を触るため、base は `fix/zig-trampoline-360` にしてある。#382 がマージされたら master に付け替える。

## 何が問題か

`lean/Malgo/Backend/Zig/Runtime.lean` は `include_str` で `runtime/zig/runtime.zig` を埋め込んでいるが、Lake はこの依存を確実には追跡しない。
同じ一つの編集で両方向を測った結果が以下である。

| 操作 | 素の `lake build` | バイナリ |
|---|---|---|
| runtime.zig に目印を入れる | 再ビルドされる | 目印が入る |
| **同じ目印を元に戻す** | **再ビルドされない** | **目印が残ったまま** |
| 戻した上で成果物を消す | 再ビルドされる | 正しくなる |

真ん中の場合でも `lake build` は成功を報告する。
Haskell 側には同じ問題が無い。`embedStringFile` が `addDependentFile` を呼ぶので、同じ revert で再ビルドされ目印は消えた。

lean-action が `.lake` をキャッシュすることと合わせると、**`runtime.zig` だけを触る PR が危険な形になる**。
`lean-zig-golden` が73ケース全てを一つ前の runtime に対してコンパイルし、緑を報告しうる。
#382 はまさにその形だったが、`Emit.lean` も同時に触っていたため、偽陽性の緑ではなく大きなコンパイルエラーとして表面化しただけだった。

## 修正

`lean-zig-golden` に、`Runtime.olean` / `Runtime.trace` / `Runtime.c` を消して `lake build` し直すステップを足す。

lean-action の**後**に置いてある。キャッシュを復元するのが lean-action だからで、その前に消しても意味がない。
条件は付けていない。「runtime.zig が変わったか」で分岐すると、いま直しているバグをそのまま作り直すことになる。1モジュールの再ビルドは、このジョブが既に払っている Zig ツールチェイン時間に対して無視できる。

ローカル用に `mise run lean-bust-runtime` を用意し、`AGENTS.md` から参照した。

あわせて `zig test -lc runtime/zig/runtime.zig` をこのジョブに移した。
これは `build.yml` にしかなく、その `build.yml` は Haskell 退役で消える。テスト対象の runtime は両実装で共有されている。

## 前回の記述の訂正

#382 で `Runtime.lean` に書いた「Lake は `include_str` を依存として追跡しない（runtime.zig を編集して再ビルドしても `.olean` は変わらない）」は強すぎた。
順方向では実際に再ビルドされる。
再現するのは「戻したときに気付かない」ほうなので、そちらに書き直した。

## 検証

否定テストがこの PR の成果物である。差分そのものではない。

```
step 1: add probe to runtime.zig, plain lake build
   binary embeds probe: 1   (want 1)
step 2: revert probe, plain lake build  <-- the failure mode
   binary embeds probe: 1   (want 0; 1 = STALE, gate needed)
step 3: mise run lean-bust-runtime, then lake build
   binary embeds probe: 0   (want 0)
```

そのうえで、再ビルドしたバイナリで既存のゲートが通ることを確認した。

- `zig test -lc runtime/zig/runtime.zig` — 18/18
- `MALGO=lean/.lake/build/bin/malgo bash scripts/zig-golden.sh` — 73/73、リーク0、タイムアウト0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
