### PR TITLE
ci(lean): bust the embedded runtime in lean-selfhost too

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -106,6 +106,18 @@ jobs:
           build: true
           test: false
 
+      # Same include_str staleness as lean-zig-golden: without this the job
+      # compiles Main.mlg against a cached, stale embedded runtime. That is
+      # not hypothetical -- it is how this step first failed, with every one
+      # of the 73 cases dying on `malgo_read_file` after that primitive had
+      # already been implemented. See lean/Malgo/Backend/Zig/Runtime.lean.
+      - name: Rebuild the embedded Zig runtime
+        run: |
+          rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
+                lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.trace \
+                lean/.lake/build/ir/Malgo/Backend/Zig/Runtime.c
+          cd lean && lake build malgo
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: '0.16.0'

--- a/lean/Malgo/Backend/Zig/Runtime.lean
+++ b/lean/Malgo/Backend/Zig/Runtime.lean
@@ -23,10 +23,14 @@ rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
 ```
 
 `touch`ing this file is *not* enough. A change that touches `runtime.zig` and
-nothing else is the dangerous case: a stale build produces a green
-`lean-zig-golden` run that tested the old runtime. CI does the removal
-unconditionally before its sweep (see `.github/workflows/lean.yml`), and
-`mise run lean-bust-runtime` does the same locally. -/
+nothing else is the dangerous case: a stale build produces a green sweep that
+tested the old runtime. `mise run lean-bust-runtime` does the removal locally.
+
+**Every CI job that builds the Lean binary and then compiles Malgo through
+the Zig backend needs the removal**, not just one of them: `lean-zig-golden`
+got it first and `lean-selfhost` was missed, which showed up as all 73 Level
+1 cases dying on an already-implemented `malgo_read_file`. If you add such a
+job, add the step. -/
 
 namespace Malgo.Backend.Zig
 


### PR DESCRIPTION
#389 で `include_str` のキャッシュ破棄を `lean-zig-golden` に入れたが、**`lean-selfhost` を漏らしていた**。

`lean-selfhost` も Lean バイナリをビルドし、#384 以降は Zig バックエンド経由で Malgo をコンパイルする。結果、#389 が防ぐはずだった失敗をそのまま踏んだ。Level 1 の73ケース全てが

```
Malgo: not yet implemented in the Zig backend: malgo_read_file
```

で落ちた。その primitive は既に実装済みである。ジョブが lean-action のキャッシュから復元した**古い runtime を埋め込んだまま** `Main.mlg` をコンパイルしていた。

`Runtime.lean` の注意書きも「CI は sweep の前にこれを行う」から「**Lean バイナリをビルドして Zig バックエンド経由でコンパイルするジョブは全てこれが要る**」に一般化した。失敗モードがまさに「どれか一つを忘れること」だったため。

#391 / #392 / #393 はいずれもこの失敗で赤くなっている。これをマージしてから3本を更新する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)