### PR TITLE
ci: disable the Level 2 metacircular sweep until #385

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,11 @@ jobs:
 
   selfhost-level2:
     name: self-hosted level 2 metacircular (GHC ${{ matrix.ghc-version }})
+    # Disabled alongside the Lean side (lean/ci-gates.env's
+    # LEAN_SELFHOST_L2): ~16 minutes against a sub-10-minute CI target,
+    # because the Zig backend is ~7.5x slower per case than the Chez Scheme
+    # path self-hosting used to take. Re-enable with #385.
+    if: false
     runs-on: ubuntu-latest
     # L2 through the Zig backend is ~7.5x slower per case than the Chez Scheme
     # path it replaced (measured locally: 220s vs 29s on Fib), so the old

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       parity: ${{ steps.g.outputs.LEAN_PARITY }}
       selfhost: ${{ steps.g.outputs.LEAN_SELFHOST }}
+      selfhostL2: ${{ steps.g.outputs.LEAN_SELFHOST_L2 }}
       zig: ${{ steps.g.outputs.LEAN_ZIG }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -125,7 +126,10 @@ jobs:
       - name: Self-hosted golden (Level 1 — Malgo-in-Malgo compiler, Zig backend)
         run: MALGO=lean/.lake/build/bin/malgo MALGO_WORK_DIR=.malgo-work-lean bash scripts/selfhost-golden.sh
 
+      # Disabled via lean/ci-gates.env until #385 makes L2 affordable: it is
+      # ~16 minutes on its own, against a target of keeping CI under 10.
       - name: Self-hosted metacircular (Level 2)
+        if: needs.gates.outputs.selfhostL2 == '1'
         run: |
           MALGO=lean/.lake/build/bin/malgo MALGO_WORK_DIR=.malgo-work-lean \
           CASE_TIMEOUT=1200 PRECOMPILE_TIMEOUT=300 bash scripts/selfhost-level2.sh

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -106,6 +106,18 @@ jobs:
           build: true
           test: false
 
+      # Same include_str staleness as lean-zig-golden: without this the job
+      # compiles Main.mlg against a cached, stale embedded runtime. That is
+      # not hypothetical -- it is how this step first failed, with every one
+      # of the 73 cases dying on `malgo_read_file` after that primitive had
+      # already been implemented. See lean/Malgo/Backend/Zig/Runtime.lean.
+      - name: Rebuild the embedded Zig runtime
+        run: |
+          rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
+                lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.trace \
+                lean/.lake/build/ir/Malgo/Backend/Zig/Runtime.c
+          cd lean && lake build malgo
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: '0.16.0'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,14 @@ Malgo has two self-hosting levels, each tested by a CI job:
 | Level | Description | Script | CI job |
 |-------|-------------|--------|--------|
 | Level 1 | The Malgo evaluator written in Malgo (`runtime/malgo/compiler/`) evaluates arbitrary Malgo programs | `scripts/selfhost-golden.sh` | `self-hosted golden` |
-| Level 2 | Level 1 evaluator evaluates `Main.mlg` which evaluates a Malgo program (metacircular interpreter) | `scripts/selfhost-level2.sh` | `self-hosted level 2 metacircular` |
+| Level 2 | Level 1 evaluator evaluates `Main.mlg` which evaluates a Malgo program (metacircular interpreter) | `scripts/selfhost-level2.sh` | **currently disabled in CI** |
+
+**Level 2 is off in CI** (`LEAN_SELFHOST_L2=0` in `lean/ci-gates.env`, and
+`if: false` on `build.yml`'s job). It takes ~16 minutes on its own against a
+target of keeping CI under 10, because the Zig backend is ~7.5x slower per
+case than the Chez Scheme path self-hosting used to run on (#385). Level 1
+still runs on every PR over all 73 testcases. Run L2 locally before touching
+`runtime/malgo/compiler/`, and re-enable the flag when #385 lands.
 
 Both levels run through the **Zig backend**: `Main.mlg` is compiled to a native
 binary with `malgo compile --opt release-fast` and that binary is the evaluator.

--- a/lean/Malgo/Backend/Zig/Runtime.lean
+++ b/lean/Malgo/Backend/Zig/Runtime.lean
@@ -23,10 +23,14 @@ rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
 ```
 
 `touch`ing this file is *not* enough. A change that touches `runtime.zig` and
-nothing else is the dangerous case: a stale build produces a green
-`lean-zig-golden` run that tested the old runtime. CI does the removal
-unconditionally before its sweep (see `.github/workflows/lean.yml`), and
-`mise run lean-bust-runtime` does the same locally. -/
+nothing else is the dangerous case: a stale build produces a green sweep that
+tested the old runtime. `mise run lean-bust-runtime` does the removal locally.
+
+**Every CI job that builds the Lean binary and then compiles Malgo through
+the Zig backend needs the removal**, not just one of them: `lean-zig-golden`
+got it first and `lean-selfhost` was missed, which showed up as all 73 Level
+1 cases dying on an already-implemented `malgo_read_file`. If you add such a
+job, add the step. -/
 
 namespace Malgo.Backend.Zig
 

--- a/lean/ci-gates.env
+++ b/lean/ci-gates.env
@@ -1,12 +1,22 @@
 # Milestone activation flags for .github/workflows/lean.yml.
 # Flip a gate to 1 in the PR that lands the corresponding milestone.
 #
-# Note: there is no separate LEAN_SELFHOST_L2 flag — the lean-selfhost job
-# runs both the Level 1 and Level 2 (metacircular) self-hosted golden
-# sweeps unconditionally once LEAN_SELFHOST=1 (see the job's two steps in
-# .github/workflows/lean.yml). An earlier LEAN_SELFHOST_L2=0 line here was
-# vestigial (never read by any conditional) and has been removed as part
-# of M9 consolidation, since Level 2 has been green since M4.
+# LEAN_SELFHOST gates the Level 1 sweep. LEAN_SELFHOST_L2 gates the Level 2
+# (metacircular) sweep separately, and is currently OFF: since self-hosting
+# moved to the Zig backend, L2 takes ~16 minutes of a CI run we want to keep
+# under 10, because the Zig backend is ~7.5x slower per case than the Chez
+# Scheme path it replaced (#385). Level 1 still runs on every PR and covers
+# the self-hosted compiler over all 73 testcases; what L2 adds on top is the
+# "evaluator evaluating an evaluator" layer.
+#
+# Flip LEAN_SELFHOST_L2 back to 1 when #385 brings L2 back into budget. That
+# is listed as #385's completion criterion, so this flag is the thing that
+# closes it.
+#
+# (An earlier LEAN_SELFHOST_L2 line existed here but was never read by any
+# conditional and was removed in M9 as vestigial. This one is wired up --
+# see the gates job's outputs in .github/workflows/lean.yml.)
 LEAN_PARITY=1
 LEAN_ZIG=1
 LEAN_SELFHOST=1
+LEAN_SELFHOST_L2=0


### PR DESCRIPTION
**L2 を CI から一旦外す。** #385（Zig バックエンドの性能）が解決したら戻す。

#394 の上に積んでいる（同じ `lean.yml` を触るため）。

## 理由

実測でジョブ別の所要時間は以下のとおり。

| ジョブ | 時間 |
|---|---|
| **self-hosted level 2 metacircular** | **16分** |
| self-hosted golden (L1) | 4分 |
| malgo（Haskell テスト） | 3分 |
| lean-parity | 3分 |
| zig-golden / lean-zig-golden | 2分 |
| lean-build | 1分 |

**L2 以外は全て4分以下**で、10分超過分はまるごと L2 である。

このコストは #384 で自己ホスティングを Zig バックエンドへ移したことの直接の帰結である。同一ケースの実測で、Zig 経路は置き換え前の Chez Scheme 経路より約7.5倍遅い（Fib で 220秒 対 29秒）。#385 で追跡している。

## 何が失われ、何が残るか

**Level 1 は全PRで走り続ける。** 73テストケース全てで自己ホストコンパイラを駆動するので、コンパイラ自体の健全性は覆われている。L2 が上乗せするのは「評価器が評価器を評価する」層で、L2 固有の失敗はその層に限られる。

## 削除ではなくゲート

既存のフラグ機構を使った。`lean/ci-gates.env` の `LEAN_SELFHOST_L2=0` を `gates` ジョブの新しい output 経由で読む。**再有効化は1文字**である。

#385 の完了基準に「CI 予算を元に戻せること」を既に書いてあるので、このフラグがそれを閉じるものになる。

Haskell 側のジョブは `if: false` にした。`build.yml` は Haskell 撤去でどのみち消える。

## 戻す人への注記

以前にも `LEAN_SELFHOST_L2` の行が存在したが、どの条件からも読まれておらず M9 で vestigial として削除された経緯がある。今回のものは実際の条件式に配線してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)