### PR TITLE
test(lean): parser/rename の error golden 11件を Lean 側でもゲートする

### DIFF
--- a/.golden-lean/Malgo.Parser/error/InvalidIdentifier/golden
+++ b/.golden-lean/Malgo.Parser/error/InvalidIdentifier/golden
@@ -1,0 +1,1 @@
+test/Malgo/ParserSpec/errors/InvalidIdentifier.mlg:7:5: unexpected 'l', expecting '('

--- a/.golden-lean/Malgo.Parser/error/InvalidOperator/golden
+++ b/.golden-lean/Malgo.Parser/error/InvalidOperator/golden
@@ -1,0 +1,1 @@
+test/Malgo/ParserSpec/errors/InvalidOperator.mlg:5:10: unexpected '='

--- a/.golden-lean/Malgo.Parser/error/MissingEqualInDef/golden
+++ b/.golden-lean/Malgo.Parser/error/MissingEqualInDef/golden
@@ -1,0 +1,1 @@
+test/Malgo/ParserSpec/errors/MissingEqualInDef.mlg:3:10: unexpected '{', expecting '='

--- a/.golden-lean/Malgo.Parser/error/MissingImportInForeign/golden
+++ b/.golden-lean/Malgo.Parser/error/MissingImportInForeign/golden
@@ -1,0 +1,1 @@
+test/Malgo/ParserSpec/errors/MissingImportInForeign.mlg:1:9: unexpected 'm', expecting 'import'

--- a/.golden-lean/Malgo.Parser/error/MissingParentheses/golden
+++ b/.golden-lean/Malgo.Parser/error/MissingParentheses/golden
@@ -1,0 +1,1 @@
+test/Malgo/ParserSpec/errors/MissingParentheses.mlg:5:1: unexpected '}', expecting ')'

--- a/.golden-lean/Malgo.Rename/error/DuplicateDef/golden
+++ b/.golden-lean/Malgo.Rename/error/DuplicateDef/golden
@@ -1,0 +1,1 @@
+test/Malgo/RenameSpec/errors/DuplicateDef.mlg: line 3, column 1 - line 5, column 1: [Rename] Duplicate name: 'fun'

--- a/.golden-lean/Malgo.Rename/error/NotImported/golden
+++ b/.golden-lean/Malgo.Rename/error/NotImported/golden
@@ -1,0 +1,1 @@
+test/Malgo/RenameSpec/errors/NotImported.mlg: line 2, column 3 - line 2, column 10: [Rename] Not in scope: 'putStr'

--- a/.golden-lean/Malgo.Rename/error/NotQualifiedImported/golden
+++ b/.golden-lean/Malgo.Rename/error/NotQualifiedImported/golden
@@ -1,0 +1,1 @@
+test/Malgo/RenameSpec/errors/NotQualifiedImported.mlg: line 8, column 3 - line 8, column 10: [Rename] Not in scope: 'Prelude'

--- a/.golden-lean/Malgo.Rename/error/UndefinedType/golden
+++ b/.golden-lean/Malgo.Rename/error/UndefinedType/golden
@@ -1,0 +1,1 @@
+test/Malgo/RenameSpec/errors/UndefinedType.mlg: line 6, column 16 - line 6, column 23: [Rename] Not in scope: 'String'

--- a/.golden-lean/Malgo.Rename/error/UndefinedTypeVariable/golden
+++ b/.golden-lean/Malgo.Rename/error/UndefinedTypeVariable/golden
@@ -1,0 +1,1 @@
+test/Malgo/RenameSpec/errors/UndefinedTypeVariable.mlg: line 4, column 17 - line 4, column 18: [Rename] Not in scope: 'a'

--- a/.golden-lean/Malgo.Rename/error/UndefinedVariable/golden
+++ b/.golden-lean/Malgo.Rename/error/UndefinedVariable/golden
@@ -1,0 +1,1 @@
+test/Malgo/RenameSpec/errors/UndefinedVariable.mlg: line 1, column 18 - line 1, column 20: [Rename] Not in scope: 'y'

--- a/lean/Malgo/Parser/Prim.lean
+++ b/lean/Malgo/Parser/Prim.lean
@@ -136,9 +136,16 @@ def lookAhead (p : P α) : P α := fun s =>
   | .ok a _ _ => .ok a s false
   | .err e _ => .err e false
 
+/-- Megaparsec reports the token that *was* there, not a generic label:
+`notFollowedBy` failing at `def let` says `unexpected 'l'`. Rendering a
+`.label` here instead produced "unexpected unexpected input". -/
 def notFollowedBy (p : P α) : P Unit := fun s =>
   match p s with
-  | .ok _ _ _ => .err (s.errorAt (some (.label "unexpected input")) []) false
+  | .ok _ _ _ =>
+    let found := match s.rest with
+      | [] => ErrorItem.endOfInput
+      | c :: _ => ErrorItem.tokens (toString c)
+    .err (s.errorAt (some found) []) false
   | .err _ _ => .ok () s false
 
 def getSourcePos : P SourcePos := fun s => .ok s.sourcePos s false

--- a/lean/Test/Golden.lean
+++ b/lean/Test/Golden.lean
@@ -4,7 +4,12 @@ written next to it on mismatch. Cases whose Lean output legitimately
 diverges from Haskell get an override in `.golden-lean/` with the same
 layout: the runner checks `.golden-lean/` first (an explicit override
 wins), then the shared `.golden/`. `--update` only ever writes to
-`.golden-lean/` — the shared tree stays Haskell-owned. -/
+`.golden-lean/` — the shared tree stays Haskell-owned.
+
+The overrides are the 11 parser/rename *error* cases, whose message text
+each implementation renders in its own format. The split exists only while
+both implementations do: once Haskell retires, these become the only
+goldens and fold back into `.golden/`. -/
 
 namespace Malgo.Test
 

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -26,6 +26,29 @@ private def parseGoldenAt (path : System.FilePath) : IO String := do
 private def parserCaseAt (name : String) (path : System.FilePath) : GoldenCase :=
   { group := "Malgo.Parser", name, run := parseGoldenAt path }
 
+/-! ### Parser error cases (`test/Malgo/ParserSpec/errors/*.mlg`)
+
+Haskell's `driveErrorParse` dumps megaparsec's `errorBundlePretty`, which
+prints the offending source line and a caret under the column. The Lean
+parser's `PError.render` is a single line. Both are legitimate renderings of
+the same failure, so these cases carry Lean-owned goldens under
+`.golden-lean/` rather than sharing the Haskell tree. -/
+
+private def parserErrorCaseDir : System.FilePath :=
+  System.FilePath.mk "test/Malgo/ParserSpec/errors"
+
+private def parseErrorGolden (path : System.FilePath) : IO String := do
+  let ws ← Workspace.setup
+  let text ← IO.FS.readFile path
+  let (result, _flags) ← Malgo.Parser.pass ws path text
+  match result with
+  | .error e => return e.render
+  | .ok m => return s!"PARSED WITHOUT ERROR: {sShow m}"
+
+private def parserErrorCase (name : String) : GoldenCase :=
+  { group := "Malgo.Parser", name := s!"error/{name}",
+    run := parseErrorGolden (parserErrorCaseDir / s!"{name}.mlg") }
+
 /-! ## Rename golden cases (the first real uniq-order-parity gate)
 
 Each case runs the M1 mini-driver (`Malgo.Driver.compileToRenamed`) and
@@ -66,6 +89,41 @@ private def renameGolden (path : System.FilePath) : IO String := do
 
 private def renameCase (name : String) (path : System.FilePath) : GoldenCase :=
   { group := "Malgo.Rename", name, run := renameGolden path }
+
+/-! ### Rename error cases (`test/Malgo/RenameSpec/errors/*.mlg`)
+
+Haskell's `driveErrorRename` `show`s the `CompileError` it caught; Lean's
+`CompileError.render` names the pass in the text and formats the range
+differently. Lean-owned goldens, same as the parser errors above. -/
+
+private def renameErrorCaseDir : System.FilePath :=
+  System.FilePath.mk "test/Malgo/RenameSpec/errors"
+
+private def renameErrorGolden (path : System.FilePath) : IO String := do
+  try
+    let ws ← Workspace.setup
+    let cache ← IO.mkRef (← getPrebuilt)
+    let (renamed, _) ← MalgoM.run flag {} (Malgo.Driver.compileToRenamed ws cache path)
+    return s!"RENAMED WITHOUT ERROR: {sShow renamed}"
+  catch e => return toString e
+
+private def renameErrorCase (name : String) : GoldenCase :=
+  { group := "Malgo.Rename", name := s!"error/{name}",
+    run := renameErrorGolden (renameErrorCaseDir / s!"{name}.mlg") }
+
+/-- Base names of an error-fixture directory, sorted (Haskell
+`listDirectory errorcaseDir`). -/
+def enumerateErrorCases (dir : System.FilePath) : IO (List String) := do
+  let entries ← dir.readDir
+  let names := entries.toList.filterMap fun e =>
+    if e.fileName.endsWith ".mlg" then (System.FilePath.mk e.fileName).fileStem else none
+  return (names.toArray.qsort (· < ·)).toList
+
+def enumerateParserErrorCases : IO (List String) := enumerateErrorCases parserErrorCaseDir
+def enumerateRenameErrorCases : IO (List String) := enumerateErrorCases renameErrorCaseDir
+
+def parserErrorCases (names : List String) : List GoldenCase := names.map parserErrorCase
+def renameErrorCases (names : List String) : List GoldenCase := names.map renameErrorCase
 
 private def testcasePath (name : String) : System.FilePath :=
   System.FilePath.mk s!"test/testcases/malgo/{name}.mlg"
@@ -268,12 +326,8 @@ def enumerateTestcases : IO (List String) := do
 /-- The 18 non-error Parser goldens, mirroring `renameCases`: Builtin/Prelude
 from `runtime/malgo/` plus the 16 representative testcases. Previously only
 three were registered, leaving 15 of the committed `.golden/Malgo.Parser`
-files ungated on the Lean side.
-
-The five `.golden/Malgo.Parser/error/*` cases are deliberately still absent:
-parser *error text* legitimately differs between the implementations (see
-this file's header), so they need Lean-owned goldens rather than the shared
-Haskell-generated ones. -/
+files ungated on the Lean side. The `error/*` cases are registered
+separately (`parserErrorCases`) because their goldens are Lean-owned. -/
 def parserCases : List GoldenCase :=
   [ parserCaseAt "Builtin" "runtime/malgo/Builtin.mlg",
     parserCaseAt "Prelude" "runtime/malgo/Prelude.mlg" ] ++
@@ -1050,7 +1104,12 @@ def main (args : List String) : IO UInt32 := do
     let forthNames ← Malgo.Test.enumerateForthTestcases
     let lintNames ← Malgo.Test.enumerateLintCases
     let exampleNames ← Malgo.Test.enumerateExamples
-    let allCases := Malgo.Test.cases ++ Malgo.Test.toCoreCases memo names
+    let parserErrorNames ← Malgo.Test.enumerateParserErrorCases
+    let renameErrorNames ← Malgo.Test.enumerateRenameErrorCases
+    let allCases := Malgo.Test.cases
+      ++ Malgo.Test.parserErrorCases parserErrorNames
+      ++ Malgo.Test.renameErrorCases renameErrorNames
+      ++ Malgo.Test.toCoreCases memo names
       ++ Malgo.Test.evalCases memo names
       ++ Malgo.Test.bigStepEvalCases memo names
       ++ Malgo.Test.forthCases memo forthNames

--- a/scripts/selfhost-level2.sh
+++ b/scripts/selfhost-level2.sh
@@ -30,6 +30,17 @@ log() {
   printf '[%s] %s\n' "$(timestamp)" "$*"
 }
 
+# Each case's own log is collected only after `wait`, so that the final
+# output stays in case order despite running in parallel. That leaves the
+# terminal silent for the whole sweep -- ~16 minutes on CI, in which a hang,
+# a timeout and a slow-but-healthy case look identical. fd 3 keeps a handle
+# on the real stdout so a case can report starting and finishing while the
+# rest are still running.
+exec 3>&1
+progress() {
+  printf '[%s] %s\n' "$(timestamp)" "$*" >&3
+}
+
 if [[ "$KEEP_WORK" != "1" ]]; then
   log "cleaning work directory: $MALGO_WORK_DIR"
   rm -rf "$MALGO_WORK_DIR"
@@ -167,9 +178,17 @@ run_case() {
   rm -f "$out" "$err"
 }
 
+run_case_watched() {
+  local dir="$1"
+  local start=$SECONDS
+  progress "start: $dir"
+  run_case "$dir" >"$results_dir/$dir.log" 2>&1
+  progress "$(cat "$results_dir/$dir.status" 2>/dev/null || echo fail): $dir ($((SECONDS - start))s)"
+}
+
 pids=()
 for dir in "${level2_cases[@]}"; do
-  run_case "$dir" >"$results_dir/$dir.log" 2>&1 &
+  run_case_watched "$dir" &
   pids+=("$!")
 done
 


### PR DESCRIPTION
## 背景

`.golden/Malgo.Parser/error/*`（5件）と `.golden/Malgo.Rename/error/*`（6件）は、コミット済み golden のうち Lean 側に対応するケースが無い唯一の一群だった。
これらの本文は各実装のエラー描画そのものであり、megaparsec の `errorBundlePretty`（該当行とキャレットを含む複数行）と Lean の `PError.render`（一行）、Haskell の `show CompileError` と Lean の `CompileError.render` は正当に異なる。
そのため共有できず、これまで Lean 側では未検査のままだった。

## 変更

`lean/Test/Main.lean` に11件を登録し、golden は `.golden-lean/` の override に置いた。
この二重ツリー機構は M1 から `Test/Golden.lean` にあったが、実際に使われるのは今回が初めてである。

登録して初めて見えた不具合も直した。
`notFollowedBy` は `.label "unexpected input"` を報告しており、`unexpected unexpected input` と描画されていた。
megaparsec は実際にそこにあったトークンを報告するので、それに合わせた。
`def let` は両実装とも `unexpected 'l'` を報告するようになり、パーサ error golden 5件に残る差は「失敗の種類が違う」ではなく `expecting` 集合が Lean のほうが狭いという差だけになった。

| ケース | Haskell | Lean |
|---|---|---|
| InvalidIdentifier | `unexpected 'l'` / `expecting '('` | `unexpected 'l', expecting '('` |
| InvalidOperator | `unexpected '='` | `unexpected '='` |
| MissingEqualInDef | `expecting ':' or '='` | `expecting '='` |
| MissingImportInForeign | `unexpected "malgo_"` | `unexpected 'm'` |
| MissingParentheses | `expecting "goto", "label", ...` | `expecting ')'` |

位置（行:桁）は5件すべて一致する。
rename の6件は範囲もメッセージも完全に一致し、差は `[Rename]` というパス名の接頭辞だけである。

あわせて `scripts/selfhost-level2.sh` に進捗の1行出力を足した。
このスクリプトは並列実行した各ケースのログを `wait` の後にまとめて `cat` するため、約16分間なにも出力しない。
ハングと単に遅いケースが区別できなかった。

## 検証

```
$ cd lean && ./.lake/build/bin/test
=== 558/558 passed ===       (547 + 今回の11)
=== infer 94/94 passed ===
=== zig-reuse 7/7 passed ===
=== zig-corpus 74/74 passed ===
=== ir-invariants 73/73 passed ===
=== reuse-specialize 6/6 passed ===
=== parser-surface 4/4 passed ===
```

`.golden/` は変更していないので Haskell 側のテストは影響を受けない。

## 位置づけ

Lean + Zig 正式採用（Haskell 実装の退役）の最後の段階のうち、両実装が並存したまま検証できる部分である。
Haskell を削除する次の PR で `.golden-lean/` は `.golden/` に畳み込み、二重ツリー機構自体を撤去する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)