### PR TITLE
feat(scheme): restore the Scheme backend as the Chez performance reference

### DIFF
--- a/.claude/rules/selfhost-evaluator.md
+++ b/.claude/rules/selfhost-evaluator.md
@@ -92,10 +92,23 @@ Level 1 では通る変更が、Level 2（Malgo → Malgo → Malgo）では失�
 ことがある。評価意味論が異なるため、自己ホスト型コンパイラを変更したら
 必ず Level 2 を手動確認する。
 
-Level 1/2 はどちらも Zig バックエンド経由で走る。`Main.mlg` を
+Level 1/2 はどちらも既定では Zig バックエンド経由で走る。`Main.mlg` を
 `malgo compile` でネイティブバイナリにし、そのバイナリが評価器になる。
-以前は Scheme バックエンド経由だったが、`malgo_read_file` の実装により
-移行した（Scheme バックエンドは削除済み）。
+この既定は `malgo_read_file` の実装により可能になった。
+
+Scheme バックエンドは**意図的に残してある**。#385 が記録している 7.5倍の
+性能差は Chez Scheme 経路との比であり、比較対象がなければ再測定できない。
+`scripts/selfhost-level2.sh` は `TARGET=scheme` で Chez 経路に切り替わる。
+測定のためだけに存在する経路なので、新しい機能をこの上に載せないこと。
+#385 が閉じるまで削除しない（削除は #400 で追跡）。
+
+なお Scheme バックエンドは**性能の基準線であって正しさの基準ではない**。
+意味論の基準は常にインタープリタ（`Malgo.Sequent.Eval`）である。
+Scheme バックエンドには golden ゲートが一度も無く、73 件の golden を通すと
+71 件通過する。落ちる 2 件は `EmptyConstructor`（空コンストラクタの表示が違う）
+と `LabelGoto`（継続が `number->string` に漏れる）。どちらのテストケースも
+バックエンド削除より数ヶ月古いので、退行ではなく元からの穴である。
+Level 2 が実際に走らせる 5 ケースはすべて通る。
 
 ### 手順
 
@@ -116,8 +129,17 @@ printf 'Hello\n' | /tmp/malgoc \
 
 # 4. フルスクリプト
 PRECOMPILE_TIMEOUT=300 CASE_TIMEOUT=1200 bash scripts/selfhost-level2.sh
+
+# 5. Chez 経路（#385 の基準線を測り直すとき。CASE_TIMEOUT の既定は 300）
+lean/.lake/build/bin/malgo eval --target scheme runtime/malgo/compiler/Main.mlg > /tmp/main.scm
+printf 'Hello\n' | scheme --script /tmp/main.scm \
+  runtime/malgo/compiler/Main.mlg test/testcases/malgo/Echo.mlg
+TARGET=scheme PRECOMPILE_TIMEOUT=300 bash scripts/selfhost-level2.sh
 ```
 
 Level 2 は Level 1 より 50〜200 倍遅く、さらに Zig バックエンドは同じ
 ケースで Chez Scheme の約7.5倍遅い（実測: Fib で 220秒 対 29秒）。
 タイムアウトは余裕を持たせること。改善は #385 で追跡している。
+この 220秒 対 29秒 は `TARGET=scheme` で再測定できる。ただし
+`selfhost-level2.sh` は 5 ケースを並列に走らせるので、比を取るときは
+1 ケースずつ直接実行して測ること（並列実行の数値は元の測定と比較できない）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ ParserPass → RenamePass → [InferPass] → [RefinePass]
     ↓
 ToFunPass → ToCorePass → FlatPass → JoinPass
     ↓
-EvalPass (Interpreter) | ZigPass (--target zig / malgo compile)
+EvalPass (Interpreter) | SchemePass (--target scheme) | ZigPass (--target zig / malgo compile)
 ```
 
 **Note**: InferPass and RefinePass can be skipped for fast evaluation without type checking.
@@ -51,8 +51,8 @@ EvalPass (Interpreter) | ZigPass (--target zig / malgo compile)
 conversion: it inlines a fully(-or-over-)saturated call of a data constructor
 (`Cons x xs`, or `Cons (f x) (mapList f xs)` — arguments need not be
 immediate) directly into `Fun.Construct`, instead of invoking the
-constructor's own curried closure. This is shared by both backends
-(Eval/Zig) and every direct caller of `toCore`, not Zig-specific.
+constructor's own curried closure. This is shared by every backend
+(Eval/Scheme/Zig) and every direct caller of `toCore`, not Zig-specific.
 
 ### Zig Backend (native executables)
 
@@ -146,11 +146,25 @@ case than the Chez Scheme path self-hosting used to run on (#385). Level 1
 still runs on every PR over all 73 testcases. Run L2 locally before touching
 `runtime/malgo/compiler/`, and re-enable the flag when #385 lands.
 
-Both levels run through the **Zig backend**: `Main.mlg` is compiled to a native
+**The v4.0.0 release is held on that flag.** Milestone `v4.0.0` gates the
+release on #385, and the Scheme backend is retained until then as the only
+cross-implementation performance reference the 7.5x figure can be measured
+against. Do not delete it early — #400 tracks the eventual removal.
+
+Both levels default to the **Zig backend**: `Main.mlg` is compiled to a native
 binary with `malgo compile --opt release-fast` and that binary is the evaluator.
-They used to go through the Scheme backend; the switch became possible once
-`malgo_read_file` was implemented in `runtime/zig/runtime.zig`, which was the
-only runtime primitive the self-hosted compiler still lacked.
+That default became possible once `malgo_read_file` was implemented in
+`runtime/zig/runtime.zig`, which was the only runtime primitive the self-hosted
+compiler still lacked. `scripts/selfhost-level2.sh` also accepts
+`TARGET=scheme`, which builds the evaluator with `malgo eval --target scheme`
+and runs it under Chez instead; that path exists for measurement, is not a
+supported target, and no new work should build on it. It is a performance
+reference, **not a correctness oracle** — the interpreter (`Malgo.Sequent.Eval`)
+is the oracle. The Scheme backend never had a golden gate, and a sweep of all 73
+goldens through it passes 71: `EmptyConstructor` renders an empty constructor
+differently and `LabelGoto` leaks a continuation into `number->string`. Both
+testcases predate the backend's deletion by months, so these are long-standing
+gaps rather than regressions. The 5 cases Level 2 actually runs all pass.
 
 ```bash
 # Level 1: ./malgoc <testcase.mlg>
@@ -163,6 +177,9 @@ bash scripts/selfhost-golden.sh
 # so that the inner Lexer can tokenize integer literals when evaluating
 # nested Malgo sources.
 bash scripts/selfhost-level2.sh
+
+# Level 2 through Chez, for the #385 baseline (CASE_TIMEOUT defaults to 300 here)
+TARGET=scheme bash scripts/selfhost-level2.sh
 ```
 
 ## Coding Style

--- a/README.md
+++ b/README.md
@@ -180,7 +180,12 @@ See `mise.toml` for more details and customization.
 - **Auto-labeling:** PRs are auto-labeled from commit messages via CI.
 - **Release PR:** On pushes to `master`, CI computes the next version, creates a draft GitHub Release, and opens a `release/vX.Y.Z` PR.
 - **Publish:** Merging a `release/*` PR to `master` tags the commit and publishes the GitHub Release.
-- **Notes:** Releases use generated notes; excluded labels: `skip-changelog`, `duplicate`, `invalid`.
+- **Notes:** Releases use generated notes; excluded labels: `duplicate`, `invalid`. (The workflow's exclusion list also names `skip-changelog`, but no such label exists, so it never matches.)
+
+**Current hold:** the `v4.0.0` release PR (#398) is a draft and the `Create Release PR`
+workflow is disabled until milestone `v4.0.0` is done (#385). Do not merge #398 before
+then, and refresh the draft release's notes before you do — `release.yml` publishes
+whatever draft exists, and the current one was generated at `v3.0.0..bf7c682f`.
 
 To create labels via GitHub CLI:
 

--- a/lean/Main.lean
+++ b/lean/Main.lean
@@ -7,7 +7,7 @@ Haskell uses optparse-applicative; this is a hand-rolled argv parser (no
 combinator library) with the same three subcommands, flags, and defaults.
 Byte-parity with optparse's generated `--help` is explicitly not a goal.
 
-Dispatch is stubbed for M1: the pipeline (`Malgo.Driver`) and the Zig
+Dispatch is stubbed for M1: the pipeline (`Malgo.Driver`) and the Scheme/Zig
 backends and the linter are not ported yet, so each `run*` arm prints a
 clear message and exits 1. `runEval` for `--target eval` carries the single
 integration seam (see the `TODO(M1 integration)` below). -/
@@ -31,6 +31,7 @@ def OptMode.toString : OptMode → String
 
 def parseTargetArg : String → Except String Target
   | "eval" => .ok .eval
+  | "scheme" => .ok .scheme
   | "zig" => .ok .zig
   | t => .error s!"Unknown target: {t}"
 
@@ -50,7 +51,7 @@ def usage : String :=
   "Usage: malgo COMMAND\n\n" ++
   "Commands:\n" ++
   "  eval SOURCE [--no-opt] [--lambdalift] [--debug-mode]\n" ++
-  "              [--target eval|zig] [--eval-mode smallstep|bigstep]\n" ++
+  "              [--target eval|scheme|zig] [--eval-mode smallstep|bigstep]\n" ++
   "              [--infer] [ARG...]\n" ++
   "  compile SOURCE [-o|--output OUT] [--opt debug|release-safe|release-fast]\n" ++
   "  lint SOURCE [--deny-warnings]\n" ++
@@ -232,6 +233,12 @@ def runEval (flag : Flag) (source : System.FilePath) : IO UInt32 := do
   | .eval =>
     try
       Malgo.Driver.compileAndEval flag source
+    catch e =>
+      IO.eprintln (toString e)
+      return 1
+  | .scheme =>
+    try
+      Malgo.Driver.compileScheme flag source
     catch e =>
       IO.eprintln (toString e)
       return 1

--- a/lean/Malgo.lean
+++ b/lean/Malgo.lean
@@ -36,6 +36,7 @@ import Malgo.Infer.Unify
 import Malgo.Infer
 import Malgo.Query
 import Malgo.Query.Engine
+import Malgo.Backend.Scheme
 import Malgo.Backend.Zig.Ir
 import Malgo.Backend.Zig.Normalize
 import Malgo.Backend.Zig.ClosureConv

--- a/lean/Malgo/Backend/Scheme.lean
+++ b/lean/Malgo/Backend/Scheme.lean
@@ -1,0 +1,608 @@
+import Malgo.Prelude
+import Malgo.Id
+import Malgo.Module
+import Malgo.Sequent.Fun
+import Malgo.Sequent.Core.Join
+
+/-! Port of `src/Malgo/Backend/Scheme.hs`: the Scheme backend that lowers
+the Join IR to Chez Scheme source text.
+
+The Haskell pass runs under `Reader ModuleName` and uses no fresh names
+(`State Uniq` is absent), so the whole port is a pure function
+`compileToScheme : ModuleName → Join.Program → String` (`Text → String`).
+
+`mangleId`/`mangleText`/`escapeString`/`escapeChar` and the embedded
+`schemeRuntime` prelude are ported byte-for-byte: mangling fixes the
+generated symbol names, and the runtime string is fed to Chez Scheme by
+the self-host gate.
+
+One deviation: Haskell's `mangleChar` fall-through uses `Data.Char.isAlphaNum`
+(Unicode-aware), whereas Lean's `Char.isAlphanum` is ASCII-only. The Greek
+letters that actually occur in Malgo identifiers are handled by explicit
+cases before the fall-through, and any remaining non-ASCII alphanumeric is
+mangled to `_u<codepoint>_` deterministically, so generated programs stay
+self-consistent (the self-host gate diffs program output, not source
+text). -/
+
+namespace Malgo.Backend.Scheme
+
+open Malgo.Sequent.Fun (Name Literal Tag Pattern)
+open Malgo.Sequent.Core
+
+/-- Mangle a single character to a valid-Scheme-identifier fragment. -/
+def mangleChar (c : Char) : String :=
+  match c with
+  | '#' => "_hash_"
+  | '.' => "_dot_"
+  | '\'' => "_prime_"
+  | '-' => "_dash_"
+  | '?' => "_q_"
+  | '!' => "_bang_"
+  | '/' => "_slash_"
+  | '+' => "_plus_"
+  | '*' => "_star_"
+  | '<' => "_lt_"
+  | '>' => "_gt_"
+  | '=' => "_eq_"
+  -- Greek letters
+  | 'α' => "alpha"
+  | 'β' => "beta"
+  | 'γ' => "gamma"
+  | 'δ' => "delta"
+  | 'λ' => "lambda_"
+  | 'μ' => "mu"
+  | c => if c.isAlphanum || c == '_' then String.singleton c else "_u" ++ toString c.toNat ++ "_"
+
+/-- Mangle a text string to be a valid Scheme identifier. -/
+def mangleText (s : String) : String :=
+  String.join (s.toList.map mangleChar)
+
+/-- Mangle a Malgo `Id` into a valid Scheme identifier. -/
+def mangleId (x : Malgo.Id) : String :=
+  match x.sort with
+  | .external => mangleText (x.moduleName.toStr ++ "." ++ x.name)
+  | .internal uniq => mangleText x.name ++ "_" ++ toString uniq
+  | .temporal uniq => "_t_" ++ mangleText x.name ++ "_" ++ toString uniq
+
+def escapeChar (c : Char) : String :=
+  match c with
+  | ' ' => "space"
+  | '\n' => "newline"
+  | '\t' => "tab"
+  | '\r' => "return"
+  | '\x00' => "nul"
+  | '\x7f' => "delete"
+  | c => String.singleton c
+
+/-- Escape special characters in a string for Scheme output. -/
+def escapeString (s : String) : String :=
+  String.join <| s.toList.map fun c =>
+    match c with
+    | '\\' => "\\\\"
+    | '"' => "\\\""
+    | '\n' => "\\n"
+    | '\r' => "\\r"
+    | '\t' => "\\t"
+    | c => String.singleton c
+
+def compileTag : Tag → String
+  | .tuple => "tuple"
+  | .tag t => mangleText t
+
+/-- Compile a literal to a Scheme expression. Floats render via
+`haskellShowFloat`/`haskellShowFloat32` (the Haskell backend emits `show`'s
+output; Chez reads both fixed and `e`-notation). -/
+def compileLiteral : Literal → String
+  | .int32 n => toString n.toInt
+  | .int64 n => toString n.toInt
+  | .float f => Malgo.haskellShowFloat32 f
+  | .double d => Malgo.haskellShowFloat d
+  | .char c => "#\\" ++ escapeChar c
+  | .string t => "\"" ++ escapeString t ++ "\""
+
+/-- Concatenate arguments with spaces, prepending a space if non-empty. -/
+def concatArgs : List String → String
+  | [] => ""
+  | xs => " " ++ " ".intercalate xs
+
+private def binop (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a, b] => "(" ++ r ++ " (" ++ op ++ " " ++ a ++ " " ++ b ++ "))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+private def unaryop (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a] => "(" ++ r ++ " (" ++ op ++ " " ++ a ++ "))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Comparison returning 1/0 instead of `#t`/`#f`. -/
+private def cmpop (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a, b] => "(" ++ r ++ " (if (" ++ op ++ " " ++ a ++ " " ++ b ++ ") 1 0))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Negated comparison returning 1/0. -/
+private def cmpopNeg (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a, b] => "(" ++ r ++ " (if (not (" ++ op ++ " " ++ a ++ " " ++ b ++ ")) 1 0))"
+  | _ => "(" ++ r ++ " (error 'prim \"not-" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Unary predicate returning 1/0. -/
+private def cmpBool (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a] => "(" ++ r ++ " (if (" ++ op ++ " " ++ a ++ ") 1 0))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Compile a primitive operation. -/
+def compilePrimitive (name : String) (args : List String) (ret : String) : String :=
+  match name with
+  | "add_i32" => binop "+" args ret
+  | "sub_i32" => binop "-" args ret
+  | "mul_i32" => binop "*" args ret
+  | "div_i32" => binop "quotient" args ret
+  | "mod_i32" => binop "modulo" args ret
+  | "add_i64" => binop "+" args ret
+  | "sub_i64" => binop "-" args ret
+  | "mul_i64" => binop "*" args ret
+  | "div_i64" => binop "quotient" args ret
+  | "mod_i64" => binop "modulo" args ret
+  | "add_f64" => binop "+" args ret
+  | "sub_f64" => binop "-" args ret
+  | "mul_f64" => binop "*" args ret
+  | "div_f64" => binop "/" args ret
+  | "eq_i32" => binop "equal?" args ret
+  | "ne_i32" => binop "malgo-ne" args ret
+  | "lt_i32" => binop "<" args ret
+  | "le_i32" => binop "<=" args ret
+  | "gt_i32" => binop ">" args ret
+  | "ge_i32" => binop ">=" args ret
+  | "eq_i64" => binop "equal?" args ret
+  | "ne_i64" => binop "malgo-ne" args ret
+  | "lt_i64" => binop "<" args ret
+  | "le_i64" => binop "<=" args ret
+  | "gt_i64" => binop ">" args ret
+  | "ge_i64" => binop ">=" args ret
+  | "eq_f64" => binop "equal?" args ret
+  | "ne_f64" => binop "malgo-ne" args ret
+  | "lt_f64" => binop "<" args ret
+  | "le_f64" => binop "<=" args ret
+  | "gt_f64" => binop ">" args ret
+  | "ge_f64" => binop ">=" args ret
+  | "eq_char" => binop "char=?" args ret
+  | "ne_char" => binop "malgo-ne" args ret
+  | "string_append" => binop "string-append" args ret
+  | "int32_to_string" => unaryop "number->string" args ret
+  | "int64_to_string" => unaryop "number->string" args ret
+  | "float_to_string" => unaryop "number->string" args ret
+  | "double_to_string" => unaryop "number->string" args ret
+  | "char_to_string" => unaryop "string" args ret
+  | "string_to_int32" => unaryop "string->number" args ret
+  | "string_to_int64" => unaryop "string->number" args ret
+  | "string_length" => unaryop "string-length" args ret
+  | "string_at" => binop "string-ref" args ret
+  | "string_substring" =>
+    match args with
+    | [s, start, len] => "(" ++ ret ++ " (substring " ++ s ++ " " ++ start ++ " (+ " ++ start ++ " " ++ len ++ ")))"
+    | _ => "(error 'prim \"string_substring: wrong number of arguments\")"
+  | "putchar" =>
+    match args with
+    | [c] => "(begin (display " ++ c ++ ") (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"putchar: wrong number of arguments\")"
+  | "getchar" =>
+    "(" ++ ret ++ " (let ((c (read-char))) (if (eof-object? c) #f c)))"
+  | "putstr" =>
+    match args with
+    | [s] => "(begin (display " ++ s ++ ") (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"putstr: wrong number of arguments\")"
+  | "println" =>
+    match args with
+    | [s] => "(begin (display " ++ s ++ ") (newline) (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"println: wrong number of arguments\")"
+  | "error" =>
+    match args with
+    | [msg] => "(error 'malgo " ++ msg ++ ")"
+    | _ => "(error 'malgo \"error\")"
+  | "negate_i32" => unaryop "-" args ret
+  | "negate_i64" => unaryop "-" args ret
+  | "negate_f64" => unaryop "-" args ret
+  -- malgo_* foreign import names
+  | "malgo_read_file" =>
+    match args with
+    | [path] => "(" ++ ret ++ " (call-with-input-file " ++ path ++ " (lambda (p) (get-string-all p))))"
+    | _ => "(error 'prim \"malgo_read_file: wrong number of arguments\")"
+  | "malgo_write_file" =>
+    match args with
+    | [path, content] => "(begin (call-with-output-file " ++ path ++ " (lambda (p) (put-string p " ++ content ++ "))) (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"malgo_write_file: wrong number of arguments\")"
+  | "malgo_get_line" =>
+    "(" ++ ret ++ " (let ((line (read-line))) (if (eof-object? line) \"\" line)))"
+  | "malgo_get_args" =>
+    "(" ++ ret ++ " (malgo-string-join (cdr (command-line)) \"\\n\"))"
+  | "malgo_exit_success" => "(exit 0)"
+  | "malgo_stderr_string" =>
+    match args with
+    | [s] => "(begin (put-string (current-error-port) " ++ s ++ ") (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"malgo_stderr_string: wrong number of arguments\")"
+  | "malgo_string_to_int32" => unaryop "string->number" args ret
+  | "malgo_string_to_int64" => unaryop "string->number" args ret
+  -- Arithmetic (malgo_* foreign import names from Builtin.mlg)
+  | "malgo_add_int32_t" => binop "+" args ret
+  | "malgo_sub_int32_t" => binop "-" args ret
+  | "malgo_mul_int32_t" => binop "*" args ret
+  | "malgo_div_int32_t" => binop "quotient" args ret
+  | "malgo_mod_int32_t" => binop "modulo" args ret
+  | "malgo_neg_int32_t" => unaryop "-" args ret
+  | "malgo_add_int64_t" => binop "+" args ret
+  | "malgo_sub_int64_t" => binop "-" args ret
+  | "malgo_mul_int64_t" => binop "*" args ret
+  | "malgo_div_int64_t" => binop "quotient" args ret
+  | "malgo_mod_int64_t" => binop "modulo" args ret
+  | "malgo_neg_int64_t" => unaryop "-" args ret
+  | "malgo_add_float" => binop "+" args ret
+  | "malgo_sub_float" => binop "-" args ret
+  | "malgo_mul_float" => binop "*" args ret
+  | "malgo_div_float" => binop "/" args ret
+  | "malgo_neg_float" => unaryop "-" args ret
+  | "malgo_add_double" => binop "+" args ret
+  | "malgo_sub_double" => binop "-" args ret
+  | "malgo_mul_double" => binop "*" args ret
+  | "malgo_div_double" => binop "/" args ret
+  | "malgo_neg_double" => unaryop "-" args ret
+  -- Comparisons return Int32# (1=true, 0=false) to match isTrue# pattern matching
+  | "malgo_eq_int32_t" => cmpop "equal?" args ret
+  | "malgo_ne_int32_t" => cmpopNeg "equal?" args ret
+  | "malgo_lt_int32_t" => cmpop "<" args ret
+  | "malgo_le_int32_t" => cmpop "<=" args ret
+  | "malgo_gt_int32_t" => cmpop ">" args ret
+  | "malgo_ge_int32_t" => cmpop ">=" args ret
+  | "malgo_eq_int64_t" => cmpop "equal?" args ret
+  | "malgo_ne_int64_t" => cmpopNeg "equal?" args ret
+  | "malgo_lt_int64_t" => cmpop "<" args ret
+  | "malgo_le_int64_t" => cmpop "<=" args ret
+  | "malgo_gt_int64_t" => cmpop ">" args ret
+  | "malgo_ge_int64_t" => cmpop ">=" args ret
+  | "malgo_eq_float" => cmpop "equal?" args ret
+  | "malgo_ne_float" => cmpopNeg "equal?" args ret
+  | "malgo_lt_float" => cmpop "<" args ret
+  | "malgo_le_float" => cmpop "<=" args ret
+  | "malgo_gt_float" => cmpop ">" args ret
+  | "malgo_ge_float" => cmpop ">=" args ret
+  | "malgo_eq_double" => cmpop "equal?" args ret
+  | "malgo_ne_double" => cmpopNeg "equal?" args ret
+  | "malgo_lt_double" => cmpop "<" args ret
+  | "malgo_le_double" => cmpop "<=" args ret
+  | "malgo_gt_double" => cmpop ">" args ret
+  | "malgo_ge_double" => cmpop ">=" args ret
+  | "malgo_eq_char" => cmpop "char=?" args ret
+  | "malgo_ne_char" => cmpopNeg "char=?" args ret
+  | "malgo_lt_char" => cmpop "char<?" args ret
+  | "malgo_le_char" => cmpop "char<=?" args ret
+  | "malgo_gt_char" => cmpop "char>?" args ret
+  | "malgo_ge_char" => cmpop "char>=?" args ret
+  | "malgo_eq_string" => cmpop "string=?" args ret
+  | "malgo_ne_string" => cmpopNeg "string=?" args ret
+  | "malgo_lt_string" => cmpop "string<?" args ret
+  | "malgo_le_string" => cmpop "string<=?" args ret
+  | "malgo_gt_string" => cmpop "string>?" args ret
+  | "malgo_ge_string" => cmpop "string>=?" args ret
+  -- Char/string operations
+  | "malgo_char_ord" => unaryop "char->integer" args ret
+  | "malgo_int32_t_to_char" => unaryop "integer->char" args ret
+  | "malgo_char_to_string" => unaryop "string" args ret
+  | "malgo_is_digit" => cmpBool "char-numeric?" args ret
+  | "malgo_is_lower" => cmpBool "char-lower-case?" args ret
+  | "malgo_is_upper" => cmpBool "char-upper-case?" args ret
+  | "malgo_is_alphanum" =>
+    match args with
+    | [c] => "(" ++ ret ++ " (if (or (char-alphabetic? " ++ c ++ ") (char-numeric? " ++ c ++ ")) 1 0))"
+    | _ => "(error 'prim \"malgo_is_alphanum: wrong number of arguments\")"
+  | "malgo_string_append" => binop "string-append" args ret
+  | "malgo_string_length" => unaryop "string-length" args ret
+  | "malgo_string_at" =>
+    match args with
+    | [i, s] => "(" ++ ret ++ " (string-ref " ++ s ++ " " ++ i ++ "))"
+    | _ => "(error 'prim \"malgo_string_at: wrong number of arguments\")"
+  | "malgo_string_cons" =>
+    match args with
+    | [c, s] => "(" ++ ret ++ " (string-append (string " ++ c ++ ") " ++ s ++ "))"
+    | _ => "(error 'prim \"malgo_string_cons: wrong number of arguments\")"
+  | "malgo_substring" =>
+    match args with
+    | [s, start, end_] => "(" ++ ret ++ " (substring " ++ s ++ " " ++ start ++ " " ++ end_ ++ "))"
+    | _ => "(error 'prim \"malgo_substring: wrong number of arguments\")"
+  | "malgo_string_reverse" =>
+    match args with
+    | [s] => "(" ++ ret ++ " (list->string (reverse (string->list " ++ s ++ "))))"
+    | _ => "(error 'prim \"malgo_string_reverse: wrong number of arguments\")"
+  -- Conversion
+  | "malgo_int32_t_to_string" => unaryop "number->string" args ret
+  | "malgo_int64_t_to_string" => unaryop "number->string" args ret
+  | "malgo_float_to_string" => unaryop "number->string" args ret
+  | "malgo_double_to_string" => unaryop "number->string" args ret
+  -- IO
+  | "malgo_print_string" =>
+    match args with
+    | [s] => "(begin (display " ++ s ++ ") (" ++ ret ++ " (list 'tuple)))"
+    | _ => "(error 'prim \"malgo_print_string: wrong number of arguments\")"
+  | "malgo_print_char" =>
+    match args with
+    | [c] => "(begin (display " ++ c ++ ") (" ++ ret ++ " (list 'tuple)))"
+    | _ => "(error 'prim \"malgo_print_char: wrong number of arguments\")"
+  | "malgo_print" =>
+    match args with
+    | [v] => "(begin (malgo-print-value " ++ v ++ ") (" ++ ret ++ " (list 'tuple)))"
+    | _ => "(error 'prim \"malgo_print: wrong number of arguments\")"
+  | "malgo_newline" => "(begin (newline) (" ++ ret ++ " (list 'tuple)))"
+  | "malgo_flush" => "(begin (flush-output-port) (" ++ ret ++ " (list 'tuple)))"
+  | "malgo_get_char" =>
+    "(" ++ ret ++ " (let ((c (read-char))) (if (eof-object? c) #\\nul c)))"
+  | "malgo_get_contents" =>
+    "(" ++ ret ++ " (get-string-all (current-input-port)))"
+  -- Error / control
+  | "malgo_panic" =>
+    match args with
+    | [msg] => "(error 'panic " ++ msg ++ ")"
+    | _ => "(error 'panic \"panic\")"
+  | "malgo_unsafe_cast" =>
+    match args with
+    | [x] => "(" ++ ret ++ " " ++ x ++ ")"
+    | _ => "(error 'prim \"malgo_unsafe_cast: wrong number of arguments\")"
+  | "malgo_exit_failure" => "(exit 1)"
+  -- Math
+  | "sqrt" => unaryop "sqrt" args ret
+  | "sqrtf" => unaryop "sqrt" args ret
+  -- Inserted by Malgo.Sequent.ReuseSpecialize for the Zig backend's
+  -- reference-counting reuse analysis; a no-op everywhere else.
+  | "reuseHint" =>
+    match args with
+    | [x] => "(" ++ ret ++ " " ++ x ++ ")"
+    | _ => "(error 'prim \"reuseHint: wrong number of arguments\")"
+  | _ => "(error 'prim \"unknown primitive: " ++ name ++ "\")"
+
+/-- Compile a pattern against a scrutinee expression, returning
+`(guard, let*-bindings)`: a Scheme boolean guard and sequential `let*`
+entries. -/
+partial def compilePattern (scrutinee : String) : Pattern → String × List (String × String)
+  | .pvar _ n => ("#t", [(mangleId n, scrutinee)])
+  | .pliteral _ lit => ("(equal? " ++ scrutinee ++ " " ++ compileLiteral lit ++ ")", [])
+  | .destruct _ tag pats =>
+    let tagStr := compileTag tag
+    let tagCheck := "(and (pair? " ++ scrutinee ++ ") (eq? (car " ++ scrutinee ++ ") '" ++ tagStr ++ "))"
+    let subResults := pats.mapIdx fun i p =>
+      compilePattern ("(list-ref " ++ scrutinee ++ " " ++ toString (i + 1) ++ ")") p
+    let subGuards := (subResults.map (·.1)).filter (· != "#t")
+    let subBindings := (subResults.map (·.2)).flatten
+    let fullGuard := match subGuards with
+      | [] => tagCheck
+      | gs => "(and " ++ " ".intercalate (tagCheck :: gs) ++ ")"
+    (fullGuard, subBindings)
+  | .expand _ fieldPats =>
+    let subResults := (sortAssocAscending fieldPats).map fun (fname, p) =>
+      let mangledFname := mangleText fname
+      let raw := "(cdr (assq '" ++ mangledFname ++ " " ++ scrutinee ++ "))"
+      let tmpName := "%fv_" ++ mangledFname
+      let tmpName2 := "%fvr_" ++ mangledFname
+      -- Object fields are stored as thunks; force them before pattern matching
+      let forced :=
+        "(let ((" ++ tmpName ++ " " ++ raw ++ ")) " ++
+        "(if (procedure? " ++ tmpName ++ ") " ++
+        "(" ++ tmpName ++ " (lambda (" ++ tmpName2 ++ ") " ++ tmpName2 ++ ")) " ++
+        tmpName ++ "))"
+      compilePattern forced p
+    let subGuards := (subResults.map (·.1)).filter (· != "#t")
+    let subBindings := (subResults.map (·.2)).flatten
+    let fullGuard := match subGuards with
+      | [] => "#t"
+      | [g] => g
+      | gs => "(and " ++ " ".intercalate gs ++ ")"
+    (fullGuard, subBindings)
+
+mutual
+
+/-- Compile a Producer to a Scheme expression. -/
+partial def compileProducer : Join.Producer → String
+  | .var _ name => mangleId name
+  | .literal _ lit => compileLiteral lit
+  | .construct _ tag producers returns =>
+    let tagStr := compileTag tag
+    let prodStrs := producers.map compileProducer
+    let retStrs := returns.map mangleId
+    "(list '" ++ tagStr ++ concatArgs prodStrs ++ concatArgs retStrs ++ ")"
+  | .lambda _ names body =>
+    let nameStrs := names.map mangleId
+    let bodyStr := compileStatement body
+    match nameStrs with
+    | [] => "(lambda () " ++ bodyStr ++ ")"
+    | [x] => "(lambda (" ++ x ++ ") " ++ bodyStr ++ ")"
+    | _ => "(lambda (" ++ " ".intercalate nameStrs ++ ") " ++ bodyStr ++ ")"
+  | .mu _ name stmt =>
+    let nameStr := mangleId name
+    let bodyStr := compileStatement stmt
+    "(lambda (" ++ nameStr ++ ") " ++ bodyStr ++ ")"
+  | .object _ fields =>
+    let fieldStrs := (sortAssocAscending fields).map compileField
+    "(list " ++ " ".intercalate fieldStrs ++ ")"
+
+partial def compileField : String × Name × Join.Statement → String
+  | (fieldName, retName, body) =>
+    let retStr := mangleId retName
+    let bodyStr := compileStatement body
+    "(cons '" ++ mangleText fieldName ++ " (lambda (" ++ retStr ++ ") " ++ bodyStr ++ "))"
+
+/-- Compile a Consumer to a Scheme expression. -/
+partial def compileConsumer : Join.Consumer → String
+  | .label _ name => mangleId name
+  | .apply _ producers returns =>
+    let prodStrs := producers.map compileProducer
+    let retStrs := returns.map mangleId
+    "(lambda (%fn) (%fn" ++ concatArgs (prodStrs ++ retStrs) ++ "))"
+  | .project _ field returnName =>
+    let retStr := mangleId returnName
+    "(lambda (%rec) (let ((%v (cdr (assq '" ++ mangleText field ++ " %rec)))) (if (procedure? %v) (%v " ++ retStr ++ ") (" ++ retStr ++ " %v))))"
+  | .«then» _ name body =>
+    let nameStr := mangleId name
+    let bodyStr := compileStatement body
+    "(lambda (" ++ nameStr ++ ") " ++ bodyStr ++ ")"
+  | .finish _ => "malgo-finish"
+  | .select _ branches =>
+    let branchStrs := branches.map compileBranch
+    "(lambda (%v) (cond " ++ " ".intercalate branchStrs ++ " (else (error 'select \"no matching branch\" %v))))"
+
+partial def compileBranch : Join.Branch → String
+  | .branch _ pat body =>
+    let bodyStr := compileStatement body
+    let (guard, bindings) := compilePattern "%v" pat
+    let withBindings :=
+      if bindings.isEmpty then bodyStr
+      else "(let* (" ++ " ".intercalate (bindings.map fun (n, e) => "(" ++ n ++ " " ++ e ++ ")") ++ ") " ++ bodyStr ++ ")"
+    "(" ++ guard ++ " " ++ withBindings ++ ")"
+
+/-- Compile a Statement to a Scheme expression. -/
+partial def compileStatement : Join.Statement → String
+  | .cut producer returnName =>
+    let prodStr := compileProducer producer
+    let retStr := mangleId returnName
+    "(" ++ retStr ++ " " ++ prodStr ++ ")"
+  | .join _ name consumer body =>
+    let nameStr := mangleId name
+    let consStr := compileConsumer consumer
+    let bodyStr := compileStatement body
+    "(let ((" ++ nameStr ++ " " ++ consStr ++ ")) " ++ bodyStr ++ ")"
+  | .primitive _ primName producers returnName =>
+    let prodStrs := producers.map compileProducer
+    let retStr := mangleId returnName
+    compilePrimitive primName prodStrs retStr
+  | .invoke _ name returnName =>
+    let nameStr := mangleId name
+    let retStr := mangleId returnName
+    "(" ++ nameStr ++ " " ++ retStr ++ ")"
+  | .externalCall _ name producers returnName =>
+    let prodStrs := producers.map compileProducer
+    let retStr := mangleId returnName
+    compilePrimitive name prodStrs retStr
+  | .binOp _ op lhs rhs returnName =>
+    let lhsStr := compileProducer lhs
+    let rhsStr := compileProducer rhs
+    let retStr := mangleId returnName
+    compilePrimitive op [lhsStr, rhsStr] retStr
+  | .ifz _ cond thenBranch elseBranch =>
+    let condStr := compileProducer cond
+    let thenStr := compileStatement thenBranch
+    let elseStr := compileStatement elseBranch
+    "(if (eqv? " ++ condStr ++ " 0) " ++ thenStr ++ " " ++ elseStr ++ ")"
+
+end
+
+def compileDefinition : Range × Name × Name × Join.Statement → String
+  | (_, name, returnName, body) =>
+    let nameStr := mangleId name
+    let returnStr := mangleId returnName
+    let bodyStr := compileStatement body
+    "(define (" ++ nameStr ++ " " ++ returnStr ++ ")\n  " ++ bodyStr ++ ")\n"
+
+/-- Minimal Chez Scheme runtime for Malgo. Ported byte-for-byte from
+`schemeRuntime` in `Scheme.hs` (`T.unlines` = each line followed by a
+newline, including a trailing blank line). -/
+def schemeRuntime : String :=
+  "\n".intercalate
+    [ ";; Malgo Runtime Support",
+      ";; Generated by Malgo Scheme Backend",
+      "",
+      ";; Result printer",
+      "(define (malgo-print-result v)",
+      "  (malgo-print-value v)",
+      "  (newline))",
+      "",
+      "(define (malgo-print-value v)",
+      "  (cond",
+      "    ((boolean? v) (display (if v \"true\" \"false\")))",
+      "    ((null? v) (display \"()\"))",
+      "    ((string? v)",
+      "     (display \"\\\"\")",
+      "     (display v)",
+      "     (display \"\\\"\"))",
+      "    ((char? v)",
+      "     (display \"'\")",
+      "     (display v)",
+      "     (display \"'\"))",
+      "    ((pair? v)",
+      "     (if (and (pair? (car v)) (symbol? (caar v)))",
+      "         ;; Record",
+      "         (begin",
+      "           (display \"{ \")",
+      "           (let loop ((fields v))",
+      "             (unless (null? fields)",
+      "               (display (caar fields))",
+      "               (display \" = \")",
+      "               (malgo-print-value (cdar fields))",
+      "               (unless (null? (cdr fields))",
+      "                 (display \", \"))",
+      "               (loop (cdr fields))))",
+      "           (display \" }\"))",
+      "         ;; Tagged data",
+      "         (if (symbol? (car v))",
+      "             (if (null? (cdr v))",
+      "                 (display (car v))",
+      "                 (begin",
+      "                   (display \"(\")",
+      "                   (display (car v))",
+      "                   (let loop ((args (cdr v)))",
+      "                     (unless (null? args)",
+      "                       (display \" \")",
+      "                       (malgo-print-value (car args))",
+      "                       (loop (cdr args))))",
+      "                   (display \")\")))",
+      "             ;; Regular pair",
+      "             (begin",
+      "               (display \"(\")",
+      "               (malgo-print-value (car v))",
+      "               (display \" . \")",
+      "               (malgo-print-value (cdr v))",
+      "               (display \")\")))))",
+      "    ((procedure? v) (display \"<function>\"))",
+      "    (else (display v))))",
+      "",
+      ";; Not-equal operator",
+      "(define (malgo-ne a b) (not (equal? a b)))",
+      "",
+      ";; String join (SRFI-13 not available in Chez Scheme)",
+      "(define (malgo-string-join lst sep)",
+      "  (if (null? lst) \"\"",
+      "    (let loop ((rest (cdr lst)) (acc (car lst)))",
+      "      (if (null? rest) acc",
+      "        (loop (cdr rest) (string-append acc sep (car rest)))))))",
+      "",
+      ";; Finish continuation (halt)",
+      "(define (malgo-finish v) v)",
+      "" ]
+    ++ "\n"
+
+/-- Compile a Join IR program to Scheme source code. -/
+def compileToScheme (modName : ModuleName) (program : Join.Program) : String :=
+  let mainName := mangleText (modName.toStr ++ ".main")
+  schemeRuntime
+    ++ "\n;; Definitions\n"
+    ++ "\n".intercalate (program.definitions.map compileDefinition)
+    ++ "\n\n;; Run main\n"
+    ++ "(" ++ mainName ++ " (lambda (fn) (fn (list 'tuple) malgo-finish)))\n"
+
+private def r0 : Range := ⟨SourcePos.initial "", SourcePos.initial ""⟩
+private def nm (s : String) : Name := { name := s, moduleName := .moduleName "t", sort := .external }
+
+-- Mangling / literal / small-tree checks.
+#guard mangleText "foo-bar?" == "foo_dash_bar_q_"
+-- External ids mangle "<module>.<name>", so the dot becomes "_dot_".
+#guard mangleId (nm "map") == "t_dot_map"
+#guard mangleId { name := "x", moduleName := .moduleName "t", sort := .temporal 3 } == "_t_x_3"
+#guard mangleId { name := "y", moduleName := .moduleName "t", sort := .internal 7 } == "y_7"
+#guard escapeString "a\"b\\c" == "a\\\"b\\\\c"
+#guard compileLiteral (.int32 (-5)) == "-5"
+#guard compileLiteral (.float 3.14) == "3.14"
+#guard compileLiteral (.string "hi\n") == "\"hi\\n\""
+#guard compileLiteral (.char ' ') == "#\\space"
+#guard compileStatement (.invoke r0 (nm "f") (nm "k")) == "(t_dot_f t_dot_k)"
+#guard compileStatement (.cut (.literal r0 (.int32 1)) (nm "k")) == "(t_dot_k 1)"
+#guard compileStatement (.binOp r0 "add_i32" (.var r0 (nm "a")) (.var r0 (nm "b")) (nm "k"))
+  == "(t_dot_k (+ t_dot_a t_dot_b))"
+
+end Malgo.Backend.Scheme

--- a/lean/Malgo/Driver.lean
+++ b/lean/Malgo/Driver.lean
@@ -13,6 +13,7 @@ import Malgo.Sequent.Eval
 import Malgo.Sequent.BigStepEval
 import Malgo.Query
 import Malgo.Query.Engine
+import Malgo.Backend.Scheme
 import Malgo.Backend.Zig
 import Malgo.Backend.Zig.Toolchain
 
@@ -205,7 +206,7 @@ already-parsed module seeded into the engine's `cacheParsedModule` under its
 own resolved name, so `fetchLinkedProgram` starts from a cache hit instead
 of re-deriving the module's identity.
 
-`compileAndEval`/`compileZig`/`compileToNativeExecutable`
+`compileAndEval`/`compileScheme`/`compileZig`/`compileToNativeExecutable`
 (all four CLI entries below) share this exact parse+link+seed sequence —
 `linkForCli` is the one place it lives, so a future fix only has one call
 site to update. -/
@@ -238,8 +239,19 @@ def compileAndEval (flag : Flag) (path : System.FilePath) : IO UInt32 := do
     | .bigStep => Malgo.Sequent.BigStepEval.bigStepEvalProgram moduleName handlers linked
   return 0
 
-/-- CLI entry for `malgo eval --target zig`: link exactly as
-`compileAndEval` but, instead of interpreting, run the Zig lowering pipeline (`Malgo.Backend.Zig.compileToZigText`, which
+/-- CLI entry for `malgo eval --target scheme`: link exactly as
+`compileAndEval` but, instead of interpreting, emit the Scheme source for the
+linked Join program. Mirrors Haskell `Driver.compileFromAST`'s `TargetScheme`
+branch. -/
+def compileScheme (flag : Flag) (path : System.FilePath) : IO UInt32 := do
+  let ws ← Workspace.setup
+  MalgoM.run flag {} do
+    let (moduleName, linked) ← linkForCli ws path
+    MalgoM.io (IO.print (Malgo.Backend.Scheme.compileToScheme moduleName linked))
+  return 0
+
+/-- CLI entry for `malgo eval --target zig`: link exactly as `compileScheme`,
+then run the Zig lowering pipeline (`Malgo.Backend.Zig.compileToZigText`, which
 runs ClosureConv → Peephole → Perceus → Reuse, the linearity check, and Emit)
 and print the generated Zig source. Mirrors Haskell `Driver.compileFromAST`'s
 `TargetZig` branch. -/

--- a/lean/Malgo/Prelude.lean
+++ b/lean/Malgo/Prelude.lean
@@ -318,6 +318,7 @@ instance : Pretty Range where
 /-- Compilation target backend. -/
 inductive Target where
   | eval
+  | scheme
   | zig
   deriving BEq, Repr
 

--- a/lean/ci-gates.env
+++ b/lean/ci-gates.env
@@ -14,6 +14,10 @@
 # Flip LEAN_SELFHOST_L2 back to 1 when #385 brings L2 back into budget. That
 # is listed as #385's completion criterion, so this flag is the thing that
 # closes it.
+#
+# The v4.0.0 release is held until this flag is back at 1 -- see milestone
+# v4.0.0. The Chez baseline the 7.5x is measured against is re-measurable with
+# `TARGET=scheme bash scripts/selfhost-level2.sh`.
 LEAN_ZIG=1
 LEAN_SELFHOST=1
 LEAN_SELFHOST_L2=0

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,7 @@ url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d
 node = "latest"
 npm = "latest"
 hyperfine = "latest"
+chezscheme = "latest"
 # Pinned: Zig minor releases break std (e.g. std.Io churn between 0.15 and
 # 0.16). Bump deliberately, re-running the full zig-golden sweep.
 zig = "0.16.0"

--- a/scripts/selfhost-level2.sh
+++ b/scripts/selfhost-level2.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # selfhost-level2.sh — Level 2 metacircular interpreter test
 #
-# Level 1: malgoc (Main.mlg compiled to a native binary via the Zig backend)
+# Level 1: the Malgo evaluator (Main.mlg), built into a runnable artifact,
 #          evaluates a .mlg program directly
-# Level 2: malgoc evaluates Main.mlg, which evaluates a .mlg program
+# Level 2: that artifact evaluates Main.mlg, which evaluates a .mlg program
+#
+# TARGET selects how Main.mlg becomes runnable:
+#   TARGET=zig    (default) `malgo compile --opt release-fast` -> native binary
+#   TARGET=scheme           `malgo eval --target scheme` -> main.scm, run under Chez
+#
+# The Scheme path is retained as the cross-implementation performance reference
+# for #385: it is the only baseline the Zig backend's numbers can be read
+# against. Do not delete it until #385 closes -- see #400.
 #
 # This script verifies the metacircular property: the Malgo evaluator
 # written in Malgo can evaluate itself while correctly running programs.
@@ -14,10 +22,18 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 MALGO=${MALGO:-lean/.lake/build/bin/malgo}
+TARGET=${TARGET:-zig}
+SCHEME=${SCHEME:-scheme}
 # Level 2 is ~50-200x slower than Level 1, and the Zig backend is a further
 # ~7.5x slower per case than the Chez Scheme path it replaced (measured:
-# 220s vs 29s on Fib, on an M-series Mac). Budget accordingly.
-CASE_TIMEOUT=${CASE_TIMEOUT:-1200}
+# 220s vs 29s on Fib, on an M-series Mac; #385). Hence the per-target default:
+# 300 is the value the Chez path shipped with before #384, and still 10x the
+# 29s observation.
+case "$TARGET" in
+  zig)    CASE_TIMEOUT=${CASE_TIMEOUT:-1200} ;;
+  scheme) CASE_TIMEOUT=${CASE_TIMEOUT:-300} ;;
+  *) echo "unknown TARGET '$TARGET' (expected zig|scheme)" >&2; exit 1 ;;
+esac
 PRECOMPILE_TIMEOUT=${PRECOMPILE_TIMEOUT:-180}
 KEEP_WORK=${KEEP_WORK:-0}
 MALGO_WORK_DIR=${MALGO_WORK_DIR:-.malgo-work}
@@ -81,18 +97,41 @@ done
 
 log "precompile phase complete (${#precompile[@]} files)"
 
-NATIVE_MAIN="$MALGO_WORK_DIR/malgoc"
 mkdir -p "$MALGO_WORK_DIR"
-if ! command -v zig >/dev/null 2>&1; then
-  echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
-  exit 1
-fi
-log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
-if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$NATIVE_MAIN" --opt release-fast; then
-  log "native compilation failed"
-  exit 1
-fi
-log "native compilation done: $NATIVE_MAIN"
+
+# Every arm must set RUNNER: under `set -u`, bash 3.2 errors on "${RUNNER[@]}"
+# for an unset/empty array. The `*)` arm above already exited, so RUNNER is
+# always populated by the time run_case uses it.
+case "$TARGET" in
+  zig)
+    EVAL_MAIN="$MALGO_WORK_DIR/malgoc"
+    RUNNER=("$EVAL_MAIN")
+    if ! command -v zig >/dev/null 2>&1; then
+      echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
+      exit 1
+    fi
+    log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
+    if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$EVAL_MAIN" --opt release-fast; then
+      log "native compilation failed"
+      exit 1
+    fi
+    log "native compilation done: $EVAL_MAIN"
+    ;;
+  scheme)
+    EVAL_MAIN="$MALGO_WORK_DIR/main.scm"
+    RUNNER=("$SCHEME" --script "$EVAL_MAIN")
+    if ! command -v "$SCHEME" >/dev/null 2>&1; then
+      echo "'$SCHEME' not found on PATH (run 'mise install' to get chezscheme, or set SCHEME)." >&2
+      exit 1
+    fi
+    log "compiling Main.mlg to Scheme (Level 1 evaluator)"
+    if ! "$MALGO" eval --target scheme runtime/malgo/compiler/Main.mlg > "$EVAL_MAIN"; then
+      log "Scheme compilation failed"
+      exit 1
+    fi
+    log "Scheme compilation done: $EVAL_MAIN"
+    ;;
+esac
 
 # Level 2 test cases: a small subset of simple programs that complete quickly
 # even when interpreted by an interpreter.
@@ -105,8 +144,8 @@ level2_cases=(
 )
 
 total_cases=${#level2_cases[@]}
-log "starting Level 2 metacircular checks: ${total_cases} cases (parallel)"
-log "command: ./malgoc runtime/malgo/compiler/Main.mlg <case.mlg>"
+log "starting Level 2 metacircular checks: ${total_cases} cases (parallel, TARGET=$TARGET)"
+log "command: ${RUNNER[*]} runtime/malgo/compiler/Main.mlg <case.mlg>"
 
 results_dir="$MALGO_WORK_DIR/level2-results"
 rm -rf "$results_dir"
@@ -140,7 +179,7 @@ run_case() {
   out=$(mktemp)
   err=$(mktemp)
 
-  if printf 'Hello\n' | timeout "$CASE_TIMEOUT" "$NATIVE_MAIN" \
+  if printf 'Hello\n' | timeout "$CASE_TIMEOUT" "${RUNNER[@]}" \
       runtime/malgo/compiler/Main.mlg "$src" >"$out" 2>"$err"; then
     local case_elapsed=$((SECONDS - case_start))
     if cmp -s "$out" "$expected"; then


### PR DESCRIPTION
## Why

#386 deleted the Scheme backend on the grounds that self-hosting had just moved to
Zig in #384, so "nothing is lost". But #384 also measured the cost of that move:
Level 2 is ~7.5x slower per case through Zig than through Chez, which forced
`LEAN_SELFHOST_L2=0` (#395) and opened #385.

That deletion removed the only cross-implementation performance reference in the
repo. #385's "29s Chez" column became a frozen number in an issue body —
unreproducible from the tree, on another machine, or after a toolchain bump. The gap
had no denominator.

This restores the Scheme backend as that reference, and makes Level 2
target-selectable so the ratio stays checkable. Removal is tracked by #400 and
gated on #385; milestone `v4.0.0` holds the release until then.

## This is not `git revert d4c0264c`

A literal revert conflicts on 10 files / 18 hunks: 8 are Haskell files #397 deleted
three days later, and 2 are markdown whose surrounding prose #397 rewrote. The
backend existed in **both** trees, so only the Lean half comes back, applied as a
scoped reverse diff of `lean/` + `mise.toml` (which applies cleanly), then adjusted
for #387 having since removed `cocase`/`destructor` from the Join IR — 3 sites,
−19 lines. `Join.Producer` and `Join.Consumer` now have 6 constructors each, so both
matches stay exhaustive with no fallback arm.

**The deletion never shipped.** `git merge-base --is-ancestor d4c0264c v3.0.0` is
false: v3.0.0 was tagged 2026-07-25 15:19, #386 landed 21:44 the same day. v3.0.0
shipped *with* `--target scheme`, so restoring it and re-deleting it inside v4.0.0's
range is invisible to users. That is also why #400 belongs in this milestone rather
than after it — slipping past v4.0.0 would ship `--target scheme` back into the
public CLI and need a second major bump to remove.

## Level 2 target switch

`scripts/selfhost-level2.sh` takes `TARGET=zig|scheme`. The zig path is
byte-identical in behavior when `TARGET` is unset; `scheme` restores the pre-#384
invocation with its historical `CASE_TIMEOUT` default of 300. An unknown `TARGET`
fails before the multi-minute precompile rather than after it.

Level 1 (`selfhost-golden.sh`) is deliberately untouched: #385's own table has L1 at
parity on Zig, and L1 has a different shape (73 cases, throttled worker pool) that
would be a second switch to get wrong, running on every PR.

## Verification

- `lake build` — the restored file's 13 inline `#guard`s are compile-time assertions
- Full Lean suite unchanged (558 goldens + all non-golden gates)
- Level 2 **5/5 on both targets**, same 5-way parallel sweep: **Chez 31–35s/case, Zig
  221–249s/case**. That reproduces #385's ~7.5x from two measurements taken
  identically — the figure in the issue paired a Chez number of unknown methodology
  against a parallel Zig one, so the ratio was not previously apples-to-apples.

## One caveat, recorded in the tree

The Scheme backend is a **performance reference, not a correctness oracle** — the
interpreter (`Malgo.Sequent.Eval`) remains the oracle. It never had a golden gate,
and sweeping all 73 goldens through it passes 71: `EmptyConstructor` renders an empty
constructor differently, and `LabelGoto` leaks a continuation into `number->string`.
Both testcases predate the backend's deletion by months, so these are long-standing
gaps, not regressions. Every copattern/codata case passes, which is what confirms the
`cocase` removal. Noted in `AGENTS.md` and `.claude/rules/selfhost-evaluator.md` so
it is not mistaken for a second oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
