### PR TITLE
perf(bench): add a MALGO_RC_STATS baseline harness and gate the counters in CI

### DIFF
--- a/.claude/rules/selfhost-evaluator.md
+++ b/.claude/rules/selfhost-evaluator.md
@@ -92,10 +92,23 @@ Level 1 では通る変更が、Level 2（Malgo → Malgo → Malgo）では失�
 ことがある。評価意味論が異なるため、自己ホスト型コンパイラを変更したら
 必ず Level 2 を手動確認する。
 
-Level 1/2 はどちらも Zig バックエンド経由で走る。`Main.mlg` を
+Level 1/2 はどちらも既定では Zig バックエンド経由で走る。`Main.mlg` を
 `malgo compile` でネイティブバイナリにし、そのバイナリが評価器になる。
-以前は Scheme バックエンド経由だったが、`malgo_read_file` の実装により
-移行した（Scheme バックエンドは削除済み）。
+この既定は `malgo_read_file` の実装により可能になった。
+
+Scheme バックエンドは**意図的に残してある**。#385 が記録している 7.5倍の
+性能差は Chez Scheme 経路との比であり、比較対象がなければ再測定できない。
+`scripts/selfhost-level2.sh` は `TARGET=scheme` で Chez 経路に切り替わる。
+測定のためだけに存在する経路なので、新しい機能をこの上に載せないこと。
+#385 が閉じるまで削除しない（削除は #400 で追跡）。
+
+なお Scheme バックエンドは**性能の基準線であって正しさの基準ではない**。
+意味論の基準は常にインタープリタ（`Malgo.Sequent.Eval`）である。
+Scheme バックエンドには golden ゲートが一度も無く、73 件の golden を通すと
+71 件通過する。落ちる 2 件は `EmptyConstructor`（空コンストラクタの表示が違う）
+と `LabelGoto`（継続が `number->string` に漏れる）。どちらのテストケースも
+バックエンド削除より数ヶ月古いので、退行ではなく元からの穴である。
+Level 2 が実際に走らせる 5 ケースはすべて通る。
 
 ### 手順
 
@@ -116,8 +129,17 @@ printf 'Hello\n' | /tmp/malgoc \
 
 # 4. フルスクリプト
 PRECOMPILE_TIMEOUT=300 CASE_TIMEOUT=1200 bash scripts/selfhost-level2.sh
+
+# 5. Chez 経路（#385 の基準線を測り直すとき。CASE_TIMEOUT の既定は 300）
+lean/.lake/build/bin/malgo eval --target scheme runtime/malgo/compiler/Main.mlg > /tmp/main.scm
+printf 'Hello\n' | scheme --script /tmp/main.scm \
+  runtime/malgo/compiler/Main.mlg test/testcases/malgo/Echo.mlg
+TARGET=scheme PRECOMPILE_TIMEOUT=300 bash scripts/selfhost-level2.sh
 ```
 
 Level 2 は Level 1 より 50〜200 倍遅く、さらに Zig バックエンドは同じ
 ケースで Chez Scheme の約7.5倍遅い（実測: Fib で 220秒 対 29秒）。
 タイムアウトは余裕を持たせること。改善は #385 で追跡している。
+この 220秒 対 29秒 は `TARGET=scheme` で再測定できる。ただし
+`selfhost-level2.sh` は 5 ケースを並列に走らせるので、比を取るときは
+1 ケースずつ直接実行して測ること（並列実行の数値は元の測定と比較できない）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ ParserPass → RenamePass → [InferPass] → [RefinePass]
     ↓
 ToFunPass → ToCorePass → FlatPass → JoinPass
     ↓
-EvalPass (Interpreter) | ZigPass (--target zig / malgo compile)
+EvalPass (Interpreter) | SchemePass (--target scheme) | ZigPass (--target zig / malgo compile)
 ```
 
 **Note**: InferPass and RefinePass can be skipped for fast evaluation without type checking.
@@ -51,8 +51,8 @@ EvalPass (Interpreter) | ZigPass (--target zig / malgo compile)
 conversion: it inlines a fully(-or-over-)saturated call of a data constructor
 (`Cons x xs`, or `Cons (f x) (mapList f xs)` — arguments need not be
 immediate) directly into `Fun.Construct`, instead of invoking the
-constructor's own curried closure. This is shared by both backends
-(Eval/Zig) and every direct caller of `toCore`, not Zig-specific.
+constructor's own curried closure. This is shared by every backend
+(Eval/Scheme/Zig) and every direct caller of `toCore`, not Zig-specific.
 
 ### Zig Backend (native executables)
 
@@ -146,11 +146,25 @@ case than the Chez Scheme path self-hosting used to run on (#385). Level 1
 still runs on every PR over all 73 testcases. Run L2 locally before touching
 `runtime/malgo/compiler/`, and re-enable the flag when #385 lands.
 
-Both levels run through the **Zig backend**: `Main.mlg` is compiled to a native
+**The v4.0.0 release is held on that flag.** Milestone `v4.0.0` gates the
+release on #385, and the Scheme backend is retained until then as the only
+cross-implementation performance reference the 7.5x figure can be measured
+against. Do not delete it early — #400 tracks the eventual removal.
+
+Both levels default to the **Zig backend**: `Main.mlg` is compiled to a native
 binary with `malgo compile --opt release-fast` and that binary is the evaluator.
-They used to go through the Scheme backend; the switch became possible once
-`malgo_read_file` was implemented in `runtime/zig/runtime.zig`, which was the
-only runtime primitive the self-hosted compiler still lacked.
+That default became possible once `malgo_read_file` was implemented in
+`runtime/zig/runtime.zig`, which was the only runtime primitive the self-hosted
+compiler still lacked. `scripts/selfhost-level2.sh` also accepts
+`TARGET=scheme`, which builds the evaluator with `malgo eval --target scheme`
+and runs it under Chez instead; that path exists for measurement, is not a
+supported target, and no new work should build on it. It is a performance
+reference, **not a correctness oracle** — the interpreter (`Malgo.Sequent.Eval`)
+is the oracle. The Scheme backend never had a golden gate, and a sweep of all 73
+goldens through it passes 71: `EmptyConstructor` renders an empty constructor
+differently and `LabelGoto` leaks a continuation into `number->string`. Both
+testcases predate the backend's deletion by months, so these are long-standing
+gaps rather than regressions. The 5 cases Level 2 actually runs all pass.
 
 ```bash
 # Level 1: ./malgoc <testcase.mlg>
@@ -163,6 +177,9 @@ bash scripts/selfhost-golden.sh
 # so that the inner Lexer can tokenize integer literals when evaluating
 # nested Malgo sources.
 bash scripts/selfhost-level2.sh
+
+# Level 2 through Chez, for the #385 baseline (CASE_TIMEOUT defaults to 300 here)
+TARGET=scheme bash scripts/selfhost-level2.sh
 ```
 
 ## Coding Style

--- a/README.md
+++ b/README.md
@@ -180,7 +180,12 @@ See `mise.toml` for more details and customization.
 - **Auto-labeling:** PRs are auto-labeled from commit messages via CI.
 - **Release PR:** On pushes to `master`, CI computes the next version, creates a draft GitHub Release, and opens a `release/vX.Y.Z` PR.
 - **Publish:** Merging a `release/*` PR to `master` tags the commit and publishes the GitHub Release.
-- **Notes:** Releases use generated notes; excluded labels: `skip-changelog`, `duplicate`, `invalid`.
+- **Notes:** Releases use generated notes; excluded labels: `duplicate`, `invalid`. (The workflow's exclusion list also names `skip-changelog`, but no such label exists, so it never matches.)
+
+**Current hold:** the `v4.0.0` release PR (#398) is a draft and the `Create Release PR`
+workflow is disabled until milestone `v4.0.0` is done (#385). Do not merge #398 before
+then, and refresh the draft release's notes before you do — `release.yml` publishes
+whatever draft exists, and the current one was generated at `v3.0.0..bf7c682f`.
 
 To create labels via GitHub CLI:
 

--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -1,0 +1,53 @@
+{
+  "$comment": "LIVE Zig-backend perf baseline for #385. Unrelated to bench/baseline-*.json, which are 2026-03 GHC *build*-time records. Regenerate with `mise run perf-baseline -- --update`; the diff of this file IS the before/after claim #385 requires. Gates are directional -- see scripts/perf-baseline.sh.",
+  "compiler": {
+    "commit": "55653528",
+    "zig": "0.16.0"
+  },
+  "tiers": {
+    "fib-shallow": {
+      "counters": {
+        "total_allocs": 135158,
+        "reuse_hits": 9868,
+        "dispatches": 152921,
+        "force_depth_max": 0
+      },
+      "derived": {
+        "reuse_rate": 0.073
+      }
+    },
+    "fib-deep": {
+      "counters": {
+        "total_allocs": 16630780,
+        "reuse_hits": 1213928,
+        "dispatches": 18815851,
+        "force_depth_max": 0
+      },
+      "derived": {
+        "reuse_rate": 0.073
+      }
+    },
+    "selfhost-l1": {
+      "counters": {
+        "total_allocs": 4570396,
+        "reuse_hits": 332109,
+        "dispatches": 5067427,
+        "force_depth_max": 1
+      },
+      "derived": {
+        "reuse_rate": 0.0727
+      }
+    },
+    "selfhost-l2": {
+      "counters": {
+        "total_allocs": 8265456483,
+        "reuse_hits": 289915189,
+        "dispatches": 9110106332,
+        "force_depth_max": 1
+      },
+      "derived": {
+        "reuse_rate": 0.0351
+      }
+    }
+  }
+}

--- a/docs/zig-backend.md
+++ b/docs/zig-backend.md
@@ -168,8 +168,21 @@ constructor name never needs a heap allocation of its own).
   holds a reference to this object right now" without manually grepping raw
   pointer addresses. See the "Debugging" section of [`perceus-gc.md`](perceus-gc.md).
 - **`MALGO_RC_STATS=1`** on a compiled binary prints
-  `MALGO-STATS: total_allocs=<N> reuse_hits=<N>` to stderr at exit — a quick way to
-  measure the `Reuse` pass's effect on allocation count without full tracing.
+  `MALGO-STATS: total_allocs=<N> reuse_hits=<N> dispatches=<N> force_depth_max=<N>`
+  to stderr at exit — a quick way to measure the `Reuse` pass's effect on allocation
+  count without full tracing. The counters themselves are always on (only the
+  reporting is env-gated), so an instrumented run and a timed run measure the same
+  binary. They are deterministic and machine-independent, which is why #385 requires
+  them in any before/after claim and treats wall clock as insufficient.
+- **`mise run perf-baseline`** (`scripts/perf-baseline.sh`) records and compares those
+  counters against `bench/perf-baseline.json` across four tiers — `fib-shallow`,
+  `fib-deep`, `selfhost-l1`, `selfhost-l2`. Gates are directional and only
+  `total_allocs`, `dispatches` and `force_depth_max` are enforced; `reuse_hits` is
+  reported, because it is a ratio whose denominator moves whenever an optimization
+  removes allocations. `--update` rewrites the baseline, and that diff is the
+  before/after claim. `fib-deep` is gated for free inside
+  `scripts/zig-deep-recursion.sh`, which already ran the instrumented binary and
+  previously discarded the numbers.
 - **`RcCheck`** runs unconditionally on every compile (see
   [`perceus-gc.md`](perceus-gc.md)) — no flag is needed to catch a Perceus/Reuse bug
   as a compile error rather than a runtime use-after-free.

--- a/lean/Main.lean
+++ b/lean/Main.lean
@@ -7,7 +7,7 @@ Haskell uses optparse-applicative; this is a hand-rolled argv parser (no
 combinator library) with the same three subcommands, flags, and defaults.
 Byte-parity with optparse's generated `--help` is explicitly not a goal.
 
-Dispatch is stubbed for M1: the pipeline (`Malgo.Driver`) and the Zig
+Dispatch is stubbed for M1: the pipeline (`Malgo.Driver`) and the Scheme/Zig
 backends and the linter are not ported yet, so each `run*` arm prints a
 clear message and exits 1. `runEval` for `--target eval` carries the single
 integration seam (see the `TODO(M1 integration)` below). -/
@@ -31,6 +31,7 @@ def OptMode.toString : OptMode → String
 
 def parseTargetArg : String → Except String Target
   | "eval" => .ok .eval
+  | "scheme" => .ok .scheme
   | "zig" => .ok .zig
   | t => .error s!"Unknown target: {t}"
 
@@ -50,7 +51,7 @@ def usage : String :=
   "Usage: malgo COMMAND\n\n" ++
   "Commands:\n" ++
   "  eval SOURCE [--no-opt] [--lambdalift] [--debug-mode]\n" ++
-  "              [--target eval|zig] [--eval-mode smallstep|bigstep]\n" ++
+  "              [--target eval|scheme|zig] [--eval-mode smallstep|bigstep]\n" ++
   "              [--infer] [ARG...]\n" ++
   "  compile SOURCE [-o|--output OUT] [--opt debug|release-safe|release-fast]\n" ++
   "  lint SOURCE [--deny-warnings]\n" ++
@@ -232,6 +233,12 @@ def runEval (flag : Flag) (source : System.FilePath) : IO UInt32 := do
   | .eval =>
     try
       Malgo.Driver.compileAndEval flag source
+    catch e =>
+      IO.eprintln (toString e)
+      return 1
+  | .scheme =>
+    try
+      Malgo.Driver.compileScheme flag source
     catch e =>
       IO.eprintln (toString e)
       return 1

--- a/lean/Malgo.lean
+++ b/lean/Malgo.lean
@@ -36,6 +36,7 @@ import Malgo.Infer.Unify
 import Malgo.Infer
 import Malgo.Query
 import Malgo.Query.Engine
+import Malgo.Backend.Scheme
 import Malgo.Backend.Zig.Ir
 import Malgo.Backend.Zig.Normalize
 import Malgo.Backend.Zig.ClosureConv

--- a/lean/Malgo/Backend/Scheme.lean
+++ b/lean/Malgo/Backend/Scheme.lean
@@ -1,0 +1,608 @@
+import Malgo.Prelude
+import Malgo.Id
+import Malgo.Module
+import Malgo.Sequent.Fun
+import Malgo.Sequent.Core.Join
+
+/-! Port of `src/Malgo/Backend/Scheme.hs`: the Scheme backend that lowers
+the Join IR to Chez Scheme source text.
+
+The Haskell pass runs under `Reader ModuleName` and uses no fresh names
+(`State Uniq` is absent), so the whole port is a pure function
+`compileToScheme : ModuleName → Join.Program → String` (`Text → String`).
+
+`mangleId`/`mangleText`/`escapeString`/`escapeChar` and the embedded
+`schemeRuntime` prelude are ported byte-for-byte: mangling fixes the
+generated symbol names, and the runtime string is fed to Chez Scheme by
+the self-host gate.
+
+One deviation: Haskell's `mangleChar` fall-through uses `Data.Char.isAlphaNum`
+(Unicode-aware), whereas Lean's `Char.isAlphanum` is ASCII-only. The Greek
+letters that actually occur in Malgo identifiers are handled by explicit
+cases before the fall-through, and any remaining non-ASCII alphanumeric is
+mangled to `_u<codepoint>_` deterministically, so generated programs stay
+self-consistent (the self-host gate diffs program output, not source
+text). -/
+
+namespace Malgo.Backend.Scheme
+
+open Malgo.Sequent.Fun (Name Literal Tag Pattern)
+open Malgo.Sequent.Core
+
+/-- Mangle a single character to a valid-Scheme-identifier fragment. -/
+def mangleChar (c : Char) : String :=
+  match c with
+  | '#' => "_hash_"
+  | '.' => "_dot_"
+  | '\'' => "_prime_"
+  | '-' => "_dash_"
+  | '?' => "_q_"
+  | '!' => "_bang_"
+  | '/' => "_slash_"
+  | '+' => "_plus_"
+  | '*' => "_star_"
+  | '<' => "_lt_"
+  | '>' => "_gt_"
+  | '=' => "_eq_"
+  -- Greek letters
+  | 'α' => "alpha"
+  | 'β' => "beta"
+  | 'γ' => "gamma"
+  | 'δ' => "delta"
+  | 'λ' => "lambda_"
+  | 'μ' => "mu"
+  | c => if c.isAlphanum || c == '_' then String.singleton c else "_u" ++ toString c.toNat ++ "_"
+
+/-- Mangle a text string to be a valid Scheme identifier. -/
+def mangleText (s : String) : String :=
+  String.join (s.toList.map mangleChar)
+
+/-- Mangle a Malgo `Id` into a valid Scheme identifier. -/
+def mangleId (x : Malgo.Id) : String :=
+  match x.sort with
+  | .external => mangleText (x.moduleName.toStr ++ "." ++ x.name)
+  | .internal uniq => mangleText x.name ++ "_" ++ toString uniq
+  | .temporal uniq => "_t_" ++ mangleText x.name ++ "_" ++ toString uniq
+
+def escapeChar (c : Char) : String :=
+  match c with
+  | ' ' => "space"
+  | '\n' => "newline"
+  | '\t' => "tab"
+  | '\r' => "return"
+  | '\x00' => "nul"
+  | '\x7f' => "delete"
+  | c => String.singleton c
+
+/-- Escape special characters in a string for Scheme output. -/
+def escapeString (s : String) : String :=
+  String.join <| s.toList.map fun c =>
+    match c with
+    | '\\' => "\\\\"
+    | '"' => "\\\""
+    | '\n' => "\\n"
+    | '\r' => "\\r"
+    | '\t' => "\\t"
+    | c => String.singleton c
+
+def compileTag : Tag → String
+  | .tuple => "tuple"
+  | .tag t => mangleText t
+
+/-- Compile a literal to a Scheme expression. Floats render via
+`haskellShowFloat`/`haskellShowFloat32` (the Haskell backend emits `show`'s
+output; Chez reads both fixed and `e`-notation). -/
+def compileLiteral : Literal → String
+  | .int32 n => toString n.toInt
+  | .int64 n => toString n.toInt
+  | .float f => Malgo.haskellShowFloat32 f
+  | .double d => Malgo.haskellShowFloat d
+  | .char c => "#\\" ++ escapeChar c
+  | .string t => "\"" ++ escapeString t ++ "\""
+
+/-- Concatenate arguments with spaces, prepending a space if non-empty. -/
+def concatArgs : List String → String
+  | [] => ""
+  | xs => " " ++ " ".intercalate xs
+
+private def binop (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a, b] => "(" ++ r ++ " (" ++ op ++ " " ++ a ++ " " ++ b ++ "))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+private def unaryop (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a] => "(" ++ r ++ " (" ++ op ++ " " ++ a ++ "))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Comparison returning 1/0 instead of `#t`/`#f`. -/
+private def cmpop (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a, b] => "(" ++ r ++ " (if (" ++ op ++ " " ++ a ++ " " ++ b ++ ") 1 0))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Negated comparison returning 1/0. -/
+private def cmpopNeg (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a, b] => "(" ++ r ++ " (if (not (" ++ op ++ " " ++ a ++ " " ++ b ++ ")) 1 0))"
+  | _ => "(" ++ r ++ " (error 'prim \"not-" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Unary predicate returning 1/0. -/
+private def cmpBool (op : String) (args : List String) (r : String) : String :=
+  match args with
+  | [a] => "(" ++ r ++ " (if (" ++ op ++ " " ++ a ++ ") 1 0))"
+  | _ => "(" ++ r ++ " (error 'prim \"" ++ op ++ ": wrong number of arguments\"))"
+
+/-- Compile a primitive operation. -/
+def compilePrimitive (name : String) (args : List String) (ret : String) : String :=
+  match name with
+  | "add_i32" => binop "+" args ret
+  | "sub_i32" => binop "-" args ret
+  | "mul_i32" => binop "*" args ret
+  | "div_i32" => binop "quotient" args ret
+  | "mod_i32" => binop "modulo" args ret
+  | "add_i64" => binop "+" args ret
+  | "sub_i64" => binop "-" args ret
+  | "mul_i64" => binop "*" args ret
+  | "div_i64" => binop "quotient" args ret
+  | "mod_i64" => binop "modulo" args ret
+  | "add_f64" => binop "+" args ret
+  | "sub_f64" => binop "-" args ret
+  | "mul_f64" => binop "*" args ret
+  | "div_f64" => binop "/" args ret
+  | "eq_i32" => binop "equal?" args ret
+  | "ne_i32" => binop "malgo-ne" args ret
+  | "lt_i32" => binop "<" args ret
+  | "le_i32" => binop "<=" args ret
+  | "gt_i32" => binop ">" args ret
+  | "ge_i32" => binop ">=" args ret
+  | "eq_i64" => binop "equal?" args ret
+  | "ne_i64" => binop "malgo-ne" args ret
+  | "lt_i64" => binop "<" args ret
+  | "le_i64" => binop "<=" args ret
+  | "gt_i64" => binop ">" args ret
+  | "ge_i64" => binop ">=" args ret
+  | "eq_f64" => binop "equal?" args ret
+  | "ne_f64" => binop "malgo-ne" args ret
+  | "lt_f64" => binop "<" args ret
+  | "le_f64" => binop "<=" args ret
+  | "gt_f64" => binop ">" args ret
+  | "ge_f64" => binop ">=" args ret
+  | "eq_char" => binop "char=?" args ret
+  | "ne_char" => binop "malgo-ne" args ret
+  | "string_append" => binop "string-append" args ret
+  | "int32_to_string" => unaryop "number->string" args ret
+  | "int64_to_string" => unaryop "number->string" args ret
+  | "float_to_string" => unaryop "number->string" args ret
+  | "double_to_string" => unaryop "number->string" args ret
+  | "char_to_string" => unaryop "string" args ret
+  | "string_to_int32" => unaryop "string->number" args ret
+  | "string_to_int64" => unaryop "string->number" args ret
+  | "string_length" => unaryop "string-length" args ret
+  | "string_at" => binop "string-ref" args ret
+  | "string_substring" =>
+    match args with
+    | [s, start, len] => "(" ++ ret ++ " (substring " ++ s ++ " " ++ start ++ " (+ " ++ start ++ " " ++ len ++ ")))"
+    | _ => "(error 'prim \"string_substring: wrong number of arguments\")"
+  | "putchar" =>
+    match args with
+    | [c] => "(begin (display " ++ c ++ ") (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"putchar: wrong number of arguments\")"
+  | "getchar" =>
+    "(" ++ ret ++ " (let ((c (read-char))) (if (eof-object? c) #f c)))"
+  | "putstr" =>
+    match args with
+    | [s] => "(begin (display " ++ s ++ ") (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"putstr: wrong number of arguments\")"
+  | "println" =>
+    match args with
+    | [s] => "(begin (display " ++ s ++ ") (newline) (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"println: wrong number of arguments\")"
+  | "error" =>
+    match args with
+    | [msg] => "(error 'malgo " ++ msg ++ ")"
+    | _ => "(error 'malgo \"error\")"
+  | "negate_i32" => unaryop "-" args ret
+  | "negate_i64" => unaryop "-" args ret
+  | "negate_f64" => unaryop "-" args ret
+  -- malgo_* foreign import names
+  | "malgo_read_file" =>
+    match args with
+    | [path] => "(" ++ ret ++ " (call-with-input-file " ++ path ++ " (lambda (p) (get-string-all p))))"
+    | _ => "(error 'prim \"malgo_read_file: wrong number of arguments\")"
+  | "malgo_write_file" =>
+    match args with
+    | [path, content] => "(begin (call-with-output-file " ++ path ++ " (lambda (p) (put-string p " ++ content ++ "))) (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"malgo_write_file: wrong number of arguments\")"
+  | "malgo_get_line" =>
+    "(" ++ ret ++ " (let ((line (read-line))) (if (eof-object? line) \"\" line)))"
+  | "malgo_get_args" =>
+    "(" ++ ret ++ " (malgo-string-join (cdr (command-line)) \"\\n\"))"
+  | "malgo_exit_success" => "(exit 0)"
+  | "malgo_stderr_string" =>
+    match args with
+    | [s] => "(begin (put-string (current-error-port) " ++ s ++ ") (" ++ ret ++ " '()))"
+    | _ => "(error 'prim \"malgo_stderr_string: wrong number of arguments\")"
+  | "malgo_string_to_int32" => unaryop "string->number" args ret
+  | "malgo_string_to_int64" => unaryop "string->number" args ret
+  -- Arithmetic (malgo_* foreign import names from Builtin.mlg)
+  | "malgo_add_int32_t" => binop "+" args ret
+  | "malgo_sub_int32_t" => binop "-" args ret
+  | "malgo_mul_int32_t" => binop "*" args ret
+  | "malgo_div_int32_t" => binop "quotient" args ret
+  | "malgo_mod_int32_t" => binop "modulo" args ret
+  | "malgo_neg_int32_t" => unaryop "-" args ret
+  | "malgo_add_int64_t" => binop "+" args ret
+  | "malgo_sub_int64_t" => binop "-" args ret
+  | "malgo_mul_int64_t" => binop "*" args ret
+  | "malgo_div_int64_t" => binop "quotient" args ret
+  | "malgo_mod_int64_t" => binop "modulo" args ret
+  | "malgo_neg_int64_t" => unaryop "-" args ret
+  | "malgo_add_float" => binop "+" args ret
+  | "malgo_sub_float" => binop "-" args ret
+  | "malgo_mul_float" => binop "*" args ret
+  | "malgo_div_float" => binop "/" args ret
+  | "malgo_neg_float" => unaryop "-" args ret
+  | "malgo_add_double" => binop "+" args ret
+  | "malgo_sub_double" => binop "-" args ret
+  | "malgo_mul_double" => binop "*" args ret
+  | "malgo_div_double" => binop "/" args ret
+  | "malgo_neg_double" => unaryop "-" args ret
+  -- Comparisons return Int32# (1=true, 0=false) to match isTrue# pattern matching
+  | "malgo_eq_int32_t" => cmpop "equal?" args ret
+  | "malgo_ne_int32_t" => cmpopNeg "equal?" args ret
+  | "malgo_lt_int32_t" => cmpop "<" args ret
+  | "malgo_le_int32_t" => cmpop "<=" args ret
+  | "malgo_gt_int32_t" => cmpop ">" args ret
+  | "malgo_ge_int32_t" => cmpop ">=" args ret
+  | "malgo_eq_int64_t" => cmpop "equal?" args ret
+  | "malgo_ne_int64_t" => cmpopNeg "equal?" args ret
+  | "malgo_lt_int64_t" => cmpop "<" args ret
+  | "malgo_le_int64_t" => cmpop "<=" args ret
+  | "malgo_gt_int64_t" => cmpop ">" args ret
+  | "malgo_ge_int64_t" => cmpop ">=" args ret
+  | "malgo_eq_float" => cmpop "equal?" args ret
+  | "malgo_ne_float" => cmpopNeg "equal?" args ret
+  | "malgo_lt_float" => cmpop "<" args ret
+  | "malgo_le_float" => cmpop "<=" args ret
+  | "malgo_gt_float" => cmpop ">" args ret
+  | "malgo_ge_float" => cmpop ">=" args ret
+  | "malgo_eq_double" => cmpop "equal?" args ret
+  | "malgo_ne_double" => cmpopNeg "equal?" args ret
+  | "malgo_lt_double" => cmpop "<" args ret
+  | "malgo_le_double" => cmpop "<=" args ret
+  | "malgo_gt_double" => cmpop ">" args ret
+  | "malgo_ge_double" => cmpop ">=" args ret
+  | "malgo_eq_char" => cmpop "char=?" args ret
+  | "malgo_ne_char" => cmpopNeg "char=?" args ret
+  | "malgo_lt_char" => cmpop "char<?" args ret
+  | "malgo_le_char" => cmpop "char<=?" args ret
+  | "malgo_gt_char" => cmpop "char>?" args ret
+  | "malgo_ge_char" => cmpop "char>=?" args ret
+  | "malgo_eq_string" => cmpop "string=?" args ret
+  | "malgo_ne_string" => cmpopNeg "string=?" args ret
+  | "malgo_lt_string" => cmpop "string<?" args ret
+  | "malgo_le_string" => cmpop "string<=?" args ret
+  | "malgo_gt_string" => cmpop "string>?" args ret
+  | "malgo_ge_string" => cmpop "string>=?" args ret
+  -- Char/string operations
+  | "malgo_char_ord" => unaryop "char->integer" args ret
+  | "malgo_int32_t_to_char" => unaryop "integer->char" args ret
+  | "malgo_char_to_string" => unaryop "string" args ret
+  | "malgo_is_digit" => cmpBool "char-numeric?" args ret
+  | "malgo_is_lower" => cmpBool "char-lower-case?" args ret
+  | "malgo_is_upper" => cmpBool "char-upper-case?" args ret
+  | "malgo_is_alphanum" =>
+    match args with
+    | [c] => "(" ++ ret ++ " (if (or (char-alphabetic? " ++ c ++ ") (char-numeric? " ++ c ++ ")) 1 0))"
+    | _ => "(error 'prim \"malgo_is_alphanum: wrong number of arguments\")"
+  | "malgo_string_append" => binop "string-append" args ret
+  | "malgo_string_length" => unaryop "string-length" args ret
+  | "malgo_string_at" =>
+    match args with
+    | [i, s] => "(" ++ ret ++ " (string-ref " ++ s ++ " " ++ i ++ "))"
+    | _ => "(error 'prim \"malgo_string_at: wrong number of arguments\")"
+  | "malgo_string_cons" =>
+    match args with
+    | [c, s] => "(" ++ ret ++ " (string-append (string " ++ c ++ ") " ++ s ++ "))"
+    | _ => "(error 'prim \"malgo_string_cons: wrong number of arguments\")"
+  | "malgo_substring" =>
+    match args with
+    | [s, start, end_] => "(" ++ ret ++ " (substring " ++ s ++ " " ++ start ++ " " ++ end_ ++ "))"
+    | _ => "(error 'prim \"malgo_substring: wrong number of arguments\")"
+  | "malgo_string_reverse" =>
+    match args with
+    | [s] => "(" ++ ret ++ " (list->string (reverse (string->list " ++ s ++ "))))"
+    | _ => "(error 'prim \"malgo_string_reverse: wrong number of arguments\")"
+  -- Conversion
+  | "malgo_int32_t_to_string" => unaryop "number->string" args ret
+  | "malgo_int64_t_to_string" => unaryop "number->string" args ret
+  | "malgo_float_to_string" => unaryop "number->string" args ret
+  | "malgo_double_to_string" => unaryop "number->string" args ret
+  -- IO
+  | "malgo_print_string" =>
+    match args with
+    | [s] => "(begin (display " ++ s ++ ") (" ++ ret ++ " (list 'tuple)))"
+    | _ => "(error 'prim \"malgo_print_string: wrong number of arguments\")"
+  | "malgo_print_char" =>
+    match args with
+    | [c] => "(begin (display " ++ c ++ ") (" ++ ret ++ " (list 'tuple)))"
+    | _ => "(error 'prim \"malgo_print_char: wrong number of arguments\")"
+  | "malgo_print" =>
+    match args with
+    | [v] => "(begin (malgo-print-value " ++ v ++ ") (" ++ ret ++ " (list 'tuple)))"
+    | _ => "(error 'prim \"malgo_print: wrong number of arguments\")"
+  | "malgo_newline" => "(begin (newline) (" ++ ret ++ " (list 'tuple)))"
+  | "malgo_flush" => "(begin (flush-output-port) (" ++ ret ++ " (list 'tuple)))"
+  | "malgo_get_char" =>
+    "(" ++ ret ++ " (let ((c (read-char))) (if (eof-object? c) #\\nul c)))"
+  | "malgo_get_contents" =>
+    "(" ++ ret ++ " (get-string-all (current-input-port)))"
+  -- Error / control
+  | "malgo_panic" =>
+    match args with
+    | [msg] => "(error 'panic " ++ msg ++ ")"
+    | _ => "(error 'panic \"panic\")"
+  | "malgo_unsafe_cast" =>
+    match args with
+    | [x] => "(" ++ ret ++ " " ++ x ++ ")"
+    | _ => "(error 'prim \"malgo_unsafe_cast: wrong number of arguments\")"
+  | "malgo_exit_failure" => "(exit 1)"
+  -- Math
+  | "sqrt" => unaryop "sqrt" args ret
+  | "sqrtf" => unaryop "sqrt" args ret
+  -- Inserted by Malgo.Sequent.ReuseSpecialize for the Zig backend's
+  -- reference-counting reuse analysis; a no-op everywhere else.
+  | "reuseHint" =>
+    match args with
+    | [x] => "(" ++ ret ++ " " ++ x ++ ")"
+    | _ => "(error 'prim \"reuseHint: wrong number of arguments\")"
+  | _ => "(error 'prim \"unknown primitive: " ++ name ++ "\")"
+
+/-- Compile a pattern against a scrutinee expression, returning
+`(guard, let*-bindings)`: a Scheme boolean guard and sequential `let*`
+entries. -/
+partial def compilePattern (scrutinee : String) : Pattern → String × List (String × String)
+  | .pvar _ n => ("#t", [(mangleId n, scrutinee)])
+  | .pliteral _ lit => ("(equal? " ++ scrutinee ++ " " ++ compileLiteral lit ++ ")", [])
+  | .destruct _ tag pats =>
+    let tagStr := compileTag tag
+    let tagCheck := "(and (pair? " ++ scrutinee ++ ") (eq? (car " ++ scrutinee ++ ") '" ++ tagStr ++ "))"
+    let subResults := pats.mapIdx fun i p =>
+      compilePattern ("(list-ref " ++ scrutinee ++ " " ++ toString (i + 1) ++ ")") p
+    let subGuards := (subResults.map (·.1)).filter (· != "#t")
+    let subBindings := (subResults.map (·.2)).flatten
+    let fullGuard := match subGuards with
+      | [] => tagCheck
+      | gs => "(and " ++ " ".intercalate (tagCheck :: gs) ++ ")"
+    (fullGuard, subBindings)
+  | .expand _ fieldPats =>
+    let subResults := (sortAssocAscending fieldPats).map fun (fname, p) =>
+      let mangledFname := mangleText fname
+      let raw := "(cdr (assq '" ++ mangledFname ++ " " ++ scrutinee ++ "))"
+      let tmpName := "%fv_" ++ mangledFname
+      let tmpName2 := "%fvr_" ++ mangledFname
+      -- Object fields are stored as thunks; force them before pattern matching
+      let forced :=
+        "(let ((" ++ tmpName ++ " " ++ raw ++ ")) " ++
+        "(if (procedure? " ++ tmpName ++ ") " ++
+        "(" ++ tmpName ++ " (lambda (" ++ tmpName2 ++ ") " ++ tmpName2 ++ ")) " ++
+        tmpName ++ "))"
+      compilePattern forced p
+    let subGuards := (subResults.map (·.1)).filter (· != "#t")
+    let subBindings := (subResults.map (·.2)).flatten
+    let fullGuard := match subGuards with
+      | [] => "#t"
+      | [g] => g
+      | gs => "(and " ++ " ".intercalate gs ++ ")"
+    (fullGuard, subBindings)
+
+mutual
+
+/-- Compile a Producer to a Scheme expression. -/
+partial def compileProducer : Join.Producer → String
+  | .var _ name => mangleId name
+  | .literal _ lit => compileLiteral lit
+  | .construct _ tag producers returns =>
+    let tagStr := compileTag tag
+    let prodStrs := producers.map compileProducer
+    let retStrs := returns.map mangleId
+    "(list '" ++ tagStr ++ concatArgs prodStrs ++ concatArgs retStrs ++ ")"
+  | .lambda _ names body =>
+    let nameStrs := names.map mangleId
+    let bodyStr := compileStatement body
+    match nameStrs with
+    | [] => "(lambda () " ++ bodyStr ++ ")"
+    | [x] => "(lambda (" ++ x ++ ") " ++ bodyStr ++ ")"
+    | _ => "(lambda (" ++ " ".intercalate nameStrs ++ ") " ++ bodyStr ++ ")"
+  | .mu _ name stmt =>
+    let nameStr := mangleId name
+    let bodyStr := compileStatement stmt
+    "(lambda (" ++ nameStr ++ ") " ++ bodyStr ++ ")"
+  | .object _ fields =>
+    let fieldStrs := (sortAssocAscending fields).map compileField
+    "(list " ++ " ".intercalate fieldStrs ++ ")"
+
+partial def compileField : String × Name × Join.Statement → String
+  | (fieldName, retName, body) =>
+    let retStr := mangleId retName
+    let bodyStr := compileStatement body
+    "(cons '" ++ mangleText fieldName ++ " (lambda (" ++ retStr ++ ") " ++ bodyStr ++ "))"
+
+/-- Compile a Consumer to a Scheme expression. -/
+partial def compileConsumer : Join.Consumer → String
+  | .label _ name => mangleId name
+  | .apply _ producers returns =>
+    let prodStrs := producers.map compileProducer
+    let retStrs := returns.map mangleId
+    "(lambda (%fn) (%fn" ++ concatArgs (prodStrs ++ retStrs) ++ "))"
+  | .project _ field returnName =>
+    let retStr := mangleId returnName
+    "(lambda (%rec) (let ((%v (cdr (assq '" ++ mangleText field ++ " %rec)))) (if (procedure? %v) (%v " ++ retStr ++ ") (" ++ retStr ++ " %v))))"
+  | .«then» _ name body =>
+    let nameStr := mangleId name
+    let bodyStr := compileStatement body
+    "(lambda (" ++ nameStr ++ ") " ++ bodyStr ++ ")"
+  | .finish _ => "malgo-finish"
+  | .select _ branches =>
+    let branchStrs := branches.map compileBranch
+    "(lambda (%v) (cond " ++ " ".intercalate branchStrs ++ " (else (error 'select \"no matching branch\" %v))))"
+
+partial def compileBranch : Join.Branch → String
+  | .branch _ pat body =>
+    let bodyStr := compileStatement body
+    let (guard, bindings) := compilePattern "%v" pat
+    let withBindings :=
+      if bindings.isEmpty then bodyStr
+      else "(let* (" ++ " ".intercalate (bindings.map fun (n, e) => "(" ++ n ++ " " ++ e ++ ")") ++ ") " ++ bodyStr ++ ")"
+    "(" ++ guard ++ " " ++ withBindings ++ ")"
+
+/-- Compile a Statement to a Scheme expression. -/
+partial def compileStatement : Join.Statement → String
+  | .cut producer returnName =>
+    let prodStr := compileProducer producer
+    let retStr := mangleId returnName
+    "(" ++ retStr ++ " " ++ prodStr ++ ")"
+  | .join _ name consumer body =>
+    let nameStr := mangleId name
+    let consStr := compileConsumer consumer
+    let bodyStr := compileStatement body
+    "(let ((" ++ nameStr ++ " " ++ consStr ++ ")) " ++ bodyStr ++ ")"
+  | .primitive _ primName producers returnName =>
+    let prodStrs := producers.map compileProducer
+    let retStr := mangleId returnName
+    compilePrimitive primName prodStrs retStr
+  | .invoke _ name returnName =>
+    let nameStr := mangleId name
+    let retStr := mangleId returnName
+    "(" ++ nameStr ++ " " ++ retStr ++ ")"
+  | .externalCall _ name producers returnName =>
+    let prodStrs := producers.map compileProducer
+    let retStr := mangleId returnName
+    compilePrimitive name prodStrs retStr
+  | .binOp _ op lhs rhs returnName =>
+    let lhsStr := compileProducer lhs
+    let rhsStr := compileProducer rhs
+    let retStr := mangleId returnName
+    compilePrimitive op [lhsStr, rhsStr] retStr
+  | .ifz _ cond thenBranch elseBranch =>
+    let condStr := compileProducer cond
+    let thenStr := compileStatement thenBranch
+    let elseStr := compileStatement elseBranch
+    "(if (eqv? " ++ condStr ++ " 0) " ++ thenStr ++ " " ++ elseStr ++ ")"
+
+end
+
+def compileDefinition : Range × Name × Name × Join.Statement → String
+  | (_, name, returnName, body) =>
+    let nameStr := mangleId name
+    let returnStr := mangleId returnName
+    let bodyStr := compileStatement body
+    "(define (" ++ nameStr ++ " " ++ returnStr ++ ")\n  " ++ bodyStr ++ ")\n"
+
+/-- Minimal Chez Scheme runtime for Malgo. Ported byte-for-byte from
+`schemeRuntime` in `Scheme.hs` (`T.unlines` = each line followed by a
+newline, including a trailing blank line). -/
+def schemeRuntime : String :=
+  "\n".intercalate
+    [ ";; Malgo Runtime Support",
+      ";; Generated by Malgo Scheme Backend",
+      "",
+      ";; Result printer",
+      "(define (malgo-print-result v)",
+      "  (malgo-print-value v)",
+      "  (newline))",
+      "",
+      "(define (malgo-print-value v)",
+      "  (cond",
+      "    ((boolean? v) (display (if v \"true\" \"false\")))",
+      "    ((null? v) (display \"()\"))",
+      "    ((string? v)",
+      "     (display \"\\\"\")",
+      "     (display v)",
+      "     (display \"\\\"\"))",
+      "    ((char? v)",
+      "     (display \"'\")",
+      "     (display v)",
+      "     (display \"'\"))",
+      "    ((pair? v)",
+      "     (if (and (pair? (car v)) (symbol? (caar v)))",
+      "         ;; Record",
+      "         (begin",
+      "           (display \"{ \")",
+      "           (let loop ((fields v))",
+      "             (unless (null? fields)",
+      "               (display (caar fields))",
+      "               (display \" = \")",
+      "               (malgo-print-value (cdar fields))",
+      "               (unless (null? (cdr fields))",
+      "                 (display \", \"))",
+      "               (loop (cdr fields))))",
+      "           (display \" }\"))",
+      "         ;; Tagged data",
+      "         (if (symbol? (car v))",
+      "             (if (null? (cdr v))",
+      "                 (display (car v))",
+      "                 (begin",
+      "                   (display \"(\")",
+      "                   (display (car v))",
+      "                   (let loop ((args (cdr v)))",
+      "                     (unless (null? args)",
+      "                       (display \" \")",
+      "                       (malgo-print-value (car args))",
+      "                       (loop (cdr args))))",
+      "                   (display \")\")))",
+      "             ;; Regular pair",
+      "             (begin",
+      "               (display \"(\")",
+      "               (malgo-print-value (car v))",
+      "               (display \" . \")",
+      "               (malgo-print-value (cdr v))",
+      "               (display \")\")))))",
+      "    ((procedure? v) (display \"<function>\"))",
+      "    (else (display v))))",
+      "",
+      ";; Not-equal operator",
+      "(define (malgo-ne a b) (not (equal? a b)))",
+      "",
+      ";; String join (SRFI-13 not available in Chez Scheme)",
+      "(define (malgo-string-join lst sep)",
+      "  (if (null? lst) \"\"",
+      "    (let loop ((rest (cdr lst)) (acc (car lst)))",
+      "      (if (null? rest) acc",
+      "        (loop (cdr rest) (string-append acc sep (car rest)))))))",
+      "",
+      ";; Finish continuation (halt)",
+      "(define (malgo-finish v) v)",
+      "" ]
+    ++ "\n"
+
+/-- Compile a Join IR program to Scheme source code. -/
+def compileToScheme (modName : ModuleName) (program : Join.Program) : String :=
+  let mainName := mangleText (modName.toStr ++ ".main")
+  schemeRuntime
+    ++ "\n;; Definitions\n"
+    ++ "\n".intercalate (program.definitions.map compileDefinition)
+    ++ "\n\n;; Run main\n"
+    ++ "(" ++ mainName ++ " (lambda (fn) (fn (list 'tuple) malgo-finish)))\n"
+
+private def r0 : Range := ⟨SourcePos.initial "", SourcePos.initial ""⟩
+private def nm (s : String) : Name := { name := s, moduleName := .moduleName "t", sort := .external }
+
+-- Mangling / literal / small-tree checks.
+#guard mangleText "foo-bar?" == "foo_dash_bar_q_"
+-- External ids mangle "<module>.<name>", so the dot becomes "_dot_".
+#guard mangleId (nm "map") == "t_dot_map"
+#guard mangleId { name := "x", moduleName := .moduleName "t", sort := .temporal 3 } == "_t_x_3"
+#guard mangleId { name := "y", moduleName := .moduleName "t", sort := .internal 7 } == "y_7"
+#guard escapeString "a\"b\\c" == "a\\\"b\\\\c"
+#guard compileLiteral (.int32 (-5)) == "-5"
+#guard compileLiteral (.float 3.14) == "3.14"
+#guard compileLiteral (.string "hi\n") == "\"hi\\n\""
+#guard compileLiteral (.char ' ') == "#\\space"
+#guard compileStatement (.invoke r0 (nm "f") (nm "k")) == "(t_dot_f t_dot_k)"
+#guard compileStatement (.cut (.literal r0 (.int32 1)) (nm "k")) == "(t_dot_k 1)"
+#guard compileStatement (.binOp r0 "add_i32" (.var r0 (nm "a")) (.var r0 (nm "b")) (nm "k"))
+  == "(t_dot_k (+ t_dot_a t_dot_b))"
+
+end Malgo.Backend.Scheme

--- a/lean/Malgo/Driver.lean
+++ b/lean/Malgo/Driver.lean
@@ -13,6 +13,7 @@ import Malgo.Sequent.Eval
 import Malgo.Sequent.BigStepEval
 import Malgo.Query
 import Malgo.Query.Engine
+import Malgo.Backend.Scheme
 import Malgo.Backend.Zig
 import Malgo.Backend.Zig.Toolchain
 
@@ -205,7 +206,7 @@ already-parsed module seeded into the engine's `cacheParsedModule` under its
 own resolved name, so `fetchLinkedProgram` starts from a cache hit instead
 of re-deriving the module's identity.
 
-`compileAndEval`/`compileZig`/`compileToNativeExecutable`
+`compileAndEval`/`compileScheme`/`compileZig`/`compileToNativeExecutable`
 (all four CLI entries below) share this exact parse+link+seed sequence —
 `linkForCli` is the one place it lives, so a future fix only has one call
 site to update. -/
@@ -238,8 +239,19 @@ def compileAndEval (flag : Flag) (path : System.FilePath) : IO UInt32 := do
     | .bigStep => Malgo.Sequent.BigStepEval.bigStepEvalProgram moduleName handlers linked
   return 0
 
-/-- CLI entry for `malgo eval --target zig`: link exactly as
-`compileAndEval` but, instead of interpreting, run the Zig lowering pipeline (`Malgo.Backend.Zig.compileToZigText`, which
+/-- CLI entry for `malgo eval --target scheme`: link exactly as
+`compileAndEval` but, instead of interpreting, emit the Scheme source for the
+linked Join program. Mirrors Haskell `Driver.compileFromAST`'s `TargetScheme`
+branch. -/
+def compileScheme (flag : Flag) (path : System.FilePath) : IO UInt32 := do
+  let ws ← Workspace.setup
+  MalgoM.run flag {} do
+    let (moduleName, linked) ← linkForCli ws path
+    MalgoM.io (IO.print (Malgo.Backend.Scheme.compileToScheme moduleName linked))
+  return 0
+
+/-- CLI entry for `malgo eval --target zig`: link exactly as `compileScheme`,
+then run the Zig lowering pipeline (`Malgo.Backend.Zig.compileToZigText`, which
 runs ClosureConv → Peephole → Perceus → Reuse, the linearity check, and Emit)
 and print the generated Zig source. Mirrors Haskell `Driver.compileFromAST`'s
 `TargetZig` branch. -/

--- a/lean/Malgo/Prelude.lean
+++ b/lean/Malgo/Prelude.lean
@@ -318,6 +318,7 @@ instance : Pretty Range where
 /-- Compilation target backend. -/
 inductive Target where
   | eval
+  | scheme
   | zig
   deriving BEq, Repr
 

--- a/lean/ci-gates.env
+++ b/lean/ci-gates.env
@@ -14,6 +14,10 @@
 # Flip LEAN_SELFHOST_L2 back to 1 when #385 brings L2 back into budget. That
 # is listed as #385's completion criterion, so this flag is the thing that
 # closes it.
+#
+# The v4.0.0 release is held until this flag is back at 1 -- see milestone
+# v4.0.0. The Chez baseline the 7.5x is measured against is re-measurable with
+# `TARGET=scheme bash scripts/selfhost-level2.sh`.
 LEAN_ZIG=1
 LEAN_SELFHOST=1
 LEAN_SELFHOST_L2=0

--- a/mise.toml
+++ b/mise.toml
@@ -1,19 +1,6 @@
 [tools]
 watchexec = "latest"
 gh = "latest"
-claude = { version = "latest", bin = "claude", platforms = """
-[linux-arm64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/linux-arm64/claude"
-
-[linux-x64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/linux-x64/claude"
-
-[macos-arm64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-arm64/claude"
-
-[macos-x64]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-x64/claude"
-""", version_list_url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/stable" }
 node = "latest"
 npm = "latest"
 hyperfine = "latest"
@@ -86,6 +73,11 @@ run = "bash scripts/zig-golden.sh"
 description = "Run Zig backend deep-recursion gate (18.8M dispatches; #360 regression)"
 depends = ["build"]
 run = "bash scripts/zig-deep-recursion.sh"
+
+[tasks.perf-baseline]
+description = "Compare MALGO_RC_STATS counters against bench/perf-baseline.json (#385); -- --tier=all --update to reseed"
+depends = ["build"]
+run = "bash scripts/perf-baseline.sh"
 
 [tasks.exec]
 description = "Run the compiler (extra args after --, e.g. mise run exec -- eval examples/malgo/Hello.mlg)"

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,7 @@ url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d
 node = "latest"
 npm = "latest"
 hyperfine = "latest"
+chezscheme = "latest"
 # Pinned: Zig minor releases break std (e.g. std.Io churn between 0.15 and
 # 0.16). Bump deliberately, re-running the full zig-golden sweep.
 zig = "0.16.0"

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# perf-baseline.sh — deterministic performance baseline for the Zig backend (#385).
+#
+# #385 requires that every before/after claim carry `MALGO_RC_STATS` counters,
+# because "wall-clock alone will not survive review". The counters are
+# deterministic and machine-independent: given the same compiler and the same
+# fixture they do not vary between runs or between machines. Wall clock does, so
+# it is recorded for information and never gated.
+#
+# The counters are always-on in the runtime (`g_total_allocs` at runtime.zig:175,
+# `g_dispatches` at :606, ...); only the reporting is env-gated. So an
+# instrumented run and a timed run measure the same binary and there is no
+# observer cost to subtract.
+#
+# Gates are DIRECTIONAL, not exact-match: an optimization must not turn the gate
+# red until the JSON is re-committed. `--update` rewrites the baseline, and that
+# diff appearing in a PR *is* the before/after claim #385 asks for.
+#
+#   total_allocs      <= baseline   (gated; fewer allocations is the goal)
+#   dispatches        <= baseline   (gated; fewer trampoline dispatches is the goal)
+#   force_depth_max   == baseline   (gated; an invariant claim, not a budget: #382
+#                                    declined to lower Force to a continuation
+#                                    edge on the strength of depth 1. A rise is
+#                                    a design regression; a fall means the
+#                                    workload changed. Either wants a human.)
+#   reuse_hits        reported, NOT gated
+#   reuse_rate        reported, NOT gated
+#
+# reuse_hits deliberately is not a gate, which cost one false regression to
+# learn. Interning small integers (#385) cut fib-deep's total_allocs by 5.8% and
+# its reuse_hits by 10% at the same time: interned ints are immortal, so they are
+# neither allocated nor available as reuse tokens. Reuse fell because there was
+# less left to reuse, which is the optimization working, not regressing. Both
+# reuse figures are ratios whose denominator legitimately moves, so only
+# total_allocs -- the quantity actually being minimized -- can be gated
+# absolutely. #354 work should read reuse_rate, and should hold total_allocs
+# fixed while doing so.
+#
+# Usage:
+#   scripts/perf-baseline.sh [--tier=LIST] [--update] [--timing]
+#
+#   --tier=LIST   comma-separated: fib-shallow,fib-deep,selfhost-l1,selfhost-l2
+#                 or `all`. Default: fib-shallow,fib-deep (the cheap tiers).
+#   --update      rewrite the baseline JSON from this run instead of comparing.
+#   --timing      also measure wall clock with hyperfine (local only; never CI).
+#
+# Env knobs:
+#   MALGO             path to the malgo executable (default: the Lean build)
+#   ZIG_BIN_DIR       directory containing the zig binary, prepended to PATH
+#   BASELINE          baseline JSON path (default: bench/perf-baseline.json)
+#   COMPILE_TIMEOUT   seconds for `malgo compile` (default: 600)
+#   CASE_TIMEOUT      seconds for running a compiled binary (default: 900)
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+MALGO="${MALGO:-lean/.lake/build/bin/malgo}"
+BASELINE="${BASELINE:-bench/perf-baseline.json}"
+COMPILE_TIMEOUT="${COMPILE_TIMEOUT:-600}"
+CASE_TIMEOUT="${CASE_TIMEOUT:-900}"
+
+TIERS="fib-shallow,fib-deep"
+UPDATE=0
+TIMING=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --tier=*)  TIERS="${arg#--tier=}" ;;
+    --update)  UPDATE=1 ;;
+    --timing)  TIMING=1 ;;
+    -h|--help) sed -n '2,48p' "$0"; exit 0 ;;
+    *) echo "unknown argument '$arg' (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$TIERS" = "all" ]; then
+  TIERS="fib-shallow,fib-deep,selfhost-l1,selfhost-l2"
+fi
+
+if [ -n "${ZIG_BIN_DIR:-}" ]; then
+  export PATH="$ZIG_BIN_DIR:$PATH"
+fi
+
+for tool in jq zig; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "$tool not found on PATH (run 'mise install' / activate mise)." >&2
+    exit 1
+  }
+done
+
+if [ ! -x "$MALGO" ]; then
+  echo "malgo executable not found at '$MALGO' (set MALGO, or run 'lake build' in lean/)." >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Bare-name imports inside Prelude.mlg resolve only via the .malgo-work mirror,
+# which is empty on a fresh checkout. Same seeding as zig-golden.sh.
+for module in Builtin Prelude Either; do
+  "$MALGO" eval "runtime/malgo/$module.mlg" >/dev/null 2>&1
+done
+
+# ---------------------------------------------------------------------------
+# Counter capture
+# ---------------------------------------------------------------------------
+
+# Parses the runtime's stats line out of a stderr capture. The line goes to
+# stderr alongside MALGO-LEAK:, so anchor on the prefix. A missing or
+# unparseable line is a hard failure, never "unchanged" -- runtime.zig:787 is a
+# fixed 160-byte buffer whose bufPrint error is swallowed into
+# "MALGO-STATS: ?", so a fifth counter would silently degrade to `?` and a
+# lenient parser would read that as no change.
+parse_stats() {
+  local stats_file="$1" label="$2"
+  local line
+  line="$(grep '^MALGO-STATS:' "$stats_file" | tail -n 1)"
+  if [ -z "$line" ]; then
+    echo "FAIL($label): no MALGO-STATS line on stderr" >&2
+    return 1
+  fi
+  case "$line" in
+    *'?'*) echo "FAIL($label): truncated stats line ($line) -- widen runtime.zig's bufPrint buffer" >&2; return 1 ;;
+  esac
+  local ta rh di fd
+  ta="$(printf '%s\n' "$line" | sed -n 's/.*total_allocs=\([0-9]*\).*/\1/p')"
+  rh="$(printf '%s\n' "$line" | sed -n 's/.*reuse_hits=\([0-9]*\).*/\1/p')"
+  di="$(printf '%s\n' "$line" | sed -n 's/.*dispatches=\([0-9]*\).*/\1/p')"
+  fd="$(printf '%s\n' "$line" | sed -n 's/.*force_depth_max=\([0-9]*\).*/\1/p')"
+  for v in "$ta" "$rh" "$di" "$fd"; do
+    if [ -z "$v" ]; then
+      echo "FAIL($label): could not parse all four counters from: $line" >&2
+      return 1
+    fi
+  done
+  printf '%s %s %s %s\n' "$ta" "$rh" "$di" "$fd"
+}
+
+# Runs one compiled binary under MALGO_RC_STATS and echoes its four counters.
+# Extra args after the binary are passed through (Level 2 needs them).
+measure_binary() {
+  local label="$1" expected="$2" bin="$3"; shift 3
+  local out status
+  out="$(printf 'Hello\n' | MALGO_RC_STATS=1 timeout "$CASE_TIMEOUT" "$bin" "$@" 2>"$WORK/stats.$label")"
+  status=$?
+  if [ "$status" -eq 124 ]; then
+    echo "FAIL($label): timed out after ${CASE_TIMEOUT}s" >&2
+    return 1
+  fi
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL($label): exited $status (83 = the runtime's leak gate, 139 = SIGSEGV)" >&2
+    return 1
+  fi
+  if [ -n "$expected" ] && [ "$out" != "$expected" ]; then
+    echo "FAIL($label): expected '$expected', got '$out'" >&2
+    return 1
+  fi
+  parse_stats "$WORK/stats.$label" "$label"
+}
+
+compile_fixture() {
+  local label="$1" src="$2" bin="$3"
+  echo "  compiling $src (--opt release-fast)" >&2
+  if ! timeout "$COMPILE_TIMEOUT" "$MALGO" compile "$src" -o "$bin" --opt release-fast >/dev/null; then
+    echo "FAIL($label): malgo compile failed" >&2
+    return 1
+  fi
+}
+
+# The Level 1 evaluator: Main.mlg compiled release-fast. Both selfhost tiers
+# need it, and it is the expensive step, so build it at most once.
+ensure_selfhost_evaluator() {
+  [ -x "$WORK/malgoc" ] && return 0
+  echo "  precompiling the self-hosted compiler's modules" >&2
+  local f
+  for f in runtime/malgo/Builtin.mlg runtime/malgo/Prelude.mlg runtime/malgo/Either.mlg \
+           runtime/malgo/compiler/AST.mlg runtime/malgo/compiler/Token.mlg \
+           runtime/malgo/compiler/Diagnostic.mlg runtime/malgo/compiler/Lexer.mlg \
+           runtime/malgo/compiler/Parser.mlg runtime/malgo/compiler/Value.mlg \
+           runtime/malgo/compiler/Eval.mlg runtime/malgo/compiler/FunIR.mlg \
+           runtime/malgo/compiler/Rename.mlg runtime/malgo/compiler/ToFun.mlg \
+           runtime/malgo/compiler/Main.mlg; do
+    if ! timeout "$COMPILE_TIMEOUT" "$MALGO" eval "$f" </dev/null >/dev/null; then
+      echo "FAIL: precompile failed on $f" >&2
+      return 1
+    fi
+  done
+  compile_fixture selfhost runtime/malgo/compiler/Main.mlg "$WORK/malgoc"
+}
+
+# Echoes "<tier> <total_allocs> <reuse_hits> <dispatches> <force_depth_max>".
+run_tier() {
+  local tier="$1" counters
+  echo "=== $tier ===" >&2
+  case "$tier" in
+    fib-shallow)
+      compile_fixture "$tier" bench/fixtures/BenchFib.mlg "$WORK/fib" || return 1
+      counters="$(measure_binary "$tier" 610 "$WORK/fib")" || return 1
+      ;;
+    fib-deep)
+      compile_fixture "$tier" bench/fixtures/BenchFibDeep.mlg "$WORK/fibdeep" || return 1
+      counters="$(measure_binary "$tier" 75025 "$WORK/fibdeep")" || return 1
+      ;;
+    selfhost-l1)
+      ensure_selfhost_evaluator || return 1
+      counters="$(measure_binary "$tier" 8 "$WORK/malgoc" test/testcases/malgo/Fib.mlg)" || return 1
+      ;;
+    selfhost-l2)
+      # Serial, single-case, deliberately NOT selfhost-level2.sh: that runs five
+      # cases in parallel and discards each case's stderr, so its numbers are
+      # neither isolated nor capturable.
+      ensure_selfhost_evaluator || return 1
+      counters="$(measure_binary "$tier" 8 "$WORK/malgoc" runtime/malgo/compiler/Main.mlg test/testcases/malgo/Fib.mlg)" || return 1
+      ;;
+    *)
+      echo "unknown tier '$tier' (fib-shallow|fib-deep|selfhost-l1|selfhost-l2|all)" >&2
+      return 1
+      ;;
+  esac
+  printf '%s %s\n' "$tier" "$counters"
+}
+
+# ---------------------------------------------------------------------------
+# Run the requested tiers
+# ---------------------------------------------------------------------------
+
+RESULTS="$WORK/results"
+: >"$RESULTS"
+failed=0
+
+old_ifs="$IFS"; IFS=','
+for tier in $TIERS; do
+  IFS="$old_ifs"
+  if ! run_tier "$tier" >>"$RESULTS"; then
+    failed=1
+    [ "$UPDATE" -eq 1 ] && { echo "refusing to --update from a failed run" >&2; exit 1; }
+  fi
+  IFS=','
+done
+IFS="$old_ifs"
+
+# ---------------------------------------------------------------------------
+# Compare or update
+# ---------------------------------------------------------------------------
+
+results_to_json() {
+  jq -n --rawfile raw "$RESULTS" --arg commit "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+        --arg zig "$(zig version 2>/dev/null || echo unknown)" '
+    def rows: $raw | split("\n") | map(select(length > 0) | split(" "));
+    {
+      "$comment": "LIVE Zig-backend perf baseline for #385. Unrelated to bench/baseline-*.json, which are 2026-03 GHC *build*-time records. Regenerate with `mise run perf-baseline -- --update`; the diff of this file IS the before/after claim #385 requires. Gates are directional -- see scripts/perf-baseline.sh.",
+      compiler: { commit: $commit, zig: $zig },
+      tiers: (rows | map({
+        key: .[0],
+        value: {
+          counters: {
+            total_allocs: (.[1] | tonumber),
+            reuse_hits: (.[2] | tonumber),
+            dispatches: (.[3] | tonumber),
+            force_depth_max: (.[4] | tonumber)
+          },
+          derived: {
+            reuse_rate: (if (.[1] | tonumber) > 0
+                         then (((.[2] | tonumber) / (.[1] | tonumber)) * 10000 | round) / 10000
+                         else 0 end)
+          }
+        }
+      }) | from_entries)
+    }'
+}
+
+if [ "$UPDATE" -eq 1 ]; then
+  # Merge, so updating a cheap tier does not drop an expensive tier's row.
+  # jq's `*` on two objects merges recursively, which is exactly the semantics
+  # wanted here: every key a fresh row supplies wins, absent tiers survive.
+  if [ -f "$BASELINE" ]; then
+    results_to_json >"$WORK/new.json" || exit 1
+    jq -s '.[0] * .[1]' "$BASELINE" "$WORK/new.json" >"$WORK/merged.json" || exit 1
+    mv "$WORK/merged.json" "$BASELINE"
+  else
+    results_to_json >"$BASELINE" || exit 1
+  fi
+  echo "updated $BASELINE:"
+  jq . "$BASELINE"
+  exit 0
+fi
+
+if [ ! -f "$BASELINE" ]; then
+  echo "NOTICE: no baseline at $BASELINE -- skipping the perf gate."
+  echo "        seed it with: mise run perf-baseline -- --tier=all --update"
+  cat "$RESULTS"
+  exit "$failed"
+fi
+
+regressions=0
+while read -r tier ta rh di fd; do
+  [ -n "$tier" ] || continue
+  base="$(jq -r --arg t "$tier" '.tiers[$t] // empty' "$BASELINE")"
+  if [ -z "$base" ]; then
+    echo "NOTICE($tier): no baseline row -- skipping (add it with --update)"
+    continue
+  fi
+  b_ta="$(printf '%s' "$base" | jq -r '.counters.total_allocs')"
+  b_rh="$(printf '%s' "$base" | jq -r '.counters.reuse_hits')"
+  b_di="$(printf '%s' "$base" | jq -r '.counters.dispatches')"
+  b_fd="$(printf '%s' "$base" | jq -r '.counters.force_depth_max')"
+
+  echo "--- $tier ---"
+  printf '  total_allocs    %12s  (baseline %12s)\n' "$ta" "$b_ta"
+  printf '  reuse_hits      %12s  (baseline %12s)\n' "$rh" "$b_rh"
+  printf '  dispatches      %12s  (baseline %12s)\n' "$di" "$b_di"
+  printf '  force_depth_max %12s  (baseline %12s)\n' "$fd" "$b_fd"
+
+  [ "$ta" -le "$b_ta" ] || { echo "  REGRESSION: total_allocs rose by $((ta - b_ta))"; regressions=1; }
+  [ "$di" -le "$b_di" ] || { echo "  REGRESSION: dispatches rose by $((di - b_di))"; regressions=1; }
+  [ "$fd" -eq "$b_fd" ] || { echo "  REGRESSION: force_depth_max changed ($b_fd -> $fd) -- see #382"; regressions=1; }
+
+  # Not a gate -- see the header. Reported so #354 work can watch it, and so a
+  # reuse drop that is NOT explained by an allocation drop still gets noticed.
+  if [ "$rh" -lt "$b_rh" ]; then
+    if [ "$ta" -lt "$b_ta" ]; then
+      echo "  note: reuse_hits fell by $((b_rh - rh)), alongside $((b_ta - ta)) fewer allocations (less left to reuse)"
+    else
+      echo "  WARNING: reuse_hits fell by $((b_rh - rh)) with no drop in total_allocs -- reuse itself got worse (#354)"
+    fi
+  fi
+
+  if [ "$ta" -lt "$b_ta" ] || [ "$di" -lt "$b_di" ]; then
+    echo "  IMPROVED -- re-run with --update to record it"
+  fi
+done <"$RESULTS"
+
+# ---------------------------------------------------------------------------
+# Wall clock (informational, local only)
+# ---------------------------------------------------------------------------
+
+if [ "$TIMING" -eq 1 ]; then
+  if command -v hyperfine >/dev/null 2>&1; then
+    echo "=== wall clock ($(uname -s) $(uname -m)) -- informational, never gated ==="
+    if [ -x "$WORK/fibdeep" ]; then
+      hyperfine --warmup 1 --runs 5 -n fib-deep "$WORK/fibdeep"
+    fi
+    if [ -x "$WORK/malgoc" ]; then
+      hyperfine --warmup 1 --runs 3 -i \
+        -n selfhost-l1 "$WORK/malgoc test/testcases/malgo/Fib.mlg" \
+        -n selfhost-l2 "$WORK/malgoc runtime/malgo/compiler/Main.mlg test/testcases/malgo/Fib.mlg"
+    fi
+  else
+    echo "NOTICE: hyperfine not on PATH -- skipping timings." >&2
+  fi
+fi
+
+if [ "$regressions" -ne 0 ] || [ "$failed" -ne 0 ]; then
+  echo "=== perf baseline FAILED ==="
+  exit 1
+fi
+echo "=== perf baseline OK ==="

--- a/scripts/selfhost-golden.sh
+++ b/scripts/selfhost-golden.sh
@@ -180,4 +180,50 @@ for i in "${!cases[@]}"; do
 done
 
 printf 'PASS: %s\nFAIL: %s\nTIMEOUT: %s\n' "$pass" "$fail" "$timeout_count"
-[[ $fail -eq 0 ]]
+
+# One extra serial run of the evaluator already built above, instrumented, to gate
+# the selfhost-l1 counters (#399). Costs ~1s: this is the tier #385's own baseline
+# reading came from, and the sweep above is parallel so its wall clock is
+# meaningless while counters from a single serial run are not. Only total_allocs /
+# dispatches / force_depth_max are gated -- see scripts/perf-baseline.sh for why
+# reuse_hits is reported instead.
+BASELINE="${BASELINE:-bench/perf-baseline.json}"
+perf_fail=0
+if [[ $fail -eq 0 ]] && [[ -f "$BASELINE" ]] && command -v jq >/dev/null 2>&1; then
+  log "measuring selfhost-l1 counters"
+  stats_file=$(mktemp)
+  if MALGO_RC_STATS=1 timeout "$CASE_TIMEOUT" "$NATIVE_MAIN" \
+       test/testcases/malgo/Fib.mlg >/dev/null 2>"$stats_file"; then
+    stats_line=$(grep '^MALGO-STATS:' "$stats_file" | tail -n 1)
+    case "$stats_line" in
+      ''|*'?'*)
+        log "perf gate: unusable MALGO-STATS line ('$stats_line')"
+        perf_fail=1
+        ;;
+      *)
+        for field in total_allocs dispatches force_depth_max; do
+          actual_v=$(sed -n "s/.*$field=\([0-9]*\).*/\1/p" <<< "$stats_line")
+          base_v=$(jq -r --arg f "$field" '.tiers["selfhost-l1"].counters[$f] // empty' "$BASELINE")
+          if [[ -z "$base_v" ]]; then
+            log "perf gate: no selfhost-l1 baseline for $field -- skipping"
+          elif [[ "$field" == "force_depth_max" && "$actual_v" -ne "$base_v" ]]; then
+            log "perf gate FAIL: force_depth_max changed ($base_v -> $actual_v); see #382"
+            perf_fail=1
+          elif [[ "$field" != "force_depth_max" && "$actual_v" -gt "$base_v" ]]; then
+            log "perf gate FAIL: $field rose ($base_v -> $actual_v, +$((actual_v - base_v)))"
+            perf_fail=1
+          elif [[ "$actual_v" -lt "$base_v" ]]; then
+            log "perf gate: $field improved ($base_v -> $actual_v) -- record with 'mise run perf-baseline -- --tier=selfhost-l1 --update'"
+          fi
+        done
+        ;;
+    esac
+  else
+    log "perf gate: instrumented selfhost-l1 run failed -- not gating"
+  fi
+  rm -f "$stats_file"
+else
+  [[ -f "$BASELINE" ]] || log "perf gate: no $BASELINE -- skipping"
+fi
+
+[[ $fail -eq 0 && $perf_fail -eq 0 ]]

--- a/scripts/selfhost-level2.sh
+++ b/scripts/selfhost-level2.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # selfhost-level2.sh — Level 2 metacircular interpreter test
 #
-# Level 1: malgoc (Main.mlg compiled to a native binary via the Zig backend)
+# Level 1: the Malgo evaluator (Main.mlg), built into a runnable artifact,
 #          evaluates a .mlg program directly
-# Level 2: malgoc evaluates Main.mlg, which evaluates a .mlg program
+# Level 2: that artifact evaluates Main.mlg, which evaluates a .mlg program
+#
+# TARGET selects how Main.mlg becomes runnable:
+#   TARGET=zig    (default) `malgo compile --opt release-fast` -> native binary
+#   TARGET=scheme           `malgo eval --target scheme` -> main.scm, run under Chez
+#
+# The Scheme path is retained as the cross-implementation performance reference
+# for #385: it is the only baseline the Zig backend's numbers can be read
+# against. Do not delete it until #385 closes -- see #400.
 #
 # This script verifies the metacircular property: the Malgo evaluator
 # written in Malgo can evaluate itself while correctly running programs.
@@ -14,10 +22,18 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 MALGO=${MALGO:-lean/.lake/build/bin/malgo}
+TARGET=${TARGET:-zig}
+SCHEME=${SCHEME:-scheme}
 # Level 2 is ~50-200x slower than Level 1, and the Zig backend is a further
 # ~7.5x slower per case than the Chez Scheme path it replaced (measured:
-# 220s vs 29s on Fib, on an M-series Mac). Budget accordingly.
-CASE_TIMEOUT=${CASE_TIMEOUT:-1200}
+# 220s vs 29s on Fib, on an M-series Mac; #385). Hence the per-target default:
+# 300 is the value the Chez path shipped with before #384, and still 10x the
+# 29s observation.
+case "$TARGET" in
+  zig)    CASE_TIMEOUT=${CASE_TIMEOUT:-1200} ;;
+  scheme) CASE_TIMEOUT=${CASE_TIMEOUT:-300} ;;
+  *) echo "unknown TARGET '$TARGET' (expected zig|scheme)" >&2; exit 1 ;;
+esac
 PRECOMPILE_TIMEOUT=${PRECOMPILE_TIMEOUT:-180}
 KEEP_WORK=${KEEP_WORK:-0}
 MALGO_WORK_DIR=${MALGO_WORK_DIR:-.malgo-work}
@@ -81,18 +97,41 @@ done
 
 log "precompile phase complete (${#precompile[@]} files)"
 
-NATIVE_MAIN="$MALGO_WORK_DIR/malgoc"
 mkdir -p "$MALGO_WORK_DIR"
-if ! command -v zig >/dev/null 2>&1; then
-  echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
-  exit 1
-fi
-log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
-if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$NATIVE_MAIN" --opt release-fast; then
-  log "native compilation failed"
-  exit 1
-fi
-log "native compilation done: $NATIVE_MAIN"
+
+# Every arm must set RUNNER: under `set -u`, bash 3.2 errors on "${RUNNER[@]}"
+# for an unset/empty array. The `*)` arm above already exited, so RUNNER is
+# always populated by the time run_case uses it.
+case "$TARGET" in
+  zig)
+    EVAL_MAIN="$MALGO_WORK_DIR/malgoc"
+    RUNNER=("$EVAL_MAIN")
+    if ! command -v zig >/dev/null 2>&1; then
+      echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
+      exit 1
+    fi
+    log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
+    if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$EVAL_MAIN" --opt release-fast; then
+      log "native compilation failed"
+      exit 1
+    fi
+    log "native compilation done: $EVAL_MAIN"
+    ;;
+  scheme)
+    EVAL_MAIN="$MALGO_WORK_DIR/main.scm"
+    RUNNER=("$SCHEME" --script "$EVAL_MAIN")
+    if ! command -v "$SCHEME" >/dev/null 2>&1; then
+      echo "'$SCHEME' not found on PATH (run 'mise install' to get chezscheme, or set SCHEME)." >&2
+      exit 1
+    fi
+    log "compiling Main.mlg to Scheme (Level 1 evaluator)"
+    if ! "$MALGO" eval --target scheme runtime/malgo/compiler/Main.mlg > "$EVAL_MAIN"; then
+      log "Scheme compilation failed"
+      exit 1
+    fi
+    log "Scheme compilation done: $EVAL_MAIN"
+    ;;
+esac
 
 # Level 2 test cases: a small subset of simple programs that complete quickly
 # even when interpreted by an interpreter.
@@ -105,8 +144,8 @@ level2_cases=(
 )
 
 total_cases=${#level2_cases[@]}
-log "starting Level 2 metacircular checks: ${total_cases} cases (parallel)"
-log "command: ./malgoc runtime/malgo/compiler/Main.mlg <case.mlg>"
+log "starting Level 2 metacircular checks: ${total_cases} cases (parallel, TARGET=$TARGET)"
+log "command: ${RUNNER[*]} runtime/malgo/compiler/Main.mlg <case.mlg>"
 
 results_dir="$MALGO_WORK_DIR/level2-results"
 rm -rf "$results_dir"
@@ -140,7 +179,7 @@ run_case() {
   out=$(mktemp)
   err=$(mktemp)
 
-  if printf 'Hello\n' | timeout "$CASE_TIMEOUT" "$NATIVE_MAIN" \
+  if printf 'Hello\n' | timeout "$CASE_TIMEOUT" "${RUNNER[@]}" \
       runtime/malgo/compiler/Main.mlg "$src" >"$out" 2>"$err"; then
     local case_elapsed=$((SECONDS - case_start))
     if cmp -s "$out" "$expected"; then

--- a/scripts/zig-deep-recursion.sh
+++ b/scripts/zig-deep-recursion.sh
@@ -87,4 +87,48 @@ if [ "$actual" != "$EXPECTED" ]; then
 fi
 
 cat "$WORK/stats"
+
+# This run already produced the fib-deep counters, so gating them here costs no
+# extra compile and no extra execution -- the numbers were previously printed and
+# thrown away (#399). Only total_allocs / dispatches / force_depth_max are gated;
+# see scripts/perf-baseline.sh for why reuse_hits is reported rather than gated.
+BASELINE="${BASELINE:-bench/perf-baseline.json}"
+if [ ! -f "$BASELINE" ] || ! command -v jq >/dev/null 2>&1; then
+  echo "NOTICE: no $BASELINE (or no jq) -- skipping the perf gate."
+else
+  stats_line="$(grep '^MALGO-STATS:' "$WORK/stats" | tail -n 1)"
+  case "$stats_line" in
+    ''|*'?'*)
+      echo "FAIL: unusable MALGO-STATS line ('$stats_line')" >&2
+      exit 1
+      ;;
+  esac
+  perf_fail=0
+  for field in total_allocs dispatches force_depth_max; do
+    actual_v="$(printf '%s\n' "$stats_line" | sed -n "s/.*$field=\([0-9]*\).*/\1/p")"
+    base_v="$(jq -r --arg f "$field" '.tiers["fib-deep"].counters[$f] // empty' "$BASELINE")"
+    if [ -z "$actual_v" ]; then
+      echo "FAIL: could not parse $field from '$stats_line'" >&2
+      exit 1
+    fi
+    if [ -z "$base_v" ]; then
+      echo "NOTICE: no fib-deep baseline for $field -- skipping"
+      continue
+    fi
+    if [ "$field" = "force_depth_max" ]; then
+      if [ "$actual_v" -ne "$base_v" ]; then
+        echo "FAIL: force_depth_max changed ($base_v -> $actual_v); see #382" >&2
+        perf_fail=1
+      fi
+    elif [ "$actual_v" -gt "$base_v" ]; then
+      echo "FAIL: $field rose ($base_v -> $actual_v, +$((actual_v - base_v)))" >&2
+      perf_fail=1
+    elif [ "$actual_v" -lt "$base_v" ]; then
+      echo "  $field improved ($base_v -> $actual_v); record it with 'mise run perf-baseline -- --tier=fib-deep --update'"
+    fi
+  done
+  [ "$perf_fail" -eq 0 ] || exit 1
+  echo "=== perf counters within baseline ==="
+fi
+
 echo "=== deep recursion OK: $actual, no leak ==="


### PR DESCRIPTION
Closes #399. Stacked on #401.

## Why

#385 requires deterministic `MALGO_RC_STATS` counters in every before/after claim,
because wall clock alone will not survive review. Nothing in the tree recorded or
compared them: the only benchmark runner that ever existed for the Zig backend,
`bench/lean-vs-haskell.sh`, went with the Haskell implementation in #397. So a perf
win had no way to be evidenced, and no way to be protected once made.

## What

`scripts/perf-baseline.sh` measures four tiers — `fib-shallow`, `fib-deep`,
`selfhost-l1`, `selfhost-l2` — and compares them against `bench/perf-baseline.json`.
`--update` rewrites the baseline, so that file's diff *is* the claim. It lives in
`scripts/` rather than `bench/` because `AGENTS.md` declares `bench/` historical and
the `bench/baseline-*.json` files there are 2026-03 GHC **build**-time records.

It also re-adopts `bench/fixtures/BenchFib.mlg`, which #397 left referenced by
nothing.

## The seeded baseline validates against #385's own anchor

`selfhost-l1` reproduces the reading in #385's body exactly:
`total_allocs=4570396 reuse_hits=332109 dispatches=5067427 force_depth_max=1`.

And `selfhost-l2` is measured here for the first time — the three costs in #385 were
labelled "by construction", never profiled:

| | `selfhost-l1` | `selfhost-l2` |
|---|---|---|
| `total_allocs` | 4,570,396 | **8,265,456,483** |
| `dispatches` | 5,067,427 | **9,110,106,332** |
| `reuse_rate` | 7.27% | **3.51%** |

The reuse rate *halves* at depth. #385 observed from the outside that "the gap opens
up exactly where the workload gets big"; in the counters that is #354 degrading with
nesting, which makes #354 #385's primary lever rather than its second.

## Gates are a ratchet, on quantities actually being minimized

`total_allocs` and `dispatches` may not rise; `force_depth_max` may not change at all
(#382 declined to lower `Force` to a continuation edge on the strength of it being 1).

**`reuse_hits` is reported, not gated** — a deliberate change from the plan in the
issue, which cost one false regression to learn. Interning small ints (#385) cut
`fib-deep`'s `total_allocs` 5.8% *and* its `reuse_hits` 10% at once, because interned
ints are neither allocated nor available as reuse tokens: reuse fell because there was
less left to reuse. Both reuse figures are ratios whose denominator legitimately
moves, so only `total_allocs` can be gated absolutely. The script still warns when
reuse falls *without* an accompanying allocation drop.

## CI cost: ~1 second, no new job

`zig-deep-recursion.sh` already compiled and ran the instrumented `fib-deep` binary
and printed its counters to no one; `selfhost-golden.sh` already built the Level 1
evaluator. Each now compares instead of discarding. Both skip with a notice when the
baseline is absent, so they stay usable standalone and on branches predating the file.
`selfhost-l2` stays local — running it in CI is the 16 minutes #385 exists to remove.

A fifth job would instead have meant a duplicate checkout + `lean-action` cache
restore + `setup-zig` + build, ~4 minutes of runner time to measure what two existing
jobs already produce and throw away.

## Verification

- Gate exits **1** on synthetic regressions (allocs rise, dispatches rise,
  `force_depth_max` change) and **0** clean — checked in both directions.
- Hard-fails on an unparseable `MALGO-STATS:` line rather than reading a missing
  counter as unchanged. `runtime.zig`'s stats buffer is a fixed 160 bytes whose
  `bufPrint` error is swallowed into `MALGO-STATS: ?`, and #385 will want more
  counters, so a lenient parser would silently stop measuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
