### PR TITLE
ci(lean): split Level 2 into a build job and one job per case

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -72,11 +72,9 @@ jobs:
     needs: gates
     if: needs.gates.outputs.selfhost == '1'
     runs-on: ubuntu-latest
-    # This one job runs both levels. L2 through the Zig backend is ~5x slower per
-    # case than the Chez Scheme path it replaced (measured locally and serially:
-    # 154s vs 31s on Fib; it was ~7.5x before #403/#405). Re-measure with
-    # `mise run perf-baseline -- --tier=l2-ratio`.
-    timeout-minutes: 60
+    # Level 1 only. Level 2 lives in l2-build + l2-case below, because a single
+    # job running all five L2 cases took 26.7 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -105,24 +103,101 @@ jobs:
       - name: Self-hosted golden (Level 1 — Malgo-in-Malgo compiler, Zig backend)
         run: bash scripts/selfhost-golden.sh
 
-      # Not run on pull requests: L2 is minutes per case, so it would set the
-      # whole run's wall clock (the jobs here are concurrent) and push PR
-      # feedback from ~3 minutes to well over the 10 we want. On master pushes
-      # and the nightly cron it still catches a regression within a day, which
-      # is the coverage that mattered -- since #395 it has been running nowhere.
-      #
-      # PARALLEL_JOBS is the reason this can use a 600s CASE_TIMEOUT at all.
-      # Unthrottled, five concurrent cases contend on a runner with far fewer
-      # cores than a workstation and every case blew past 600s, while the same
-      # sweep is 154-177s per case locally. Lower this further before ever
-      # raising CASE_TIMEOUT again (#385).
-      - name: Self-hosted metacircular (Level 2)
-        if: needs.gates.outputs.selfhostL2 == '1' && github.event_name != 'pull_request'
+  # ===== Level 2, split so no single job runs long =====
+  #
+  # Not run on pull requests at all: a case is minutes, and the jobs here are
+  # concurrent, so L2 would set the whole run's wall clock and push PR feedback
+  # from ~3 minutes to well past it. Master pushes and the nightly cron still
+  # catch a regression within a day, which is the coverage that mattered --
+  # since #395 L2 had been running nowhere.
+  #
+  # Why two jobs. Measured on run 30239212721, one job running all five cases
+  # took 26.7 minutes, and the fixed cost was almost entirely `malgo compile
+  # Main.mlg` (~105s; the 14-module precompile is only ~12s). Splitting per case
+  # without splitting the build would make each job ~11 min -- still over
+  # budget -- so the evaluator is built once and handed to the case jobs.
+  #
+  # This also buys headroom on CASE_TIMEOUT. Five concurrent cases contend on a
+  # runner with far fewer cores than a workstation: unthrottled they all blew
+  # past 600s, at PARALLEL_JOBS=2 they were 435-492s. One case alone on a runner
+  # has no contention at all. If a case ever times out again, take the time out
+  # of the case (#407) -- do not raise CASE_TIMEOUT, which is what buried #385.
+  l2-build:
+    needs: gates
+    if: needs.gates.outputs.selfhostL2 == '1' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
+        with:
+          lake-package-directory: lean
+          build: true
+          test: false
+
+      # Not optional, for the same reason lean-selfhost and lean-zig-golden do
+      # it: Lake does not reliably track the include_str that embeds
+      # runtime.zig, so without this the evaluator can be built against a stale
+      # cached runtime. See lean/Malgo/Backend/Zig/Runtime.lean.
+      - name: Rebuild the embedded Zig runtime
+        run: |
+          rm -f lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.olean \
+                lean/.lake/build/lib/lean/Malgo/Backend/Zig/Runtime.trace \
+                lean/.lake/build/ir/Malgo/Backend/Zig/Runtime.c
+          cd lean && lake build malgo
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: '0.16.0'
+
+      - name: Build the Level 1 evaluator
         env:
-          CASE_TIMEOUT: 600
+          BUILD_ONLY: 1
           PRECOMPILE_TIMEOUT: 300
-          PARALLEL_JOBS: 2
         run: bash scripts/selfhost-level2.sh
+
+      # 5.6 MB. The binary is the whole dependency: it reads Main.mlg and its
+      # imports as source at run time, and .malgo-work is the Lean compiler's
+      # workspace, not the evaluator's -- verified by running a case with an
+      # empty workspace and no Lean toolchain present.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: l2-evaluator
+          path: .malgo-work/malgoc
+          retention-days: 1
+          if-no-files-found: error
+
+  l2-case:
+    needs: [gates, l2-build]
+    if: needs.gates.outputs.selfhostL2 == '1' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    # One case, no contention, plus ~10s of setup. The 600s CASE_TIMEOUT is the
+    # real gate; this is only a backstop against a hang.
+    timeout-minutes: 15
+    strategy:
+      # Each case is an independent claim about the evaluator. Cancelling the
+      # others on the first failure would throw away exactly the information
+      # needed to tell "one case regressed" from "the evaluator is broken".
+      fail-fast: false
+      matrix:
+        case: [Echo, Factorial, Fib, StringOps, Bool]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: l2-evaluator
+
+      - name: Level 2 — ${{ matrix.case }}
+        env:
+          EVAL_BIN: ./malgoc
+          L2_CASES: ${{ matrix.case }}
+          PARALLEL_JOBS: 1
+          CASE_TIMEOUT: 600
+        run: |
+          chmod +x ./malgoc
+          bash scripts/selfhost-level2.sh
 
   lean-zig-golden:
     needs: gates
@@ -177,7 +252,7 @@ jobs:
         run: bash scripts/zig-deep-recursion.sh
 
   actions-timeline:
-    needs: [gates, lean-build, cli-gate, lean-selfhost, lean-zig-golden]
+    needs: [gates, lean-build, cli-gate, lean-selfhost, lean-zig-golden, l2-build, l2-case]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/lean/ci-gates.env
+++ b/lean/ci-gates.env
@@ -9,26 +9,25 @@
 # than the Chez Scheme path it replaced (#385).
 #
 # Back ON, but for master pushes and the nightly cron only -- not pull requests.
-# The jobs in lean.yml run concurrently, so L2 sets the whole run's wall clock;
-# keeping it off PRs holds PR feedback at ~3 minutes while still catching a
-# regression within a day. Since #395 it had been running nowhere at all, which
-# was the actual loss.
+# The jobs in lean.yml run concurrently, so L2 would set the whole run's wall
+# clock; keeping it off PRs holds PR feedback at ~3 minutes while still catching
+# a regression within a day. Since #395 it had been running nowhere at all,
+# which was the actual loss.
+#
+# L2 is split across jobs: `l2-build` compiles the evaluator once and uploads it,
+# and `l2-case` runs one case per job from that artifact. One job running all
+# five took 26.7 minutes; this keeps every job under 10. Running a case alone on
+# a runner also removes the contention that made five concurrent cases blow past
+# the 600s CASE_TIMEOUT, so the budget has more headroom than it did at
+# PARALLEL_JOBS=2 (435-492s per case).
 #
 # L2 is now ~5x slower per case than the Chez path rather than ~7.5x (measured
-# serially on an M-series Mac: 154s vs 31s on Fib, slowest of the five 177s;
+# serially on an M-series Mac: 154s vs 31s on Fib;
 # `mise run perf-baseline -- --tier=l2-ratio`, which needs the Chez control that
 # #400 removes).
 #
-# #385 is NOT closed by this. Its criterion is L2 CASE_TIMEOUT back at 600, and
-# the first attempt at that failed on CI: all five cases timed out at 600s even
-# though a local cold run is 231s total. The cause was contention, not compute --
-# five concurrent cases on a runner with far fewer cores than a workstation --
-# so the sweep is now throttled with PARALLEL_JOBS (2 in CI). Whether 600s holds
-# under that throttle is the open question #385 tracks.
-#
-# lean-selfhost timeout-minutes is back at 60 (the failing run was 15.2 min).
-# If 600s still does not hold, lower PARALLEL_JOBS or set this flag to 0. Do not
-# raise CASE_TIMEOUT again -- that is what buried #385 the first time.
+# If a case times out, take the time out of the case (#407) or narrow the
+# trigger. Do not raise CASE_TIMEOUT -- that is what buried #385 the first time.
 LEAN_ZIG=1
 LEAN_SELFHOST=1
 LEAN_SELFHOST_L2=1

--- a/scripts/selfhost-level2.sh
+++ b/scripts/selfhost-level2.sh
@@ -13,6 +13,21 @@
 # for #385: it is the only baseline the Zig backend's numbers can be read
 # against. Do not delete it until #385 closes -- see #400.
 #
+# Building the evaluator and running the cases can be separated, which is how CI
+# keeps any one job under 10 minutes:
+#   BUILD_ONLY=1   build the evaluator and stop
+#   EVAL_BIN=PATH  use an already-built evaluator; skip the precompile and the
+#                  `malgo compile` entirely
+#   L2_CASES="A B" run only these cases (default: all five)
+#
+# Splitting matters because the fixed cost dwarfs everything else: on CI the
+# 14-module precompile is ~12s but `malgo compile Main.mlg` is ~105s, and a job
+# that runs one case would otherwise spend more time building than testing. The
+# built evaluator needs nothing from `.malgo-work` -- it reads `Main.mlg` and its
+# imports as source at run time, and `.malgo-work` is the Lean compiler's own
+# workspace (lean/Malgo/Module.lean) -- so the binary alone is enough to hand to
+# another machine.
+#
 # This script verifies the metacircular property: the Malgo evaluator
 # written in Malgo can evaluate itself while correctly running programs.
 
@@ -43,6 +58,38 @@ PRECOMPILE_TIMEOUT=${PRECOMPILE_TIMEOUT:-180}
 PARALLEL_JOBS=${PARALLEL_JOBS:-2}
 KEEP_WORK=${KEEP_WORK:-0}
 MALGO_WORK_DIR=${MALGO_WORK_DIR:-.malgo-work}
+BUILD_ONLY=${BUILD_ONLY:-0}
+EVAL_BIN=${EVAL_BIN:-}
+# Space-separated. Kept as a string rather than an array so the CI matrix can
+# pass a single name through `env:`.
+L2_CASES=${L2_CASES:-"Echo Factorial Fib StringOps Bool"}
+
+# Validate arguments before anything expensive or destructive happens -- the
+# build phase wipes MALGO_WORK_DIR, so a bad argument must not get that far.
+# (L2_CASES unset falls back to all five, as every other knob here does; this
+# catches an explicitly whitespace-only value, which is a mistake, not a default.)
+if [[ -z "${L2_CASES// /}" ]]; then
+  echo "L2_CASES is empty -- nothing to run" >&2
+  exit 1
+fi
+
+if [[ -n "$EVAL_BIN" ]]; then
+  # The Scheme path's evaluator is a .scm run through `scheme --script`, not a
+  # binary, and the ratio measurement it exists for wants both halves built the
+  # same way in one place. Rather than guess which, refuse the combination.
+  if [[ "$TARGET" != "zig" ]]; then
+    echo "EVAL_BIN is TARGET=zig only (got TARGET=$TARGET)" >&2
+    exit 1
+  fi
+  if [[ "$BUILD_ONLY" == "1" ]]; then
+    echo "BUILD_ONLY and EVAL_BIN are mutually exclusive: one builds, the other skips building" >&2
+    exit 1
+  fi
+  if [[ ! -x "$EVAL_BIN" ]]; then
+    echo "EVAL_BIN '$EVAL_BIN' is not an executable file" >&2
+    exit 1
+  fi
+fi
 
 timestamp() {
   date '+%Y-%m-%d %H:%M:%S'
@@ -63,91 +110,105 @@ progress() {
   printf '[%s] %s\n' "$(timestamp)" "$*" >&3
 }
 
-if [[ "$KEEP_WORK" != "1" ]]; then
-  log "cleaning work directory: $MALGO_WORK_DIR"
-  rm -rf "$MALGO_WORK_DIR"
-fi
+# With EVAL_BIN there is nothing to build, so there is nothing to clean and no
+# Lean-side compiler needed -- the whole point is that a case can run on a
+# machine that has neither a toolchain nor a workspace.
+if [[ -z "$EVAL_BIN" ]]; then
+  if [[ "$KEEP_WORK" != "1" ]]; then
+    log "cleaning work directory: $MALGO_WORK_DIR"
+    rm -rf "$MALGO_WORK_DIR"
+  fi
 
-if [[ ! -x "$MALGO" ]]; then
-  echo "malgo executable not found at '$MALGO' (set MALGO, or run 'lake build' in lean/)." >&2
-  exit 1
-fi
-
-precompile=(
-  runtime/malgo/Builtin.mlg
-  runtime/malgo/Prelude.mlg
-  runtime/malgo/Either.mlg
-  runtime/malgo/compiler/AST.mlg
-  runtime/malgo/compiler/Token.mlg
-  runtime/malgo/compiler/Diagnostic.mlg
-  runtime/malgo/compiler/Lexer.mlg
-  runtime/malgo/compiler/Parser.mlg
-  runtime/malgo/compiler/Value.mlg
-  runtime/malgo/compiler/Eval.mlg
-  runtime/malgo/compiler/FunIR.mlg
-  runtime/malgo/compiler/Rename.mlg
-  runtime/malgo/compiler/ToFun.mlg
-  runtime/malgo/compiler/Main.mlg
-)
-
-for file in "${precompile[@]}"; do
-  start=$SECONDS
-  log "precompile start: $file"
-  if ! timeout "$PRECOMPILE_TIMEOUT" "$MALGO" eval "$file" </dev/null >/dev/null; then
-    log "precompile failed: $file"
+  if [[ ! -x "$MALGO" ]]; then
+    echo "malgo executable not found at '$MALGO' (set MALGO, or run 'lake build' in lean/)." >&2
     exit 1
   fi
-  elapsed=$((SECONDS - start))
-  log "precompile done: $file (${elapsed}s)"
-done
+fi
 
-log "precompile phase complete (${#precompile[@]} files)"
+if [[ -n "$EVAL_BIN" ]]; then
+  EVAL_MAIN="$EVAL_BIN"
+  RUNNER=("$EVAL_BIN")
+  log "using prebuilt Level 1 evaluator: $EVAL_MAIN (skipping precompile and compile)"
+else
+  precompile=(
+    runtime/malgo/Builtin.mlg
+    runtime/malgo/Prelude.mlg
+    runtime/malgo/Either.mlg
+    runtime/malgo/compiler/AST.mlg
+    runtime/malgo/compiler/Token.mlg
+    runtime/malgo/compiler/Diagnostic.mlg
+    runtime/malgo/compiler/Lexer.mlg
+    runtime/malgo/compiler/Parser.mlg
+    runtime/malgo/compiler/Value.mlg
+    runtime/malgo/compiler/Eval.mlg
+    runtime/malgo/compiler/FunIR.mlg
+    runtime/malgo/compiler/Rename.mlg
+    runtime/malgo/compiler/ToFun.mlg
+    runtime/malgo/compiler/Main.mlg
+  )
 
-mkdir -p "$MALGO_WORK_DIR"
+  for file in "${precompile[@]}"; do
+    start=$SECONDS
+    log "precompile start: $file"
+    if ! timeout "$PRECOMPILE_TIMEOUT" "$MALGO" eval "$file" </dev/null >/dev/null; then
+      log "precompile failed: $file"
+      exit 1
+    fi
+    elapsed=$((SECONDS - start))
+    log "precompile done: $file (${elapsed}s)"
+  done
 
-# Every arm must set RUNNER: under `set -u`, bash 3.2 errors on "${RUNNER[@]}"
-# for an unset/empty array. The `*)` arm above already exited, so RUNNER is
-# always populated by the time run_case uses it.
-case "$TARGET" in
-  zig)
-    EVAL_MAIN="$MALGO_WORK_DIR/malgoc"
-    RUNNER=("$EVAL_MAIN")
-    if ! command -v zig >/dev/null 2>&1; then
-      echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
-      exit 1
-    fi
-    log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
-    if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$EVAL_MAIN" --opt release-fast; then
-      log "native compilation failed"
-      exit 1
-    fi
-    log "native compilation done: $EVAL_MAIN"
-    ;;
-  scheme)
-    EVAL_MAIN="$MALGO_WORK_DIR/main.scm"
-    RUNNER=("$SCHEME" --script "$EVAL_MAIN")
-    if ! command -v "$SCHEME" >/dev/null 2>&1; then
-      echo "'$SCHEME' not found on PATH (run 'mise install' to get chezscheme, or set SCHEME)." >&2
-      exit 1
-    fi
-    log "compiling Main.mlg to Scheme (Level 1 evaluator)"
-    if ! "$MALGO" eval --target scheme runtime/malgo/compiler/Main.mlg > "$EVAL_MAIN"; then
-      log "Scheme compilation failed"
-      exit 1
-    fi
-    log "Scheme compilation done: $EVAL_MAIN"
-    ;;
-esac
+  log "precompile phase complete (${#precompile[@]} files)"
+
+  mkdir -p "$MALGO_WORK_DIR"
+
+  # Every arm must set RUNNER: under `set -u`, bash 3.2 errors on "${RUNNER[@]}"
+  # for an unset/empty array. The `*)` arm above already exited, so RUNNER is
+  # always populated by the time run_case uses it.
+  case "$TARGET" in
+    zig)
+      EVAL_MAIN="$MALGO_WORK_DIR/malgoc"
+      RUNNER=("$EVAL_MAIN")
+      if ! command -v zig >/dev/null 2>&1; then
+        echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
+        exit 1
+      fi
+      log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
+      if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$EVAL_MAIN" --opt release-fast; then
+        log "native compilation failed"
+        exit 1
+      fi
+      log "native compilation done: $EVAL_MAIN"
+      ;;
+    scheme)
+      EVAL_MAIN="$MALGO_WORK_DIR/main.scm"
+      RUNNER=("$SCHEME" --script "$EVAL_MAIN")
+      if ! command -v "$SCHEME" >/dev/null 2>&1; then
+        echo "'$SCHEME' not found on PATH (run 'mise install' to get chezscheme, or set SCHEME)." >&2
+        exit 1
+      fi
+      log "compiling Main.mlg to Scheme (Level 1 evaluator)"
+      if ! "$MALGO" eval --target scheme runtime/malgo/compiler/Main.mlg > "$EVAL_MAIN"; then
+        log "Scheme compilation failed"
+        exit 1
+      fi
+      log "Scheme compilation done: $EVAL_MAIN"
+      ;;
+  esac
+
+  if [[ "$BUILD_ONLY" == "1" ]]; then
+    log "BUILD_ONLY: evaluator built, stopping before the case sweep"
+    exit 0
+  fi
+fi
 
 # Level 2 test cases: a small subset of simple programs that complete quickly
 # even when interpreted by an interpreter.
-level2_cases=(
-  Echo
-  Factorial
-  Fib
-  StringOps
-  Bool
-)
+# Word-split L2_CASES deliberately -- it is a space-separated list, and this
+# keeps the script bash 3.2 clean (no mapfile). Validated near the top, before
+# anything expensive runs.
+# shellcheck disable=SC2206
+level2_cases=($L2_CASES)
 
 total_cases=${#level2_cases[@]}
 log "starting Level 2 metacircular checks: ${total_cases} cases (TARGET=$TARGET, parallelism: ${PARALLEL_JOBS}, CASE_TIMEOUT: ${CASE_TIMEOUT}s)"


### PR DESCRIPTION
Level 2 は #406 で CI に戻ったが、**1 ジョブ 26.7 分**かかっていた。「1 ジョブ最大 10 分」に収める。

## 1 ジョブ内では解けない

`PARALLEL_JOBS=2` への絞り込みは 600s の per-case 予算を通すためのもので、実時間は縮んでいない。`PARALLEL_JOBS=1` にすれば余裕は増えるが 35–40 分に伸びる。**1 ジョブの中では per-case の余裕と実時間が直接トレードオフになる。**

CI のジョブを分ければ抜けられる。別ジョブは別ランナーなので競合が一切なく、実時間は 5 ケースぶんではなく 1 ケースぶんになる。

## なぜ 2 ジョブなのか

run 30239212721 の実測では、固定費はほぼ 1 項目に集中している:

| | 秒 |
|---|---|
| ツールチェーン（checkout / lean-action / bust runtime / setup-zig） | 32–39 |
| 14 モジュール precompile | 11–14 |
| **`malgo compile Main.mlg` → `malgoc`** | **95–114** |
| 1 ケース（`PARALLEL_JOBS=2`） | 435–492 |

ビルドを分けずにケースだけ 5 分割すると 166 + 492 = **11.0 分**でまだ足が出る。なので `l2-build` が評価器を 1 回だけ作って artifact にし、`l2-case` 5 本がそれを受け取る。

### 前提は実測で確認した

`malgoc` は checkout 以外に何も要らない。バイナリ内に `.malgo-work` / `.sqt` / `.mlgi` への参照は **0 件**で、`Main.mlg` とその import を実行時にソースとして読む。`.malgo-work` は Lean コンパイラ側のワークスペース（`lean/Malgo/Module.lean`）。

読みで終わらせず、`MALGO` を存在しないパスに向け、空のワークスペースでケースを実行して確認した → **PASS**、書き込まれたのは自身の結果ファイルだけ。

## 結果（run 30242379986、workflow_dispatch）

| ジョブ | 分 |
|---|---|
| l2-case (Factorial) | **7.2** ← 最大 |
| l2-case (Fib) | 7.0 |
| l2-case (StringOps) | 6.8 |
| l2-case (Echo) | 6.3 |
| l2-case (Bool) | 5.9 |
| l2-build | 2.6 |
| lean-selfhost（L1 のみ） | 2.6 |
| lean-zig-golden | 2.4 |

**26.7 分 → 最大 7.2 分。** 全ジョブ 10 分以内、5 ケース全 PASS。

### CASE_TIMEOUT の余裕も増えた

| | 1 ケースの実測 | 600s に対する余裕 |
|---|---|---|
| `PARALLEL_JOBS=2`（従来） | 435–492s | 18% |
| **単独実行（本 PR）** | **344–420s** | **30%** |

最遅ケースは 2 回の計測で 433s → 492s と 14% ぶれていた。単独実行はその余裕を広げるので、**この変更は flakiness を減らす方向**でもある。

## 追加した env（既定は現行と完全に同一）

| env | 効果 |
|---|---|
| `BUILD_ONLY=1` | 評価器を作った時点で終了 |
| `EVAL_BIN=PATH` | ビルド済み評価器を使い precompile と compile を飛ばす |
| `L2_CASES="A B"` | ケースを選択（既定は 5 件） |

`EVAL_BIN` は `TARGET=scheme` との併用を拒否する（Chez 側の評価器は `.scm` で、これが存在する理由である比の計測は両者を同じ場所で作りたい）。`BUILD_ONLY` との併用も拒否する。空白のみの `L2_CASES` は**ビルド前**に落とす — ビルド段階は `MALGO_WORK_DIR` を消すので、引数ミスがそこまで到達してはいけない。

## 意図的にやっていないこと

- **PR 経路は触っていない。** すでに平均 1.2 分・最大 2.6 分で目標を満たしており、`l2-build` に依存させると builder + L1 の直列になってかえって遅くなる。L2 ジョブは PR では skip される。
- `fail-fast: false`。各ケースは評価器に対する独立した主張で、最初の失敗で残りを cancel すると「1 ケースの退行」と「評価器が壊れた」を区別する材料が消える。

## 注意

- run 全体は builder → ケースの直列で約 11 分になる（ジョブ単位で 10 分、という合意に基づく）。ランナー時間は増えるが public リポジトリなので課金上は無料。
- **#404（Scheme 再削除）は `selfhost-level2.sh` を大きく書き換えるので本 PR と衝突する。** rebase 時に `EVAL_BIN` / `L2_CASES` / throttle をまとめて解決すること。

ローカル検証: `BUILD_ONLY` が 51s で 5.6MB のバイナリを作って停止、`EVAL_BIN` が単独で 172s、既定の呼び出しは 5/5・146–169s/ケースで不変、ガード 5 種すべて期待どおり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
