### PR TITLE
chore: disable malgo-lsp plugin for the team

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,15 +5,5 @@
       "Bash(mise run test:*)"
     ]
   },
-  "extraKnownMarketplaces": {
-    "malgo-local": {
-      "source": {
-        "source": "directory",
-        "path": ".claude/plugins"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "malgo-lsp@malgo-local": true
-  }
+  "enabledPlugins": {}
 }


### PR DESCRIPTION
## Summary
- Remove the `malgo-lsp@malgo-local` plugin enablement and its `malgo-local` marketplace declaration from `.claude/settings.json`, so it's no longer active for anyone on the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)