### PR TITLE
feat(nix): package malgo as a Nix flake (Lean built from source)

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -300,13 +300,22 @@ jobs:
   # see PR #421) takes 45-60 minutes with no cache.nixos.org substitute --
   # far too slow for per-PR feedback. Runs on master pushes and the nightly
   # cron only, so a flake regression still surfaces within a day.
-  # aarch64-darwin specifically, matching the flake's own hardcoded
-  # `system` and its one real consumer's (nix-config) target -- there is
-  # no ubuntu-latest equivalent here, unlike every other job in this file.
+  # Matrixed across both of GitHub's native runner architectures now that
+  # the flake supports more than aarch64-darwin: macos-latest is genuine
+  # aarch64-darwin hardware, ubuntu-latest is genuine x86_64-linux hardware
+  # -- nix-config (the one real consumer) runs its own CI on the latter, so
+  # this is that exact target, not an emulated stand-in for it.
+  # aarch64-linux (the flake's third supported system) has no matching
+  # GitHub-hosted runner and isn't covered here; it was verified once,
+  # manually, via a native-architecture Docker container.
   nix-build:
     needs: gates
     if: needs.gates.outputs.nixBuild == '1' && github.event_name != 'pull_request'
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -29,6 +29,7 @@ jobs:
       selfhost: ${{ steps.g.outputs.LEAN_SELFHOST }}
       selfhostL2: ${{ steps.g.outputs.LEAN_SELFHOST_L2 }}
       zig: ${{ steps.g.outputs.LEAN_ZIG }}
+      nixBuild: ${{ steps.g.outputs.NIX_BUILD }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: g
@@ -294,8 +295,36 @@ jobs:
       - name: Subprocess-exec regression check (interpreter vs Scheme backend)
         run: bash scripts/scheme-process-check.sh
 
+  # Gated off pull requests for the same reason as l2-build/l2-case: a
+  # from-source Lean bootstrap (flake.nix pins an off-nixpkgs-cache 4.32.0,
+  # see PR #421) takes 45-60 minutes with no cache.nixos.org substitute --
+  # far too slow for per-PR feedback. Runs on master pushes and the nightly
+  # cron only, so a flake regression still surfaces within a day.
+  # aarch64-darwin specifically, matching the flake's own hardcoded
+  # `system` and its one real consumer's (nix-config) target -- there is
+  # no ubuntu-latest equivalent here, unlike every other job in this file.
+  nix-build:
+    needs: gates
+    if: needs.gates.outputs.nixBuild == '1' && github.event_name != 'pull_request'
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - name: nix build
+        run: nix build .#default -L
+
+      - name: Smoke test against nixpkgs' chez (not the mise-installed one)
+        run: |
+          ./result/bin/malgo eval examples/malgo/Hello.mlg --target scheme > hello.scm
+          out="$(nix shell nixpkgs#chez -c scheme --script hello.scm)"
+          echo "$out"
+          [ "$out" = "Hello, world!" ]
+
   actions-timeline:
-    needs: [gates, lean-build, cli-gate, lean-selfhost, lean-zig-golden, lean-scheme-golden, l2-build, l2-case]
+    needs: [gates, lean-build, cli-gate, lean-selfhost, lean-zig-golden, lean-scheme-golden, l2-build, l2-case, nix-build]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,80 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "lean4-nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1784744474,
+        "narHash": "sha256-9yx5PzXBkZ+160uquH4f7lCCPZGlzdc1Y2j+zOKRc54=",
+        "owner": "lenianiva",
+        "repo": "lean4-nix",
+        "rev": "9edc9448c8fe9552ba2b66e6097abda6e14e5c6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lenianiva",
+        "repo": "lean4-nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749871736,
-        "narHash": "sha256-K9yBph93OLTNw02Q6e9CYFGrUhvEXnh45vrZqIRWfvQ=",
+        "lastModified": 1765779637,
+        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1786348146,
+        "narHash": "sha256-we5zDEFfn8TgzeWKjKDMIjeQZ59omEPl23NIF+13/ys=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6afe187897bef7933475e6af374c893f4c84a293",
+        "rev": "d482ef84049d9b7276b83a06e4e4d76983830097",
         "type": "github"
       },
       "original": {
@@ -36,23 +86,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "lean4-nix": "lean4-nix",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -17,113 +17,147 @@
   outputs =
     { self, nixpkgs, lean4-nix }:
     let
-      system = "aarch64-darwin";
+      # aarch64-darwin is where this flake was built and verified (PR #421).
+      # x86_64-linux/aarch64-linux were added because nix-config's own CI
+      # (Ubuntu, x86_64-linux) evaluates `inputs.malgo.packages.${pkgs.system}`
+      # as part of building its own config, which forced this flake to
+      # actually have a package for that system, not merely be evaluable on
+      # it. Not x86_64-darwin: nothing has asked for it yet, and there's no
+      # machine here to verify it against -- add it the same way, verified
+      # the same way, if that ever changes.
+      supportedSystems = [
+        "aarch64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      # `binary = false` builds Lean from source (lean4-nix's own CMake
-      # bootstrap) instead of the default `binary = true`, which fetches a
-      # pre-built macOS release whose `libInit_shared.dylib` has no Mach-O
-      # header slack for `install_name_tool` to rewrite its rpath -- every
-      # workaround tried for that failed to make the binary loadable; a
-      # from-source build gets correct rpaths as a normal side effect of
-      # compilation instead. Full history of what was tried: PR #421.
-      #
-      # This means no `cache.nixos.org` substitute (nixpkgs' own `lean4`
-      # package is pinned to 4.30.0, not this project's 4.32.0), so the
-      # first build is a genuinely slow, full local Lean bootstrap --
-      # several thousand tiny per-module derivations, roughly 45-60 minutes
-      # measured on an M-series Mac. That tradeoff was not weighed against
-      # downgrading malgo's own toolchain to nixpkgs' cached 4.30.0:
-      # `lean/lean-toolchain` has pinned 4.32.0 since the Lean port's
-      # original scaffold, predating this flake by months, and the M0-M9
-      # port is large enough that revisiting the toolchain version is a
-      # separate decision from packaging it, not a free substitution here.
-      lean432Overlay = lean4-nix.readToolchainFile {
-        toolchain = ./lean/lean-toolchain;
-        binary = false;
-      };
+      # Everything below was `system`-free before -- a single `let` binding
+      # computed once for the hardcoded aarch64-darwin. Wrapped in a function
+      # over `system` instead of switching to flake-utils: `genAttrs` above
+      # is already reachable through the existing `nixpkgs` input, so a
+      # second flake input for one helper function wasn't justified.
+      mkMalgo =
+        system:
+        let
+          # `binary = false` builds Lean from source (lean4-nix's own CMake
+          # bootstrap) instead of the default `binary = true`, which fetches
+          # a pre-built binary release. On aarch64-darwin specifically, that
+          # pre-built release's `libInit_shared.dylib` has no Mach-O header
+          # slack for `install_name_tool` to rewrite its rpath -- every
+          # workaround tried for that failed to make the binary loadable; a
+          # from-source build gets correct rpaths as a normal side effect of
+          # compilation instead. Full history of what was tried: PR #421.
+          # Using the same from-source path uniformly across all systems
+          # here, not just aarch64-darwin where it was originally forced:
+          # lean4-nix's own CI (github.com/lenianiva/lean4-nix's flake.nix)
+          # tests this exact `readToolchainFile { binary = false; }` overlay
+          # on aarch64-darwin, aarch64-linux, x86_64-darwin, and x86_64-linux
+          # alike, so it isn't a Darwin-specific workaround being applied
+          # somewhere it doesn't belong.
+          #
+          # This means no `cache.nixos.org` substitute (nixpkgs' own `lean4`
+          # package is pinned to 4.30.0, not this project's 4.32.0), so the
+          # first build on any given system is a genuinely slow, full local
+          # Lean bootstrap -- several thousand tiny per-module derivations,
+          # roughly 45-60 minutes measured on an M-series Mac for
+          # aarch64-darwin. That tradeoff was not weighed against
+          # downgrading malgo's own toolchain to nixpkgs' cached 4.30.0:
+          # `lean/lean-toolchain` has pinned 4.32.0 since the Lean port's
+          # original scaffold, predating this flake by months, and the M0-M9
+          # port is large enough that revisiting the toolchain version is a
+          # separate decision from packaging it, not a free substitution
+          # here.
+          lean432Overlay = lean4-nix.readToolchainFile {
+            toolchain = ./lean/lean-toolchain;
+            binary = false;
+          };
 
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ lean432Overlay ];
-      };
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ lean432Overlay ];
+          };
 
-      # zig only needs to be on PATH at `malgo compile` *runtime* -- it's not
-      # a build input. `lake build` embeds runtime/zig/runtime.zig as text
-      # (`include_str`, see Backend/Zig/Runtime.lean) and never invokes zig
-      # itself; only the resulting `malgo` binary's `compile` subcommand
-      # shells out to a real `zig build-exe` when a user runs it. nixpkgs
-      # pins zig_0_16 to exactly 0.16.0, matching mise.toml's pin -- use
-      # that name explicitly rather than the unversioned `zig` alias, which
-      # tracks whatever nixpkgs currently defaults to.
-      zig = pkgs.zig_0_16;
+          # zig only needs to be on PATH at `malgo compile` *runtime* -- it's
+          # not a build input. `lake build` embeds runtime/zig/runtime.zig as
+          # text (`include_str`, see Backend/Zig/Runtime.lean) and never
+          # invokes zig itself; only the resulting `malgo` binary's
+          # `compile` subcommand shells out to a real `zig build-exe` when a
+          # user runs it. nixpkgs pins zig_0_16 to exactly 0.16.0, matching
+          # mise.toml's pin -- use that name explicitly rather than the
+          # unversioned `zig` alias, which tracks whatever nixpkgs currently
+          # defaults to. Confirmed nixpkgs carries `zig_0_16` for all three
+          # `supportedSystems` above, not just aarch64-darwin.
+          zig = pkgs.zig_0_16;
+        in
+        # `lake-manifest.json` (empty `packages`, no Lake dependencies -- see
+        # lean/lake-manifest.json) lives under lean/, not the repo root, so
+        # lean4-nix's `lake2nix.mkPackage` (built to shadow *other packages'*
+        # `.lake/packages/` from the Nix store) solves a problem this
+        # project doesn't have. A plain derivation is simpler and avoids
+        # fighting that machinery over the subdirectory layout.
+        #
+        # `src` has to be the whole repo, not just `lean/`: Runtime.lean's
+        # `include_str "../../../../runtime/zig/runtime.zig"` reaches
+        # outside `lean/` to embed the Zig runtime source, so `runtime/`
+        # must be present alongside `lean/` in the Nix build sandbox.
+        pkgs.stdenv.mkDerivation {
+          pname = "malgo";
+          # Matches the latest release tag (`git tag`), not an independent
+          # flake-only version line.
+          version = "4.0.0";
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter =
+              path: type:
+              let
+                base = baseNameOf path;
+              in
+              pkgs.lib.cleanSourceFilter path type
+              && base != ".lake"
+              && base != ".malgo-work"
+              && base != "vendor";
+          };
 
-      # `lake-manifest.json` (empty `packages`, no Lake dependencies -- see
-      # lean/lake-manifest.json) lives under lean/, not the repo root, so
-      # lean4-nix's `lake2nix.mkPackage` (built to shadow *other packages'*
-      # `.lake/packages/` from the Nix store) solves a problem this project
-      # doesn't have. A plain derivation is simpler and avoids fighting that
-      # machinery over the subdirectory layout.
-      #
-      # `src` has to be the whole repo, not just `lean/`: Runtime.lean's
-      # `include_str "../../../../runtime/zig/runtime.zig"` reaches outside
-      # `lean/` to embed the Zig runtime source, so `runtime/` must be
-      # present alongside `lean/` in the Nix build sandbox.
-      malgo = pkgs.stdenv.mkDerivation {
-        pname = "malgo";
-        # Matches the latest release tag (`git tag`), not an independent
-        # flake-only version line.
-        version = "4.0.0";
-        src = pkgs.lib.cleanSourceWith {
-          src = ./.;
-          filter =
-            path: type:
-            let
-              base = baseNameOf path;
-            in
-            pkgs.lib.cleanSourceFilter path type
-            && base != ".lake"
-            && base != ".malgo-work"
-            && base != "vendor";
+          nativeBuildInputs = [
+            pkgs.lean.lean-all
+            pkgs.makeWrapper
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+            cd lean
+            lake build malgo
+            cd ..
+            runHook postBuild
+          '';
+
+          # `$out/bin/malgo` alone isn't a complete package: any real
+          # `.mlg` program needs `import "Builtin.mlg"`/`"Prelude.mlg"`
+          # (and often `Either.mlg`) to resolve to *something*, and those
+          # live in this source tree, not inside the compiled binary.
+          # Installing them under `$out/share` makes that an explicit,
+          # versioned part of this derivation's output instead of an
+          # implicit contract on this flake's own `runtime/malgo/` layout
+          # -- a consumer reaching past `${malgo}` into `${self}`'s raw
+          # source tree (as a first attempt at using this flake did)
+          # breaks the moment that layout changes, silently, in neither
+          # repo. Not `runtime/malgo/compiler/` (the self-hosted
+          # evaluator's own internals, not meant for external `.mlg`
+          # programs to import) or `runtime/zig/` (already embedded into
+          # the compiled binary via `include_str`, per Runtime.lean).
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/bin" "$out/share/malgo/runtime/malgo"
+            cp lean/.lake/build/bin/malgo "$out/bin/malgo"
+            cp runtime/malgo/Builtin.mlg runtime/malgo/Prelude.mlg runtime/malgo/Either.mlg \
+              "$out/share/malgo/runtime/malgo/"
+            wrapProgram "$out/bin/malgo" --prefix PATH : ${pkgs.lib.makeBinPath [ zig ]}
+            runHook postInstall
+          '';
         };
-
-        nativeBuildInputs = [
-          pkgs.lean.lean-all
-          pkgs.makeWrapper
-        ];
-
-        buildPhase = ''
-          runHook preBuild
-          cd lean
-          lake build malgo
-          cd ..
-          runHook postBuild
-        '';
-
-        # `$out/bin/malgo` alone isn't a complete package: any real `.mlg`
-        # program needs `import "Builtin.mlg"`/`"Prelude.mlg"` (and often
-        # `Either.mlg`) to resolve to *something*, and those live in this
-        # source tree, not inside the compiled binary. Installing them
-        # under `$out/share` makes that an explicit, versioned part of this
-        # derivation's output instead of an implicit contract on this
-        # flake's own `runtime/malgo/` layout -- a consumer reaching past
-        # `${malgo}` into `${self}`'s raw source tree (as a first attempt
-        # at using this flake did) breaks the moment that layout changes,
-        # silently, in neither repo. Not `runtime/malgo/compiler/` (the
-        # self-hosted evaluator's own internals, not meant for external
-        # `.mlg` programs to import) or `runtime/zig/` (already embedded
-        # into the compiled binary via `include_str`, per Runtime.lean).
-        installPhase = ''
-          runHook preInstall
-          mkdir -p "$out/bin" "$out/share/malgo/runtime/malgo"
-          cp lean/.lake/build/bin/malgo "$out/bin/malgo"
-          cp runtime/malgo/Builtin.mlg runtime/malgo/Prelude.mlg runtime/malgo/Either.mlg \
-            "$out/share/malgo/runtime/malgo/"
-          wrapProgram "$out/bin/malgo" --prefix PATH : ${pkgs.lib.makeBinPath [ zig ]}
-          runHook postInstall
-        '';
-      };
     in
     {
-      packages.${system}.default = malgo;
+      packages = forAllSystems (system: { default = mkMalgo system; });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,158 @@
+{
+  description = "Malgo: a statically typed functional language (Lean 4 + Zig backend)";
+
+  inputs = {
+    # Not `nixpkgs.follows = "lean4-nix/nixpkgs"`: lean4-nix's own pin
+    # predates `zig_0_16` (nixpkgs added it after lean4-nix's pinned
+    # revision), and that attribute name is a hard requirement, not a
+    # preference -- Zig minor releases break std (see mise.toml), so
+    # silently falling back to zig_0_15 would be the wrong kind of quiet.
+    # `readToolchainFile`'s overlay only fetches a pinned Lean *binary*
+    # release; it doesn't depend on nixpkgs' own package versions, so
+    # applying it to an independently-pinned nixpkgs is safe.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    lean4-nix.url = "github:lenianiva/lean4-nix";
+  };
+
+  outputs =
+    { self, nixpkgs, lean4-nix }:
+    let
+      system = "aarch64-darwin";
+
+      # Not the `lean4-nix.readToolchainFile ./lean/lean-toolchain`
+      # convenience wrapper: it calls `toolchain.nix` with no override, so
+      # `fixDarwinDylibNames` resolves to nixpkgs' real hook, which fails on
+      # this pre-built (not Nix-compiled) macOS binary --
+      # `install_name_tool: ... larger updated load commands do not fit
+      # (the program must be relinked)`. The reference flake at
+      # github.com/lenianiva/lean4-nix/blob/main/templates/mathlib-demo/flake.nix
+      # works around the identical failure the same way: call `toolchain.nix`
+      # directly with a no-op override.
+      lean432Overlay =
+        final: prev:
+        {
+          lean = (
+            (final.callPackage "${lean4-nix}/lib/toolchain.nix" {
+              fixDarwinDylibNames = final.writeTextFile {
+                name = "noop-fix-darwin-dylib-names-hook";
+                destination = "/nix-support/setup-hook";
+                text = "";
+              };
+            }).fetchBinaryLean
+              (import "${lean4-nix}/manifests/v4.32.0.nix")
+          );
+        };
+
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ lean432Overlay ];
+      };
+
+      # zig only needs to be on PATH at `malgo compile` *runtime* -- it's not
+      # a build input. `lake build` embeds runtime/zig/runtime.zig as text
+      # (`include_str`, see Backend/Zig/Runtime.lean) and never invokes zig
+      # itself; only the resulting `malgo` binary's `compile` subcommand
+      # shells out to a real `zig build-exe` when a user runs it. nixpkgs
+      # pins zig_0_16 to exactly 0.16.0, matching mise.toml's pin -- use
+      # that name explicitly rather than the unversioned `zig` alias, which
+      # tracks whatever nixpkgs currently defaults to.
+      zig = pkgs.zig_0_16;
+
+      # `lake-manifest.json` (empty `packages`, no Lake dependencies -- see
+      # lean/lake-manifest.json) lives under lean/, not the repo root, so
+      # lean4-nix's `lake2nix.mkPackage` (built to shadow *other packages'*
+      # `.lake/packages/` from the Nix store) solves a problem this project
+      # doesn't have. A plain derivation is simpler and avoids fighting that
+      # machinery over the subdirectory layout.
+      #
+      # `src` has to be the whole repo, not just `lean/`: Runtime.lean's
+      # `include_str "../../../../runtime/zig/runtime.zig"` reaches outside
+      # `lean/` to embed the Zig runtime source, so `runtime/` must be
+      # present alongside `lean/` in the Nix build sandbox.
+      malgo = pkgs.stdenv.mkDerivation {
+        pname = "malgo";
+        version = "0.1.0";
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter =
+            path: type:
+            let
+              base = baseNameOf path;
+            in
+            pkgs.lib.cleanSourceFilter path type
+            && base != ".lake"
+            && base != ".malgo-work"
+            && base != "vendor";
+        };
+
+        nativeBuildInputs = [
+          pkgs.lean.lean-all
+          pkgs.makeWrapper
+        ];
+
+        # STATUS: this derivation does not build yet. `lake build malgo`
+        # fails with:
+        #   dyld[...]: Library not loaded: @rpath/libInit_shared.dylib
+        #   Referenced from: .../lean/bin/.lake-wrapped
+        #   Reason: tried: '.../lean/lib/lean/libInit_shared.dylib'
+        #     (load commands do not fit in __TEXT segment filesize) ...
+        #
+        # Root cause is upstream in lean4-nix's handling of the pre-built
+        # (not Nix-compiled) Lean 4.32.0 darwin_aarch64 release, not in this
+        # flake's own derivation. What's been ruled out, each confirmed by
+        # direct testing rather than assumption:
+        #   - Not a stale-rpath-with-a-fixup-available problem: the real
+        #     `fixDarwinDylibNames` hook's `install_name_tool` rewrite fails
+        #     outright on this binary ("larger updated load commands do not
+        #     fit (the program must be relinked)") -- there is no free
+        #     header space to rewrite the load command in place, which is
+        #     why the no-op override above exists at all.
+        #   - Not a missing-file problem: `libInit_shared.dylib` genuinely
+        #     exists at the exact path dyld's own error message lists as
+        #     "tried" (${pkgs.lean}/lib/lean/libInit_shared.dylib) --
+        #     confirmed with `find` against the built `pkgs.lean` output.
+        #   - Not stdenv-darwin's DYLD_* stripping: `DYLD_LIBRARY_PATH` was
+        #     set both as a derivation attribute and as an `export` inside
+        #     this phase's own script body (i.e. after stdenv's setup
+        #     script runs); neither took effect, and reading `lean`'s own
+        #     `lake` wrapper script confirms it doesn't touch DYLD_* itself
+        #     -- it only rewrites PATH before `exec -a "$0" .lake-wrapped`.
+        #   - Not a hardened-runtime/entitlement problem: `codesign -dv
+        #     --entitlements -` on `.lake-wrapped` shows
+        #     `flags=0x20002(adhoc,linker-signed)`, no restrict flag and no
+        #     entitlements at all, so macOS has no declared reason to ignore
+        #     DYLD_* for this binary.
+        # None of these four rule-outs identifies what dyld is actually
+        # doing instead, so the true root cause is still open. Two
+        # escape hatches for whoever picks this up next, neither attempted
+        # here: (a) build Lean from source via lean4-nix's bootstrap path
+        # instead of fetching the pre-built binary release, sidestepping
+        # binary relocation entirely; (b) drop the flake and have
+        # consumers invoke a `mise`-built `malgo` directly -- the actual
+        # Phase 2 requirement was always "a reproducible way to get
+        # compiled `.scm`", not "a flake" specifically, and nixpkgs'
+        # `chez` (10.4.1, matching what's already validated locally) is
+        # confirmed available on aarch64-darwin regardless of how `malgo`
+        # itself gets built.
+        buildPhase = ''
+          runHook preBuild
+          export DYLD_LIBRARY_PATH="${pkgs.lean}/lib:${pkgs.lean}/lib/lean"
+          cd lean
+          lake build malgo
+          cd ..
+          runHook postBuild
+        '';
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p "$out/bin"
+          cp lean/.lake/build/bin/malgo "$out/bin/malgo"
+          wrapProgram "$out/bin/malgo" --prefix PATH : ${pkgs.lib.makeBinPath [ zig ]}
+          runHook postInstall
+        '';
+      };
+    in
+    {
+      packages.${system}.default = malgo;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,19 +20,23 @@
       system = "aarch64-darwin";
 
       # `binary = false` builds Lean from source (lean4-nix's own CMake
-      # bootstrap: a stage0 compiler, then Init/Std/Lean/Lake compiled by
-      # it) instead of the default `binary = true`, which fetches a
-      # pre-built macOS release. The pre-built release's own
-      # `libInit_shared.dylib` has no Mach-O header slack for
-      # `install_name_tool` to rewrite its rpath ("load commands do not fit
-      # in __TEXT segment filesize"), and every workaround tried for that
-      # (a no-op `fixDarwinDylibNames`, setting `DYLD_LIBRARY_PATH`) failed
-      # to make the resulting binary loadable. Building from source
-      # sidesteps this: a binary Nix's own `stdenv` compiles gets its
-      # rpaths right as a normal side effect of compilation, no post-hoc
-      # rewrite needed. `manifests/v4.32.0.nix`'s `bootstrap` is exactly
-      # this version -- it already carries an OpenSSL >=3 fix specific to
-      # 4.32.0's TLS support, so it's not a generic/untested path.
+      # bootstrap) instead of the default `binary = true`, which fetches a
+      # pre-built macOS release whose `libInit_shared.dylib` has no Mach-O
+      # header slack for `install_name_tool` to rewrite its rpath -- every
+      # workaround tried for that failed to make the binary loadable; a
+      # from-source build gets correct rpaths as a normal side effect of
+      # compilation instead. Full history of what was tried: PR #421.
+      #
+      # This means no `cache.nixos.org` substitute (nixpkgs' own `lean4`
+      # package is pinned to 4.30.0, not this project's 4.32.0), so the
+      # first build is a genuinely slow, full local Lean bootstrap --
+      # several thousand tiny per-module derivations, roughly 45-60 minutes
+      # measured on an M-series Mac. That tradeoff was not weighed against
+      # downgrading malgo's own toolchain to nixpkgs' cached 4.30.0:
+      # `lean/lean-toolchain` has pinned 4.32.0 since the Lean port's
+      # original scaffold, predating this flake by months, and the M0-M9
+      # port is large enough that revisiting the toolchain version is a
+      # separate decision from packaging it, not a free substitution here.
       lean432Overlay = lean4-nix.readToolchainFile {
         toolchain = ./lean/lean-toolchain;
         binary = false;
@@ -66,7 +70,9 @@
       # present alongside `lean/` in the Nix build sandbox.
       malgo = pkgs.stdenv.mkDerivation {
         pname = "malgo";
-        version = "0.1.0";
+        # Matches the latest release tag (`git tag`), not an independent
+        # flake-only version line.
+        version = "4.0.0";
         src = pkgs.lib.cleanSourceWith {
           src = ./.;
           filter =
@@ -93,10 +99,25 @@
           runHook postBuild
         '';
 
+        # `$out/bin/malgo` alone isn't a complete package: any real `.mlg`
+        # program needs `import "Builtin.mlg"`/`"Prelude.mlg"` (and often
+        # `Either.mlg`) to resolve to *something*, and those live in this
+        # source tree, not inside the compiled binary. Installing them
+        # under `$out/share` makes that an explicit, versioned part of this
+        # derivation's output instead of an implicit contract on this
+        # flake's own `runtime/malgo/` layout -- a consumer reaching past
+        # `${malgo}` into `${self}`'s raw source tree (as a first attempt
+        # at using this flake did) breaks the moment that layout changes,
+        # silently, in neither repo. Not `runtime/malgo/compiler/` (the
+        # self-hosted evaluator's own internals, not meant for external
+        # `.mlg` programs to import) or `runtime/zig/` (already embedded
+        # into the compiled binary via `include_str`, per Runtime.lean).
         installPhase = ''
           runHook preInstall
-          mkdir -p "$out/bin"
+          mkdir -p "$out/bin" "$out/share/malgo/runtime/malgo"
           cp lean/.lake/build/bin/malgo "$out/bin/malgo"
+          cp runtime/malgo/Builtin.mlg runtime/malgo/Prelude.mlg runtime/malgo/Either.mlg \
+            "$out/share/malgo/runtime/malgo/"
           wrapProgram "$out/bin/malgo" --prefix PATH : ${pkgs.lib.makeBinPath [ zig ]}
           runHook postInstall
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,9 @@
     # revision), and that attribute name is a hard requirement, not a
     # preference -- Zig minor releases break std (see mise.toml), so
     # silently falling back to zig_0_15 would be the wrong kind of quiet.
-    # `readToolchainFile`'s overlay only fetches a pinned Lean *binary*
-    # release; it doesn't depend on nixpkgs' own package versions, so
-    # applying it to an independently-pinned nixpkgs is safe.
+    # The Lean source-build overlay below only needs long-stable nixpkgs
+    # packages (cmake, gmp, git, ...), not anything as version-sensitive as
+    # `zig_0_16`, so applying it to an independently-pinned nixpkgs is safe.
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     lean4-nix.url = "github:lenianiva/lean4-nix";
   };
@@ -19,29 +19,24 @@
     let
       system = "aarch64-darwin";
 
-      # Not the `lean4-nix.readToolchainFile ./lean/lean-toolchain`
-      # convenience wrapper: it calls `toolchain.nix` with no override, so
-      # `fixDarwinDylibNames` resolves to nixpkgs' real hook, which fails on
-      # this pre-built (not Nix-compiled) macOS binary --
-      # `install_name_tool: ... larger updated load commands do not fit
-      # (the program must be relinked)`. The reference flake at
-      # github.com/lenianiva/lean4-nix/blob/main/templates/mathlib-demo/flake.nix
-      # works around the identical failure the same way: call `toolchain.nix`
-      # directly with a no-op override.
-      lean432Overlay =
-        final: prev:
-        {
-          lean = (
-            (final.callPackage "${lean4-nix}/lib/toolchain.nix" {
-              fixDarwinDylibNames = final.writeTextFile {
-                name = "noop-fix-darwin-dylib-names-hook";
-                destination = "/nix-support/setup-hook";
-                text = "";
-              };
-            }).fetchBinaryLean
-              (import "${lean4-nix}/manifests/v4.32.0.nix")
-          );
-        };
+      # `binary = false` builds Lean from source (lean4-nix's own CMake
+      # bootstrap: a stage0 compiler, then Init/Std/Lean/Lake compiled by
+      # it) instead of the default `binary = true`, which fetches a
+      # pre-built macOS release. The pre-built release's own
+      # `libInit_shared.dylib` has no Mach-O header slack for
+      # `install_name_tool` to rewrite its rpath ("load commands do not fit
+      # in __TEXT segment filesize"), and every workaround tried for that
+      # (a no-op `fixDarwinDylibNames`, setting `DYLD_LIBRARY_PATH`) failed
+      # to make the resulting binary loadable. Building from source
+      # sidesteps this: a binary Nix's own `stdenv` compiles gets its
+      # rpaths right as a normal side effect of compilation, no post-hoc
+      # rewrite needed. `manifests/v4.32.0.nix`'s `bootstrap` is exactly
+      # this version -- it already carries an OpenSSL >=3 fix specific to
+      # 4.32.0's TLS support, so it's not a generic/untested path.
+      lean432Overlay = lean4-nix.readToolchainFile {
+        toolchain = ./lean/lean-toolchain;
+        binary = false;
+      };
 
       pkgs = import nixpkgs {
         inherit system;
@@ -90,53 +85,8 @@
           pkgs.makeWrapper
         ];
 
-        # STATUS: this derivation does not build yet. `lake build malgo`
-        # fails with:
-        #   dyld[...]: Library not loaded: @rpath/libInit_shared.dylib
-        #   Referenced from: .../lean/bin/.lake-wrapped
-        #   Reason: tried: '.../lean/lib/lean/libInit_shared.dylib'
-        #     (load commands do not fit in __TEXT segment filesize) ...
-        #
-        # Root cause is upstream in lean4-nix's handling of the pre-built
-        # (not Nix-compiled) Lean 4.32.0 darwin_aarch64 release, not in this
-        # flake's own derivation. What's been ruled out, each confirmed by
-        # direct testing rather than assumption:
-        #   - Not a stale-rpath-with-a-fixup-available problem: the real
-        #     `fixDarwinDylibNames` hook's `install_name_tool` rewrite fails
-        #     outright on this binary ("larger updated load commands do not
-        #     fit (the program must be relinked)") -- there is no free
-        #     header space to rewrite the load command in place, which is
-        #     why the no-op override above exists at all.
-        #   - Not a missing-file problem: `libInit_shared.dylib` genuinely
-        #     exists at the exact path dyld's own error message lists as
-        #     "tried" (${pkgs.lean}/lib/lean/libInit_shared.dylib) --
-        #     confirmed with `find` against the built `pkgs.lean` output.
-        #   - Not stdenv-darwin's DYLD_* stripping: `DYLD_LIBRARY_PATH` was
-        #     set both as a derivation attribute and as an `export` inside
-        #     this phase's own script body (i.e. after stdenv's setup
-        #     script runs); neither took effect, and reading `lean`'s own
-        #     `lake` wrapper script confirms it doesn't touch DYLD_* itself
-        #     -- it only rewrites PATH before `exec -a "$0" .lake-wrapped`.
-        #   - Not a hardened-runtime/entitlement problem: `codesign -dv
-        #     --entitlements -` on `.lake-wrapped` shows
-        #     `flags=0x20002(adhoc,linker-signed)`, no restrict flag and no
-        #     entitlements at all, so macOS has no declared reason to ignore
-        #     DYLD_* for this binary.
-        # None of these four rule-outs identifies what dyld is actually
-        # doing instead, so the true root cause is still open. Two
-        # escape hatches for whoever picks this up next, neither attempted
-        # here: (a) build Lean from source via lean4-nix's bootstrap path
-        # instead of fetching the pre-built binary release, sidestepping
-        # binary relocation entirely; (b) drop the flake and have
-        # consumers invoke a `mise`-built `malgo` directly -- the actual
-        # Phase 2 requirement was always "a reproducible way to get
-        # compiled `.scm`", not "a flake" specifically, and nixpkgs'
-        # `chez` (10.4.1, matching what's already validated locally) is
-        # confirmed available on aarch64-darwin regardless of how `malgo`
-        # itself gets built.
         buildPhase = ''
           runHook preBuild
-          export DYLD_LIBRARY_PATH="${pkgs.lean}/lib:${pkgs.lean}/lib/lean"
           cd lean
           lake build malgo
           cd ..

--- a/lean/ci-gates.env
+++ b/lean/ci-gates.env
@@ -31,3 +31,11 @@
 LEAN_ZIG=1
 LEAN_SELFHOST=1
 LEAN_SELFHOST_L2=1
+
+# NIX_BUILD gates the flake.nix build+smoke-test job. Same reasoning as
+# LEAN_SELFHOST_L2 above: a from-source Lean bootstrap (flake.nix pins an
+# off-nixpkgs-cache 4.32.0, see PR #421) takes 45-60 minutes with no
+# cache.nixos.org substitute, so it also only runs for master pushes and
+# the nightly cron, not pull requests (enforced directly in lean.yml's
+# job condition, same as LEAN_SELFHOST_L2's).
+NIX_BUILD=1


### PR DESCRIPTION
## Why

Part of #416, Phase 2 -- packaging `malgo` as a Nix flake so nix-config can
depend on it at build time. The first commit on this branch landed
documented-as-blocked: `lake build malgo` failed with a dyld
`Library not loaded: @rpath/libInit_shared.dylib` error, root cause in
lean4-nix's pre-built Lean 4.32.0 darwin_aarch64 release having no Mach-O
header slack for `install_name_tool` to rewrite its rpath. Four hypotheses
were ruled out (missing file, stdenv's DYLD_* stripping, the `lake` wrapper
script, hardened-runtime entitlements) with no fix found.

The second commit fixes it for real: `lean4-nix.readToolchainFile
{ toolchain; binary = false; }` switches to lean4-nix's *other* code path
-- a full from-source CMake bootstrap -- instead of fetching the broken
pre-built binary release. This sidesteps the problem entirely, since a
binary Nix's own `stdenv` compiles gets its rpaths right as a normal side
effect of compilation. `manifests/v4.32.0.nix`'s `bootstrap` is exactly the
version malgo's `lean-toolchain` pins, and already carries an OpenSSL >=3
fix specific to 4.32.0 -- a tested path, not a generic/untested one.

## What works

- `nix build .#default` succeeds and produces a working `malgo` binary.
- `chez` (10.4.1, matching what's already validated locally) supports
  `aarch64-darwin` natively in nixpkgs -- confirmed via source read, no
  fallback needed for the Scheme-runtime side of delivery.
- End-to-end smoke test: `malgo eval examples/malgo/Hello.mlg --target
  scheme` produces valid Chez Scheme source; running it through `nix shell
  nixpkgs#chez -c scheme --script` prints `Hello, world!` correctly --
  confirms the whole chain works with zero non-Nix dependencies.

## Tradeoff, documented for whoever touches this next

Building Lean from source at an off-pin version (4.32.0; nixpkgs' own
actively-maintained `lean4` package is currently at 4.30.0) means no
`cache.nixos.org` substitute is available -- this is a genuinely slow, full
local build the first time (lean4-nix's bootstrap builds each Lean stdlib
module as its own tiny Nix derivation, several thousand of them). Once
built, the result is cached in the local Nix store like anything else.

## Verification

- `nix build .#default`: succeeds, "Build completed successfully (128
  jobs)" in 38s (after the one-time Lean toolchain build).
- Smoke test above: `Hello, world!` printed correctly via nixpkgs' `chez`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
