### PR TITLE
fix(scheme): readFile/getContents on EOF, writeFile on existing files

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -295,6 +295,9 @@ jobs:
       - name: Subprocess-exec regression check (interpreter vs Scheme backend)
         run: bash scripts/scheme-process-check.sh
 
+      - name: File I/O edge-case regression check (interpreter vs Scheme backend)
+        run: bash scripts/scheme-file-io-check.sh
+
   # Gated off pull requests for the same reason as l2-build/l2-case: a
   # from-source Lean bootstrap (flake.nix pins an off-nixpkgs-cache 4.32.0,
   # see PR #421) takes 45-60 minutes with no cache.nixos.org substitute --

--- a/lean/Malgo/Backend/Scheme.lean
+++ b/lean/Malgo/Backend/Scheme.lean
@@ -213,11 +213,16 @@ def compilePrimitive (name : String) (args : List String) (ret : String) : Strin
   -- malgo_* foreign import names
   | "malgo_read_file" =>
     match args with
-    | [path] => "(" ++ ret ++ " (call-with-input-file " ++ path ++ " (lambda (p) (get-string-all p))))"
+    | [path] => "(" ++ ret ++ " (call-with-input-file " ++ path ++ " (lambda (p) (let ((s (get-string-all p))) (if (eof-object? s) \"\" s)))))"
     | _ => "(error 'prim \"malgo_read_file: wrong number of arguments\")"
   | "malgo_write_file" =>
     match args with
-    | [path, content] => "(begin (call-with-output-file " ++ path ++ " (lambda (p) (put-string p " ++ content ++ "))) (" ++ ret ++ " '()))"
+    -- `call-with-output-file` opens in Chez's default exclusive-create
+    -- mode, erroring "file exists" the moment the target already has
+    -- content -- unlike the interpreter's IO.FS.writeFile, which always
+    -- overwrites. `'replace` matches that: creates if absent, truncates
+    -- if present.
+    | [path, content] => "(begin (call-with-port (open-output-file " ++ path ++ " 'replace) (lambda (p) (put-string p " ++ content ++ "))) (" ++ ret ++ " '()))"
     | _ => "(error 'prim \"malgo_write_file: wrong number of arguments\")"
   | "malgo_get_line" =>
     "(" ++ ret ++ " (let ((line (read-line))) (if (eof-object? line) \"\" line)))"
@@ -360,7 +365,7 @@ def compilePrimitive (name : String) (args : List String) (ret : String) : Strin
   | "malgo_get_char" =>
     "(" ++ ret ++ " (let ((c (read-char))) (if (eof-object? c) #\\nul c)))"
   | "malgo_get_contents" =>
-    "(" ++ ret ++ " (get-string-all (current-input-port)))"
+    "(" ++ ret ++ " (let ((s (get-string-all (current-input-port)))) (if (eof-object? s) \"\" s)))"
   -- Error / control
   | "malgo_panic" =>
     match args with

--- a/scripts/scheme-file-io-check.sh
+++ b/scripts/scheme-file-io-check.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# File-I/O regression gate for the Scheme backend.
+#
+# Deliberately NOT a `test/testcases/malgo` case, same reasoning as
+# scheme-process-check.sh: that directory is swept by zig-golden.sh/
+# selfhost-golden.sh/cli-gate.sh/the Lean corpus gates too, and this fixture
+# only needs to run on the interpreter (oracle) and the Scheme backend.
+# `test/testcases/scheme-only/` holds fixtures meant for scripts like this
+# one alone.
+#
+# Unlike scheme-process-check.sh's fixtures, this one doesn't diff stdout
+# between backends -- ReadWriteFileEdgeCases.mlg prints its own "ok"/"FAIL"
+# assertions, so a real mismatch shows up as a FAIL line printed on stdout,
+# not just a stdout diff. This script's job is to run it on both backends
+# and make sure it exits cleanly with zero FAIL lines on each.
+#
+# Env knobs (all optional):
+#   MALGO             path to the malgo executable (default: the Lean build)
+#   SCHEME            path to the Chez Scheme executable (default: scheme)
+#   COMPILE_TIMEOUT   seconds allowed for `malgo eval --target scheme` (default: 60)
+#   CASE_TIMEOUT      seconds allowed for running either side (default: 10)
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+MALGO="${MALGO:-lean/.lake/build/bin/malgo}"
+SCHEME="${SCHEME:-scheme}"
+COMPILE_TIMEOUT="${COMPILE_TIMEOUT:-60}"
+CASE_TIMEOUT="${CASE_TIMEOUT:-10}"
+
+if ! command -v "$SCHEME" >/dev/null 2>&1; then
+  echo "$SCHEME not found on PATH (set SCHEME, or run 'mise install' / activate mise)." >&2
+  exit 1
+fi
+
+if [ ! -x "$MALGO" ]; then
+  echo "malgo executable not found at '$MALGO' (set MALGO, or run 'lake build' in lean/)." >&2
+  exit 1
+fi
+
+SRC="test/testcases/scheme-only/ReadWriteFileEdgeCases.mlg"
+
+for module in Builtin Prelude Either; do
+  "$MALGO" eval "runtime/malgo/$module.mlg" >/dev/null 2>&1
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+check_no_fail() {
+  local label="$1" out="$2"
+  if grep -q '^FAIL' <<<"$out"; then
+    echo "FAIL: $label reported an assertion failure:" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+}
+
+echo "=== interpreter (oracle) ==="
+if ! interp_out="$(timeout "$CASE_TIMEOUT" "$MALGO" eval "$SRC" 2>"$WORK/interp.err")"; then
+  echo "FAIL: interpreter run failed:" >&2
+  cat "$WORK/interp.err" >&2
+  exit 1
+fi
+echo "$interp_out"
+check_no_fail "interpreter" "$interp_out"
+
+echo "=== scheme backend ==="
+if ! timeout "$COMPILE_TIMEOUT" "$MALGO" eval --target scheme "$SRC" >"$WORK/main.scm" 2>"$WORK/compile.err"; then
+  echo "FAIL: --target scheme compilation failed:" >&2
+  cat "$WORK/compile.err" >&2
+  exit 1
+fi
+if ! scheme_out="$(timeout "$CASE_TIMEOUT" "$SCHEME" --script "$WORK/main.scm" 2>"$WORK/scheme.err")"; then
+  echo "FAIL: scheme run failed:" >&2
+  cat "$WORK/scheme.err" >&2
+  exit 1
+fi
+echo "$scheme_out"
+check_no_fail "scheme backend" "$scheme_out"
+
+if [ "$interp_out" != "$scheme_out" ]; then
+  echo "FAIL: interpreter and scheme backend disagree on $SRC" >&2
+  diff <(echo "$interp_out") <(echo "$scheme_out") >&2
+  exit 1
+fi
+
+echo "=== scheme-file-io-check OK ==="

--- a/test/testcases/scheme-only/ReadWriteFileEdgeCases.mlg
+++ b/test/testcases/scheme-only/ReadWriteFileEdgeCases.mlg
@@ -1,0 +1,34 @@
+module {..} = import "../../../runtime/malgo/Builtin.mlg"
+module {..} = import "../../../runtime/malgo/Prelude.mlg"
+
+-- Chez's `get-string-all` returns the EOF object (not "") when a port
+-- yields zero bytes -- readFile on a 0-byte file, and getContents on
+-- already-exhausted stdin, both hit this on the Scheme backend and need
+-- the same `(if (eof-object? s) "" s)` guard `malgo_get_line` already had.
+--
+-- `call-with-output-file` opens in Chez's default exclusive-create mode,
+-- erroring "file exists" the instant the target already has content --
+-- writeFile on an existing file (a common overwrite pattern) crashed on
+-- the Scheme backend only. Fixed with `(open-output-file path 'replace)`.
+--
+-- Not diffed against the interpreter output line-by-line via this script
+-- (unlike RunProcess.mlg's fixtures): the assertions themselves are the
+-- check, printed as pass/fail markers so a compile-time-only regression
+-- (a syntax error) still shows up as a compile failure, not a silent skip.
+def assertEq : String -> String -> String -> ()
+def assertEq = { caseName expected actual ->
+  if (eqString expected actual)
+    { putStrLn (appendString "ok: " caseName) }
+    { putStrLn (appendString "FAIL: " (appendString caseName (appendString " expected=" (appendString expected (appendString " actual=" actual))))) }
+}
+
+def main = { () ->
+  writeFile "/tmp/malgo-rwfile-empty.txt" "";
+  let empty = readFile "/tmp/malgo-rwfile-empty.txt";
+  assertEq "readFile on 0-byte file" "" empty;
+
+  writeFile "/tmp/malgo-rwfile-overwrite.txt" "first version, long enough to matter";
+  writeFile "/tmp/malgo-rwfile-overwrite.txt" "second";
+  let overwritten = readFile "/tmp/malgo-rwfile-overwrite.txt";
+  assertEq "writeFile overwrites an existing file" "second" overwritten
+}


### PR DESCRIPTION
Two real Scheme-backend bugs found via nix-config's Phase 5 script port
(setup-git-signing.sh), each diverging from the interpreter oracle:

- `malgo_read_file`/`malgo_get_contents`: Chez's `get-string-all` returns
  the EOF object, not "", when the port yields zero bytes -- reading a
  0-byte file (or already-exhausted stdin) crashed downstream string
  operations with "Exception in string=?: #!eof is not a string" instead
  of returning "". Same class of bug `malgo_get_line` already guards
  against (`(if (eof-object? line) "" line)`), and the same one the
  subprocess-exec work (#420) found and fixed for stdout/stderr capture --
  just never applied to file reads. Fixed both with the same guard.

- `malgo_write_file`: `call-with-output-file` opens in Chez's default
  exclusive-create mode, erroring "file exists" the instant the target
  already has content -- so writeFile on an existing file (a common
  overwrite pattern) crashed on the Scheme backend only; the
  interpreter's IO.FS.writeFile always overwrites. Fixed by opening via
  `(open-output-file path 'replace)` instead, confirmed empirically
  (not from documentation alone) to both create-if-absent and
  truncate-if-present.

New test/testcases/scheme-only/ReadWriteFileEdgeCases.mlg (self-asserting,
not stdout-diffed like RunProcess.mlg's fixtures) + a new
scripts/scheme-file-io-check.sh, wired into the same lean-scheme-golden CI
job as scheme-process-check.sh. Verified against the rebuilt malgo binary
on both the interpreter and the Scheme backend before and after each fix.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>