### PR TITLE
docs(tour): Common Idioms section -- sequencing, filter+project

### DIFF
--- a/docs/tour.md
+++ b/docs/tour.md
@@ -159,6 +159,34 @@ def main = {
 }
 ```
 
+### Common Idioms
+
+**A multi-step `def` doesn't need a lambda wrapper.** A parenthesized `let`-chain is legal directly in a `def name = (...)` position -- no `{ () -> ... } ()` immediately-invoked-thunk needed:
+
+```malgo
+def machineTag : String
+def machineTag = (
+  let whoamiResult = runProcess "hostname" Nil;
+  trimTrailingNewlines whoamiResult.stdout
+)
+```
+
+See `test/testcases/malgo/Seq.mlg` for a tested example of this shape.
+
+**Filtering a list and projecting one field of the surviving elements doesn't need hand-written `Cons`/`Nil` recursion** -- compose `filter`, `mapList`, and `fst`/`snd` (or `(<<)`):
+
+```malgo
+-- Instead of:
+def matchingKeys =
+  { Nil -> Nil,
+    (Cons {k, v} rest) ->
+      if (matchesAnyApproval v) { Cons k (matchingKeys rest) } { matchingKeys rest }
+  }
+
+-- write:
+def matchingKeys = { entries -> mapList fst (filter (matchesAnyApproval << snd) entries) }
+```
+
 ## 10. Compiler Pipeline
 
 Malgo's compiler is modular, with distinct passes:


### PR DESCRIPTION
Both come from reviewing nix-config's real tasks/*.mlg ports: two spots
where the author reached for more machinery than the language actually
needs, because the existing feature wasn't obvious from the surface
syntax alone.

- A bare-parenthesized let-chain works directly in a `def name = (...)`
  position -- no `{ () -> ... } ()` immediately-invoked-thunk wrapper
  needed. Confirmed via the existing test/testcases/malgo/Seq.mlg, not
  asserted from documentation.
- Filtering a list of pairs by a predicate on one component and
  projecting the other is `filter`+`mapList`+`fst`/`snd`/`(<<)`
  composition, not hand-rolled Cons/Nil recursion.

No code change -- both are already possible today.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>