### PR TITLE
feat(syntax)!: unify record literal/pattern syntax with codata's .field

### DIFF
--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -1,7 +1,7 @@
 {
   "$comment": "LIVE Zig-backend perf baseline for #385. Unrelated to bench/baseline-*.json, which are 2026-03 GHC *build*-time records. Regenerate with `mise run perf-baseline -- --update`; the diff of this file IS the before/after claim #385 requires. Gates are directional -- see scripts/perf-baseline.sh.",
   "compiler": {
-    "commit": "52a985ae",
+    "commit": "ccd43830",
     "zig": "0.16.0"
   },
   "tiers": {
@@ -29,9 +29,9 @@
     },
     "selfhost-l1": {
       "counters": {
-        "total_allocs": 7864639,
-        "reuse_hits": 570224,
-        "dispatches": 8860660,
+        "total_allocs": 7925424,
+        "reuse_hits": 574676,
+        "dispatches": 8928668,
         "force_depth_max": 1
       },
       "derived": {
@@ -40,13 +40,13 @@
     },
     "selfhost-l2": {
       "counters": {
-        "total_allocs": 12835004194,
-        "reuse_hits": 461321795,
-        "dispatches": 14630000854,
+        "total_allocs": 12907065009,
+        "reuse_hits": 464166894,
+        "dispatches": 14712123847,
         "force_depth_max": 1
       },
       "derived": {
-        "reuse_rate": 0.0359
+        "reuse_rate": 0.036
       }
     }
   }

--- a/docs/c-style.md
+++ b/docs/c-style.md
@@ -28,7 +28,7 @@ This will be lowered to a Core `Invoke` of `hello` with no arguments.
 - **Function Application**: Arguments are passed with parentheses and commas, e.g., `f(x, y)`.
 - **Data Definition**: Type parameters and constructor arguments use parentheses and commas, e.g., `data Foo(a, b) = Bar(a) | Baz(b)`.
 - **Type Synonym**: `type Pair(a, b) = { fst: a, snd: b }`
-- **Record/Tuple**: Expressed as `{ x, y }` or `{ x = 1, y = 2 }`.
+- **Record/Tuple**: Expressed as `{ x, y }` or `{ .x -> 1, .y -> 2 }`.
 - **List**: `[1, 2, 3]`
 - **Pattern Matching**: Multiple patterns can be written comma-separated, e.g., `def f = { (x, y) -> x + y, (z) -> z }`.
 - **Copatterns**: Supports copattern syntax starting with `#`, e.g., `def g = { #.field -> ... }`.
@@ -46,7 +46,7 @@ def add = { (x, y) -> x + y }
 data Either(a, b) = Left(a) | Right(b)
 
 -- Record
-def person = { name = "Alice", age = 30 }
+def person = { .name -> "Alice", .age -> 30 }
 
 -- Tuple
 def point = { 1, 2 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -139,7 +139,7 @@ with expr
 
 ### Structured Data
 
-- **Records:** `{ x = 1, y = 2 }`
+- **Records:** `{ .x -> 1, .y -> 2 }`
 - **Lists:** `[1, 2, 3]`, `[]`
 - **Tuples:** `(a, b)`, `(1, "foo")`
 
@@ -151,7 +151,7 @@ with expr
 - **Literal pattern:** `1`, `'a'`, `"foo"`
 - **Constructor pattern:** `Cons x xs`, `Int# x`
 - **Tuple pattern:** `(x, y)`
-- **Record pattern:** `{ x = x, y = y }`
+- **Record pattern:** `{ .x -> x, .y -> y }`
 - **List pattern:** `[x, y, z]`, `[]`
 
 Example:
@@ -213,9 +213,9 @@ foreign import malgo_int64_t_to_string : Int64# -> String#
 ```malgo
 type Point2D = { x : Int32, y : Int32 }
 def zero2D : Point2D
-def zero2D = { x = 0, y = 0 }
+def zero2D = { .x -> 0, .y -> 0 }
 def x2D : Point2D -> Int32
-def x2D = { { x = x, y = _ } -> x }
+def x2D = { { .x -> x, .y -> _ } -> x }
 ```
 
 ### Use of `with` Statements

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -78,7 +78,7 @@ def fromMaybe = { default m ->
 
 ```malgo
 type Person = { name: String, age: Int32 }
-def personAge = { { name = _, age = age } -> age }
+def personAge = { { .name -> _, .age -> age } -> age }
 ```
 
 ### Tuples

--- a/examples/malgo/Forth.mlg
+++ b/examples/malgo/Forth.mlg
@@ -56,21 +56,21 @@ def dictInsert = { name word dict -> DictBind(name, word, dict) }
 
 def withStack : List ForthVal -> ForthState -> ForthState
 def withStack = { s state ->
-  { stack = s
-  , dict = state.dict
-  , compiling = state.compiling
-  , compileName = state.compileName
-  , compileBuffer = state.compileBuffer
+  { .stack -> s
+  , .dict -> state.dict
+  , .compiling -> state.compiling
+  , .compileName -> state.compileName
+  , .compileBuffer -> state.compileBuffer
   }
 }
 
 def enterCompile : String -> ForthState -> ForthState
 def enterCompile = { name state ->
-  { stack = state.stack
-  , dict = state.dict
-  , compiling = True
-  , compileName = name
-  , compileBuffer = Nil
+  { .stack -> state.stack
+  , .dict -> state.dict
+  , .compiling -> True
+  , .compileName -> name
+  , .compileBuffer -> Nil
   }
 }
 
@@ -78,21 +78,21 @@ def exitCompile : ForthState -> ForthState
 def exitCompile = { state ->
   let newWord = UserDef (reverse (state.compileBuffer));
   let newDict = dictInsert (state.compileName) newWord (state.dict);
-  { stack = state.stack
-  , dict = newDict
-  , compiling = False
-  , compileName = ""
-  , compileBuffer = Nil
+  { .stack -> state.stack
+  , .dict -> newDict
+  , .compiling -> False
+  , .compileName -> ""
+  , .compileBuffer -> Nil
   }
 }
 
 def appendToken : String -> ForthState -> ForthState
 def appendToken = { tok state ->
-  { stack = state.stack
-  , dict = state.dict
-  , compiling = state.compiling
-  , compileName = state.compileName
-  , compileBuffer = Cons tok (state.compileBuffer)
+  { .stack -> state.stack
+  , .dict -> state.dict
+  , .compiling -> state.compiling
+  , .compileName -> state.compileName
+  , .compileBuffer -> Cons tok (state.compileBuffer)
   }
 }
 
@@ -141,7 +141,7 @@ def nextToken = { src ->
     { Nothing }
     { let tok  = takeWhileString notWhiteSpace src1;
       let rest = dropWhileString notWhiteSpace src1;
-      Just {val = tok, rest = rest}
+      Just {.val -> tok, .rest -> rest}
     }
 }
 
@@ -149,7 +149,7 @@ def tokenize : String -> List String
 def tokenize = { src ->
   case (nextToken src) {
     Nothing -> Nil,
-    (Just {val = tok, rest = rest}) -> Cons tok (tokenize rest)
+    (Just {.val -> tok, .rest -> rest}) -> Cons tok (tokenize rest)
   }
 }
 
@@ -418,11 +418,11 @@ def execLines = {
 
 def main = {
   let init =
-    { stack = Nil
-    , dict = makeBaseDict ()
-    , compiling = False
-    , compileName = ""
-    , compileBuffer = Nil
+    { .stack -> Nil
+    , .dict -> makeBaseDict ()
+    , .compiling -> False
+    , .compileName -> ""
+    , .compileBuffer -> Nil
     };
   let input = getContents ();
   let lines = splitLines input;

--- a/examples/malgo/Record.mlg
+++ b/examples/malgo/Record.mlg
@@ -3,10 +3,10 @@ module {..} = import "../../runtime/malgo/Prelude.mlg"
 
 type Person = { name: String, age: Int32 }
 
-def personAge = { { name = _, age = age } -> age }
+def personAge = { { .name -> _, .age -> age } -> age }
 
 def main = {
-  personAge {name = "Hoge", age = 42}
+  personAge {.name -> "Hoge", .age -> 42}
     |> toStringInt32
     |> putStrLn
 }

--- a/lean/Malgo/Parser/CStyle.lean
+++ b/lean/Malgo/Parser/CStyle.lean
@@ -290,8 +290,9 @@ partial def pRecord : P (Expr .parse) := P.captureRange do
   pure fun range => Expr.record range fields.toList
 
 partial def pRecordField : P (String × Expr .parse) := do
+  P.reservedOperator "."
   let field ← P.ident
-  P.reservedOperator "="
+  P.reservedOperator "->"
   let value ← pExpr
   pure (field, value)
 
@@ -406,8 +407,9 @@ partial def pRecordP : P (Pat .parse) := P.captureRange do
   pure fun range => Pat.record range fields.toList
 
 partial def pRecordPField : P (String × Pat .parse) := do
+  P.reservedOperator "."
   let field ← P.ident
-  P.reservedOperator "="
+  P.reservedOperator "->"
   let value ← pPat
   pure (field, value)
 

--- a/runtime/malgo/Json.mlg
+++ b/runtime/malgo/Json.mlg
@@ -26,7 +26,7 @@ data Json
 def parseJson : String -> Maybe Json
 def parseJson = { s ->
   let p0 = jsonSkipWs s 0i64;
-  bindMaybe (jsonParseValue s p0) { {value = v, pos = p1} ->
+  bindMaybe (jsonParseValue s p0) { {.value -> v, .pos -> p1} ->
     let p2 = jsonSkipWs s p1;
     if (eqInt64 p2 (lengthString s))
       { Just v }
@@ -212,7 +212,7 @@ def jsonParseLit = { s pos lit j ->
   if (gtInt64 endPos (lengthString s))
     { Nothing }
     { if (eqString (substring s pos endPos) lit)
-        { Just {value = j, pos = endPos} }
+        { Just {.value -> j, .pos -> endPos} }
         { Nothing }
     }
 }
@@ -222,8 +222,8 @@ def jsonParseLit = { s pos lit j ->
 def jsonParseStringValue : String -> Int64 -> Maybe {value: Json, pos: Int64}
 def jsonParseStringValue = { s pos ->
   -- `pos` points at the opening quote.
-  bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {value = str, pos = p} ->
-    Just {value = JString str, pos = p}
+  bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {.value -> str, .pos -> p} ->
+    Just {.value -> JString str, .pos -> p}
   }
 }
 
@@ -238,11 +238,11 @@ def jsonParseRawString = { s pos ->
 
 def jsonParseRawStringAt : Char -> String -> Int64 -> Maybe {value: String, pos: Int64}
 def jsonParseRawStringAt =
-  { (Char# '"'#)  _ pos -> Just {value = "", pos = addInt64 pos 1i64},
+  { (Char# '"'#)  _ pos -> Just {.value -> "", .pos -> addInt64 pos 1i64},
     (Char# '\\'#) s pos -> jsonParseEscape s (addInt64 pos 1i64),
     c s pos ->
-      bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {value = rest, pos = p} ->
-        Just {value = consString c rest, pos = p}
+      bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {.value -> rest, .pos -> p} ->
+        Just {.value -> consString c rest, .pos -> p}
       }
   }
 
@@ -273,8 +273,8 @@ def jsonParseEscapeAt =
 
 def jsonConsEscaped : Char -> String -> Int64 -> Maybe {value: String, pos: Int64}
 def jsonConsEscaped = { c s pos ->
-  bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {value = rest, pos = p} ->
-    Just {value = consString c rest, pos = p}
+  bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {.value -> rest, .pos -> p} ->
+    Just {.value -> consString c rest, .pos -> p}
   }
 }
 
@@ -283,7 +283,7 @@ def jsonConsEscaped = { c s pos ->
 def jsonParseNumber : String -> Int64 -> Maybe {value: Json, pos: Int64}
 def jsonParseNumber = { s pos ->
   bindMaybe (jsonScanNumber s pos) { endPos ->
-    Just {value = JNumber (substring s pos endPos), pos = endPos}
+    Just {.value -> JNumber (substring s pos endPos), .pos -> endPos}
   }
 }
 
@@ -352,25 +352,25 @@ def jsonParseArray = { s pos ->
   -- `pos` points at '['.
   let p1 = jsonSkipWs s (addInt64 pos 1i64);
   if (jsonAtChar s p1 (Char# ']'#))
-    { Just {value = JArray Nil, pos = addInt64 p1 1i64} }
-    { bindMaybe (jsonParseArrayItems s p1) { {value = items, pos = p2} ->
-        Just {value = JArray items, pos = p2}
+    { Just {.value -> JArray Nil, .pos -> addInt64 p1 1i64} }
+    { bindMaybe (jsonParseArrayItems s p1) { {.value -> items, .pos -> p2} ->
+        Just {.value -> JArray items, .pos -> p2}
       }
     }
 }
 
 def jsonParseArrayItems : String -> Int64 -> Maybe {value: List Json, pos: Int64}
 def jsonParseArrayItems = { s pos ->
-  bindMaybe (jsonParseValue s pos) { {value = v, pos = p1} ->
+  bindMaybe (jsonParseValue s pos) { {.value -> v, .pos -> p1} ->
     let p2 = jsonSkipWs s p1;
     if (jsonAtChar s p2 (Char# ','#))
       { let p3 = jsonSkipWs s (addInt64 p2 1i64);
-        bindMaybe (jsonParseArrayItems s p3) { {value = rest, pos = p4} ->
-          Just {value = Cons v rest, pos = p4}
+        bindMaybe (jsonParseArrayItems s p3) { {.value -> rest, .pos -> p4} ->
+          Just {.value -> Cons v rest, .pos -> p4}
         }
       }
       { if (jsonAtChar s p2 (Char# ']'#))
-          { Just {value = Cons v Nil, pos = addInt64 p2 1i64} }
+          { Just {.value -> Cons v Nil, .pos -> addInt64 p2 1i64} }
           { Nothing }
       }
   }
@@ -383,25 +383,25 @@ def jsonParseObject = { s pos ->
   -- `pos` points at '{'.
   let p1 = jsonSkipWs s (addInt64 pos 1i64);
   if (jsonAtChar s p1 (Char# '}'#))
-    { Just {value = JObject Nil, pos = addInt64 p1 1i64} }
-    { bindMaybe (jsonParseObjectEntries s p1) { {value = entries, pos = p2} ->
-        Just {value = JObject entries, pos = p2}
+    { Just {.value -> JObject Nil, .pos -> addInt64 p1 1i64} }
+    { bindMaybe (jsonParseObjectEntries s p1) { {.value -> entries, .pos -> p2} ->
+        Just {.value -> JObject entries, .pos -> p2}
       }
     }
 }
 
 def jsonParseObjectEntries : String -> Int64 -> Maybe {value: List (String, Json), pos: Int64}
 def jsonParseObjectEntries = { s pos ->
-  bindMaybe (jsonParseObjectEntry s pos) { {value = entry, pos = p1} ->
+  bindMaybe (jsonParseObjectEntry s pos) { {.value -> entry, .pos -> p1} ->
     let p2 = jsonSkipWs s p1;
     if (jsonAtChar s p2 (Char# ','#))
       { let p3 = jsonSkipWs s (addInt64 p2 1i64);
-        bindMaybe (jsonParseObjectEntries s p3) { {value = rest, pos = p4} ->
-          Just {value = Cons entry rest, pos = p4}
+        bindMaybe (jsonParseObjectEntries s p3) { {.value -> rest, .pos -> p4} ->
+          Just {.value -> Cons entry rest, .pos -> p4}
         }
       }
       { if (jsonAtChar s p2 (Char# '}'#))
-          { Just {value = Cons entry Nil, pos = addInt64 p2 1i64} }
+          { Just {.value -> Cons entry Nil, .pos -> addInt64 p2 1i64} }
           { Nothing }
       }
   }
@@ -410,12 +410,12 @@ def jsonParseObjectEntries = { s pos ->
 def jsonParseObjectEntry : String -> Int64 -> Maybe {value: (String, Json), pos: Int64}
 def jsonParseObjectEntry = { s pos ->
   if (jsonAtChar s pos (Char# '"'#))
-    { bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {value = key, pos = p1} ->
+    { bindMaybe (jsonParseRawString s (addInt64 pos 1i64)) { {.value -> key, .pos -> p1} ->
         let p2 = jsonSkipWs s p1;
         if (jsonAtChar s p2 (Char# ':'#))
           { let p3 = jsonSkipWs s (addInt64 p2 1i64);
-            bindMaybe (jsonParseValue s p3) { {value = v, pos = p4} ->
-              Just {value = (key, v), pos = p4}
+            bindMaybe (jsonParseValue s p3) { {.value -> v, .pos -> p4} ->
+              Just {.value -> (key, v), .pos -> p4}
             }
           }
           { Nothing }

--- a/runtime/malgo/Map.mlg
+++ b/runtime/malgo/Map.mlg
@@ -144,7 +144,7 @@ def mapMember = { cmp k m ->
 def mapMinEntry : Map k v -> Maybe {key: k, val: v}
 def mapMinEntry = {
   MapEmpty                   -> Nothing,
-  (MapNode MapEmpty k v _ _) -> Just {key = k, val = v},
+  (MapNode MapEmpty k v _ _) -> Just {.key -> k, .val -> v},
   (MapNode l _ _ _ _)        -> mapMinEntry l
 }
 
@@ -162,7 +162,7 @@ def mapMerge = {
   l r ->
     case (mapMinEntry r) {
       Nothing              -> l,
-      (Just {key = k, val = v}) ->
+      (Just {.key -> k, .val -> v}) ->
         mapBalance l k v (mapDeleteMin r)
     }
 }
@@ -188,19 +188,19 @@ def mapToList : Map k v -> List {key: k, val: v}
 def mapToList = {
   MapEmpty            -> Nil,
   (MapNode l k v r _) ->
-    append (mapToList l) (Cons {key = k, val = v} (mapToList r))
+    append (mapToList l) (Cons {.key -> k, .val -> v} (mapToList r))
 }
 
 def mapFromList : (k -> k -> Int32) -> List {key: k, val: v} -> Map k v
 def mapFromList = { cmp pairs ->
-  foldl { m {key = k, val = v} -> mapInsert cmp k v m } mapEmpty pairs
+  foldl { m {.key -> k, .val -> v} -> mapInsert cmp k v m } mapEmpty pairs
 }
 
 def mapKeys : Map k v -> List k
-def mapKeys = { m -> mapList { {key = k, val = _} -> k } (mapToList m) }
+def mapKeys = { m -> mapList { {.key -> k, .val -> _} -> k } (mapToList m) }
 
 def mapValues : Map k v -> List v
-def mapValues = { m -> mapList { {key = _, val = v} -> v } (mapToList m) }
+def mapValues = { m -> mapList { {.key -> _, .val -> v} -> v } (mapToList m) }
 
 def mapMap : (v -> w) -> Map k v -> Map k w
 def mapMap = {

--- a/runtime/malgo/Prelude.mlg
+++ b/runtime/malgo/Prelude.mlg
@@ -185,7 +185,7 @@ data ProcessResult = ProcessResult { exitCode: Int32, stdout: String, stderr: St
 -- boxed-argument wrapper in this file) rather than a `case`, since a tuple
 -- has exactly one shape and the lint flags that kind of match as irrefutable.
 def toProcessResult : (Int32, String, String) -> ProcessResult
-def toProcessResult = { {code, out, err} -> { exitCode = code, stdout = out, stderr = err } }
+def toProcessResult = { {code, out, err} -> { .exitCode -> code, .stdout -> out, .stderr -> err } }
 
 def runProcess : String -> List String -> ProcessResult
 def runProcess = { (String# cmd) args ->

--- a/runtime/malgo/compiler/Eval.mlg
+++ b/runtime/malgo/compiler/Eval.mlg
@@ -303,7 +303,7 @@ def keepScopedValue = { scopedEnv v ->
 def matchCoApply : Env -> List Pat -> List Value -> Either String {env: Env, rest: List Value}
 def matchCoApply = { lEnv pats args ->
   case pats {
-    Nil -> Right {env = lEnv, rest = args},
+    Nil -> Right {.env -> lEnv, .rest -> args},
     (Cons pat patRest) ->
       case args {
         Nil -> Left "mismatch",
@@ -319,13 +319,13 @@ def matchCoPrefix : Env -> List Value -> String -> List CoSeg -> Either String {
 def matchCoPrefix = {
   lEnv args field Nil -> Left "mismatch",
   lEnv args field (Cons (CoApply pats) restSegs) ->
-    bindRight (matchCoApply lEnv pats args) { {env = lEnv2, rest = remainingArgs} ->
+    bindRight (matchCoApply lEnv pats args) { {.env -> lEnv2, .rest -> remainingArgs} ->
       matchCoPrefix lEnv2 remainingArgs field restSegs
     },
   lEnv args field (Cons (CoField name) restSegs) ->
     if (eqString name field)
       { case args {
-          Nil -> Right {env = lEnv, rest = restSegs},
+          Nil -> Right {.env -> lEnv, .rest -> restSegs},
           _ -> Left "mismatch"
         }
       }
@@ -357,7 +357,7 @@ def matchCoApplyOnly = {
       _ -> Left "mismatch"
     },
   lEnv args (Cons (CoApply pats) restSegs) ->
-    bindRight (matchCoApply lEnv pats args) { {env = lEnv2, rest = remainingArgs} ->
+    bindRight (matchCoApply lEnv pats args) { {.env -> lEnv2, .rest -> remainingArgs} ->
       matchCoApplyOnly lEnv2 remainingArgs restSegs
     },
   lEnv args (Cons (CoField _) restSegs) -> Left "mismatch"
@@ -390,7 +390,7 @@ def projectCoArms = { gEnv lEnv acc field arms conts contEnv ->
     (Cons (ExCoArm segs body) restArms) ->
       case (matchCoPrefix lEnv acc field segs) {
         (Left _) -> projectCoArms gEnv lEnv acc field restArms conts contEnv,
-        (Right {env = armEnv, rest = restSegs}) ->
+        (Right {.env -> armEnv, .rest -> restSegs}) ->
           case restSegs {
             Nil -> eval gEnv armEnv body,
             _ -> projectCoArms gEnv lEnv acc field restArms (append conts (Cons (ExCoArm(restSegs, body)) Nil)) (Just armEnv)
@@ -406,7 +406,7 @@ def projectCoArms = { gEnv lEnv acc field arms conts contEnv ->
 -- Only DeclImport uses bindRight since it's the only decl that can fail or update state.
 def evalDecls : Env -> CompilerState -> List Decl -> Either String {state: CompilerState, env: Env}
 def evalDecls = {
-  gEnv state Nil -> Right {state = state, env = gEnv},
+  gEnv state Nil -> Right {.state -> state, .env -> gEnv},
   gEnv state (Cons (DeclDef name expr) rest) ->
     case (envLookup name gEnv) {
       (Just (VBuiltin _ _ _)) -> evalDecls gEnv state rest,
@@ -415,7 +415,7 @@ def evalDecls = {
   gEnv state (Cons (DeclData _ _ cons) rest) ->
     evalDecls (addConstructors gEnv cons) state rest,
   gEnv state (Cons (DeclImport target path) rest) ->
-    bindRight (evalImport gEnv state target path) { {state = state2, env = gEnv2} ->
+    bindRight (evalImport gEnv state target path) { {.state -> state2, .env -> gEnv2} ->
       evalDecls gEnv2 state2 rest
     },
   gEnv state (Cons (DeclForeign fname _) rest) ->
@@ -656,19 +656,19 @@ def evalImport = { gEnv state target rawPath ->
   let path = normalizeImportPathFrom (stateCurrentDir state) rawPath;
   if (isPreloadedImport path)
     { bindRight (extendFromModuleEnv target gEnv makeBaseEnv) { newEnv ->
-        Right {state = state, env = newEnv}
+        Right {.state -> state, .env -> newEnv}
       }
     }
     { case (cacheLookup path (stateCache state)) {
         (Just Loading) -> Left (formatImportCycle path (stateStack state)),
         (Just (Loaded moduleEnv)) ->
           bindRight (extendFromModuleEnv target gEnv moduleEnv) { newEnv ->
-            Right {state = state, env = newEnv}
+            Right {.state -> state, .env -> newEnv}
           },
         Nothing ->
-          bindRight (loadModule makeBaseEnv state path) { {state = nextState, moduleEnv = moduleEnv} ->
+          bindRight (loadModule makeBaseEnv state path) { {.state -> nextState, .moduleEnv -> moduleEnv} ->
             bindRight (extendFromModuleEnv target gEnv moduleEnv) { newEnv ->
-              Right {state = nextState, env = newEnv}
+              Right {.state -> nextState, .env -> newEnv}
             }
           }
       }
@@ -683,9 +683,9 @@ def loadModule = { baseEnv state path ->
   let src = readFile path;
   bindRight (tokenize src) { toks ->
     bindRight (parseModule toks) { m ->
-      bindRight (evalModuleWithState baseEnv loadingState m) { {state = loadedState, env = moduleEnv} ->
+      bindRight (evalModuleWithState baseEnv loadingState m) { {.state -> loadedState, .env -> moduleEnv} ->
         let cachedState = withLoadedModuleEnv path moduleEnv loadedState;
-        Right {state = restoreModuleContext parentDir parentStack cachedState, moduleEnv = moduleEnv}
+        Right {.state -> restoreModuleContext parentDir parentStack cachedState, .moduleEnv -> moduleEnv}
       }
     }
   }
@@ -1340,7 +1340,7 @@ def evalModuleWithState = { baseEnv state (Module decls) -> evalDecls baseEnv st
 
 def evalModule : Env -> Module -> Either String Env
 def evalModule = { baseEnv modl ->
-  bindRight (evalModuleWithState baseEnv emptyState modl) { {state = _, env = moduleEnv} ->
+  bindRight (evalModuleWithState baseEnv emptyState modl) { {.state -> _, .env -> moduleEnv} ->
     Right moduleEnv
   }
 }
@@ -1357,7 +1357,7 @@ def evalModuleAt = { baseEnv sourcePath modl ->
           dirname normalizedPath
         )
       };
-  bindRight (evalModuleWithState baseEnv initialState modl) { {state = _, env = moduleEnv} ->
+  bindRight (evalModuleWithState baseEnv initialState modl) { {.state -> _, .env -> moduleEnv} ->
     Right moduleEnv
   }
 }

--- a/runtime/malgo/compiler/Infer.mlg
+++ b/runtime/malgo/compiler/Infer.mlg
@@ -17,7 +17,7 @@ data InferState = InferState(Int32, TySub)
 def freshTyVar : InferState -> {state: InferState, var: TyVar}
 def freshTyVar = { (InferState count sub) ->
   let name = appendString "a" (toStringInt32 count);
-  {state = InferState(addInt32 count 1i32, sub), var = TyVar name}
+  {.state -> InferState(addInt32 count 1i32, sub), .var -> TyVar name}
 }
 
 def inferState0 : InferState
@@ -162,7 +162,7 @@ def tyEnvLookup = {
 -- Instantiate a scheme with fresh type variables
 def instantiate : InferState -> Scheme -> {state: InferState, ty: Ty}
 def instantiate = {
-  istate (Scheme Nil body) -> {state = istate, ty = body},
+  istate (Scheme Nil body) -> {.state -> istate, .ty -> body},
   istate (Scheme (Cons v rest) body) ->
     let fr = freshTyVar istate;
     let sub2 = singleSub v (TVar fr.var);

--- a/runtime/malgo/compiler/Lexer.mlg
+++ b/runtime/malgo/compiler/Lexer.mlg
@@ -39,7 +39,7 @@ def lexAll = { src acc ->
                 }
                 { if (isBlockCommentStart src)
                 { bindRight (skipBlockComment src) { r -> lexAll r acc } }
-                { bindRight (lexOne src) { {val = tok, rest = rest} -> lexAll rest (Cons tok acc) } }
+                { bindRight (lexOne src) { {.val -> tok, .rest -> rest} -> lexAll rest (Cons tok acc) } }
               }
             }
         }
@@ -166,17 +166,17 @@ def skipBlockCommentInner = { src depth ->
 def lexOne : String -> Either String {val: Token, rest: String}
 def lexOne = { src ->
   if (eqString src "")
-    { Right {val = TkEof, rest = src} }
+    { Right {.val -> TkEof, .rest -> src} }
     { let c = atString 0i64 src;
       let rest = substring src 1i64 (lengthString src);
       case c {
-        '{'  -> Right {val = TkLBrace, rest = rest},
-        '}'  -> Right {val = TkRBrace, rest = rest},
-        '('  -> Right {val = TkLParen, rest = rest},
-        ')'  -> Right {val = TkRParen, rest = rest},
-        '['  -> Right {val = TkLBracket, rest = rest},
-        ']'  -> Right {val = TkRBracket, rest = rest},
-        ','  -> Right {val = TkComma, rest = rest},
+        '{'  -> Right {.val -> TkLBrace, .rest -> rest},
+        '}'  -> Right {.val -> TkRBrace, .rest -> rest},
+        '('  -> Right {.val -> TkLParen, .rest -> rest},
+        ')'  -> Right {.val -> TkRParen, .rest -> rest},
+        '['  -> Right {.val -> TkLBracket, .rest -> rest},
+        ']'  -> Right {.val -> TkRBracket, .rest -> rest},
+        ','  -> Right {.val -> TkComma, .rest -> rest},
         '"'  -> lexString rest "",
         '\'' -> lexChar rest,
         _ ->
@@ -205,9 +205,9 @@ def lexString = { src acc ->
     { let c = atString 0i64 src;
       let tail = substring src 1i64 (lengthString src);
       if (eqChar c '"')
-        { Right {val = TkString (reverseString acc), rest = dropUnboxedSuffix tail} }
+        { Right {.val -> TkString (reverseString acc), .rest -> dropUnboxedSuffix tail} }
         { if (eqChar c '\\')
-            { bindRight (lexEscape tail) { {val = esc, rest = rest} -> lexString rest (consString esc acc) } }
+            { bindRight (lexEscape tail) { {.val -> esc, .rest -> rest} -> lexString rest (consString esc acc) } }
             { lexString tail (consString c acc) }
         }
     }
@@ -224,11 +224,11 @@ def lexChar = { src ->
     { let c = atString 0i64 src;
       let tail = substring src 1i64 (lengthString src);
       if (eqChar c '\\')
-        { bindRight (lexEscape tail) { {val = esc, rest = rest} ->
-            bindRight (expectChar '\'' rest) { r -> Right {val = TkChar esc, rest = dropUnboxedSuffix r} }
+        { bindRight (lexEscape tail) { {.val -> esc, .rest -> rest} ->
+            bindRight (expectChar '\'' rest) { r -> Right {.val -> TkChar esc, .rest -> dropUnboxedSuffix r} }
           }
         }
-        { bindRight (expectChar '\'' tail) { r -> Right {val = TkChar c, rest = dropUnboxedSuffix r} } }
+        { bindRight (expectChar '\'' tail) { r -> Right {.val -> TkChar c, .rest -> dropUnboxedSuffix r} } }
     }
 }
 
@@ -254,13 +254,13 @@ def lexEscape = { src ->
     { let c = atString 0i64 src;
       let rest = substring src 1i64 (lengthString src);
       case c {
-        'n'  -> Right {val = '\n', rest = rest},
-        't'  -> Right {val = '\t', rest = rest},
-        'r'  -> Right {val = '\r', rest = rest},
-        '\\' -> Right {val = '\\', rest = rest},
-        '"'  -> Right {val = '"',  rest = rest},
-        '\'' -> Right {val = '\'', rest = rest},
-        '0'  -> Right {val = '\0', rest = rest},
+        'n'  -> Right {.val -> '\n', .rest -> rest},
+        't'  -> Right {.val -> '\t', .rest -> rest},
+        'r'  -> Right {.val -> '\r', .rest -> rest},
+        '\\' -> Right {.val -> '\\', .rest -> rest},
+        '"'  -> Right {.val -> '"',  .rest -> rest},
+        '\'' -> Right {.val -> '\'', .rest -> rest},
+        '0'  -> Right {.val -> '\0', .rest -> rest},
         _    -> Left (appendString "unknown escape: \\" (consString c ""))
       }
     }
@@ -278,13 +278,13 @@ def lexNumber = { src ->
   if (hasDecimalSuffix rest)
     { let frac = takeDigits (substring rest 1i64 (lengthString rest));
       let rest2 = substring rest (addInt64 1i64 (lengthString frac)) (lengthString rest);
-      Right {val = TkString (appendString digs (appendString "." frac)), rest = dropUnboxedSuffix rest2}
+      Right {.val -> TkString (appendString digs (appendString "." frac)), .rest -> dropUnboxedSuffix rest2}
     }
     { if (hasI64Suffix rest)
-    { Right {val = TkInt64 n64, rest = dropUnboxedSuffix (substring rest 3i64 (lengthString rest))} }
+    { Right {.val -> TkInt64 n64, .rest -> dropUnboxedSuffix (substring rest 3i64 (lengthString rest))} }
     { if (hasI32Suffix rest)
-        { Right {val = TkInt32 (parseIntString32 digs), rest = dropUnboxedSuffix (substring rest 3i64 (lengthString rest))} }
-        { Right {val = TkInt32 (parseIntString32 digs), rest = dropUnboxedSuffix rest} }
+        { Right {.val -> TkInt32 (parseIntString32 digs), .rest -> dropUnboxedSuffix (substring rest 3i64 (lengthString rest))} }
+        { Right {.val -> TkInt32 (parseIntString32 digs), .rest -> dropUnboxedSuffix rest} }
     }
     }
 }
@@ -382,7 +382,7 @@ def lexIdent = { src ->
   let len = identLen src 0i64;
   let name = substring src 0i64 len;
   let rest = substring src len (lengthString src);
-  Right {val = TkIdent name, rest = rest}
+  Right {.val -> TkIdent name, .rest -> rest}
 }
 
 def identLen : String -> Int64 -> Int64
@@ -404,7 +404,7 @@ def lexOp = { src ->
   let len = opLen src 0i64;
   let op = substring src 0i64 len;
   let rest = substring src len (lengthString src);
-  Right {val = TkOp op, rest = rest}
+  Right {.val -> TkOp op, .rest -> rest}
 }
 
 def opLen : String -> Int64 -> Int64
@@ -483,7 +483,7 @@ def lexAllWithPos = { src pos acc ->
                     lexAllWithPos rest newPos acc
                   }
                 }
-                { bindRight (lexOne src) { {val = tok, rest = rest} ->
+                { bindRight (lexOne src) { {.val -> tok, .rest -> rest} ->
                     let consumed = substring src 0i64 (subInt64 (lengthString src) (lengthString rest));
                     let newPos = advancePosStr pos consumed;
                     lexAllWithPos rest newPos (Cons (Located(tok, pos)) acc)

--- a/runtime/malgo/compiler/Parser.mlg
+++ b/runtime/malgo/compiler/Parser.mlg
@@ -15,7 +15,7 @@ module {..} = import "../../../runtime/malgo/compiler/AST.mlg"
 def nextTok : List Token -> Either String {val: Token, rest: List Token}
 def nextTok = {
   Nil -> Left "unexpected end of input",
-  (Cons t ts) -> Right {val = t, rest = ts}
+  (Cons t ts) -> Right {.val -> t, .rest -> ts}
 }
 
 def peekTok : List Token -> Either String Token
@@ -86,7 +86,7 @@ def isCopatternStart = {
 
 def isRecordStart : List Token -> Bool
 def isRecordStart = {
-  (Cons (TkIdent _) (Cons (TkOp op) _)) -> eqString op "=",
+  (Cons (TkOp op) _) -> eqString op ".",
   _ -> False
 }
 
@@ -106,7 +106,7 @@ def isNextEof = {
 -- Consume and assert an operator token
 def expectOp : String -> List Token -> Either String (List Token)
 def expectOp = { expected ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       (TkOp s) ->
         if (eqString s expected)
@@ -120,7 +120,7 @@ def expectOp = { expected ts ->
 -- Consume and assert TkLBrace
 def expectLBrace : List Token -> Either String (List Token)
 def expectLBrace = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkLBrace -> Right ts2,
       _ -> Left (appendString "expected '{' but got " (showToken t))
@@ -131,7 +131,7 @@ def expectLBrace = { ts ->
 -- Consume and assert TkRBrace
 def expectRBrace : List Token -> Either String (List Token)
 def expectRBrace = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRBrace -> Right ts2,
       _ -> Left (appendString "expected '}' but got " (showToken t))
@@ -142,7 +142,7 @@ def expectRBrace = { ts ->
 -- Consume and assert TkLParen
 def expectLParen : List Token -> Either String (List Token)
 def expectLParen = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkLParen -> Right ts2,
       _ -> Left (appendString "expected '(' but got " (showToken t))
@@ -153,7 +153,7 @@ def expectLParen = { ts ->
 -- Consume and assert TkRParen
 def expectRParen : List Token -> Either String (List Token)
 def expectRParen = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRParen -> Right ts2,
       _ -> Left (appendString "expected ')' but got " (showToken t))
@@ -163,7 +163,7 @@ def expectRParen = { ts ->
 
 def expectRBracket : List Token -> Either String (List Token)
 def expectRBracket = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRBracket -> Right ts2,
       _ -> Left (appendString "expected ']' but got " (showToken t))
@@ -174,9 +174,9 @@ def expectRBracket = { ts ->
 -- Consume an identifier and return its string value
 def eatIdent : List Token -> Either String {val: String, rest: List Token}
 def eatIdent = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
-      (TkIdent s) -> Right {val = s, rest = ts2},
+      (TkIdent s) -> Right {.val -> s, .rest -> ts2},
       _ -> Left (appendString "expected identifier but got " (showToken t))
     }
   }
@@ -255,12 +255,12 @@ def skipToNextDecl = {
 
 def parseLit : List Token -> Either String {val: Lit, rest: List Token}
 def parseLit = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
-      (TkInt32 n)  -> Right {val = LitInt32 n, rest = ts2},
-      (TkInt64 n)  -> Right {val = LitInt64 n, rest = ts2},
-      (TkChar c)   -> Right {val = LitChar c, rest = ts2},
-      (TkString s) -> Right {val = LitString s, rest = ts2},
+      (TkInt32 n)  -> Right {.val -> LitInt32 n, .rest -> ts2},
+      (TkInt64 n)  -> Right {.val -> LitInt64 n, .rest -> ts2},
+      (TkChar c)   -> Right {.val -> LitChar c, .rest -> ts2},
+      (TkString s) -> Right {.val -> LitString s, .rest -> ts2},
       _ -> Left (appendString "expected literal but got " (showToken t))
     }
   }
@@ -273,11 +273,11 @@ def parseLit = { ts ->
 -- Parse one atom-level pattern (no constructor application)
 def parseAtomPat : List Token -> Either String {val: Pat, rest: List Token}
 def parseAtomPat = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       (TkIdent s)   ->
         if (eqString s "_")
-          { Right {val = PatWild, rest = ts2} }
+          { Right {.val -> PatWild, .rest -> ts2} }
           { if (isUpperFirst s)
               -- Uppercase: constructor, possibly with C-style args Con(p1, p2)
               { if (isNextLParen ts2)
@@ -285,32 +285,32 @@ def parseAtomPat = { ts ->
                       if (isNextRParen ts3)
                         -- Con() empty
                         { bindRight (expectRParen ts3) { ts4 ->
-                            Right {val = PatCon(s, Nil), rest = ts4}
+                            Right {.val -> PatCon(s, Nil), .rest -> ts4}
                           }
                         }
-                        { bindRight (parseCStylePatArgs ts3) { {val = ps, rest = ts4} ->
-                            Right {val = PatCon(s, ps), rest = ts4}
+                        { bindRight (parseCStylePatArgs ts3) { {.val -> ps, .rest -> ts4} ->
+                            Right {.val -> PatCon(s, ps), .rest -> ts4}
                           }
                         }
                     }
                   }
                   { if (isNextLBrace ts2)
                       { bindRight (expectLBrace ts2) { ts3 ->
-                          bindRight (parseRecordPatFields ts3) { {val = fs, rest = ts4} ->
-                            Right {val = PatCon(s, Cons (PatRecord fs) Nil), rest = ts4}
+                          bindRight (parseRecordPatFields ts3) { {.val -> fs, .rest -> ts4} ->
+                            Right {.val -> PatCon(s, Cons (PatRecord fs) Nil), .rest -> ts4}
                           }
                         }
                       }
-                      { Right {val = PatCon(s, Nil), rest = ts2} }
+                      { Right {.val -> PatCon(s, Nil), .rest -> ts2} }
                   }
               }
               -- Lowercase: variable
-              { Right {val = PatVar s, rest = ts2} }
+              { Right {.val -> PatVar s, .rest -> ts2} }
           },
-      (TkInt32 n)   -> Right {val = PatLit (LitInt32 n), rest = ts2},
-      (TkInt64 n)   -> Right {val = PatLit (LitInt64 n), rest = ts2},
-      (TkChar c)    -> Right {val = PatLit (LitChar c), rest = ts2},
-      (TkString s)  -> Right {val = PatLit (LitString s), rest = ts2},
+      (TkInt32 n)   -> Right {.val -> PatLit (LitInt32 n), .rest -> ts2},
+      (TkInt64 n)   -> Right {.val -> PatLit (LitInt64 n), .rest -> ts2},
+      (TkChar c)    -> Right {.val -> PatLit (LitChar c), .rest -> ts2},
+      (TkString s)  -> Right {.val -> PatLit (LitString s), .rest -> ts2},
       TkLParen      -> parseParenPat ts2,
       TkLBrace      -> parseBracePat ts2,
       TkLBracket    -> parseListPat ts2,
@@ -321,27 +321,27 @@ def parseAtomPat = { ts ->
 
 def parseSpaceAtomPat : List Token -> Either String {val: Pat, rest: List Token}
 def parseSpaceAtomPat = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       (TkIdent s)   ->
         if (eqString s "_")
-          { Right {val = PatWild, rest = ts2} }
+          { Right {.val -> PatWild, .rest -> ts2} }
           { if (isUpperFirst s)
               { if (isNextLBrace ts2)
                   { bindRight (expectLBrace ts2) { ts3 ->
-                      bindRight (parseRecordPatFields ts3) { {val = fs, rest = ts4} ->
-                        Right {val = PatCon(s, Cons (PatRecord fs) Nil), rest = ts4}
+                      bindRight (parseRecordPatFields ts3) { {.val -> fs, .rest -> ts4} ->
+                        Right {.val -> PatCon(s, Cons (PatRecord fs) Nil), .rest -> ts4}
                       }
                     }
                   }
-                  { Right {val = PatCon(s, Nil), rest = ts2} }
+                  { Right {.val -> PatCon(s, Nil), .rest -> ts2} }
               }
-              { Right {val = PatVar s, rest = ts2} }
+              { Right {.val -> PatVar s, .rest -> ts2} }
           },
-      (TkInt32 n)   -> Right {val = PatLit (LitInt32 n), rest = ts2},
-      (TkInt64 n)   -> Right {val = PatLit (LitInt64 n), rest = ts2},
-      (TkChar c)    -> Right {val = PatLit (LitChar c), rest = ts2},
-      (TkString s)  -> Right {val = PatLit (LitString s), rest = ts2},
+      (TkInt32 n)   -> Right {.val -> PatLit (LitInt32 n), .rest -> ts2},
+      (TkInt64 n)   -> Right {.val -> PatLit (LitInt64 n), .rest -> ts2},
+      (TkChar c)    -> Right {.val -> PatLit (LitChar c), .rest -> ts2},
+      (TkString s)  -> Right {.val -> PatLit (LitString s), .rest -> ts2},
       TkLParen      -> parseParenPat ts2,
       TkLBrace      -> parseBracePat ts2,
       TkLBracket    -> parseListPat ts2,
@@ -353,10 +353,10 @@ def parseSpaceAtomPat = { ts ->
 def parseListPat : List Token -> Either String {val: Pat, rest: List Token}
 def parseListPat = { ts ->
   if (isNextRBracket ts)
-    { bindRight (nextTok ts) { {rest = ts2} -> Right {val = PatCon("Nil", Nil), rest = ts2} } }
-    { bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
-        bindRight (parseListPatRest ts2) { {val = ps, rest = ts3} ->
-          Right {val = listPatFromItems (Cons p ps), rest = ts3}
+    { bindRight (nextTok ts) { {.rest -> ts2} -> Right {.val -> PatCon("Nil", Nil), .rest -> ts2} } }
+    { bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
+        bindRight (parseListPatRest ts2) { {.val -> ps, .rest -> ts3} ->
+          Right {.val -> listPatFromItems (Cons p ps), .rest -> ts3}
         }
       }
     }
@@ -365,15 +365,15 @@ def parseListPat = { ts ->
 def parseListPatRest : List Token -> Either String {val: List Pat, rest: List Token}
 def parseListPatRest = { ts ->
   if (isNextComma ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (parseAtomPat ts2) { {val = p, rest = ts3} ->
-          bindRight (parseListPatRest ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (parseAtomPat ts2) { {.val -> p, .rest -> ts3} ->
+          bindRight (parseListPatRest ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
     }
-    { bindRight (expectRBracket ts) { ts2 -> Right {val = Nil, rest = ts2} } }
+    { bindRight (expectRBracket ts) { ts2 -> Right {.val -> Nil, .rest -> ts2} } }
 }
 
 def listPatFromItems : List Pat -> Pat
@@ -385,21 +385,21 @@ def listPatFromItems = {
 def parseBracePat : List Token -> Either String {val: Pat, rest: List Token}
 def parseBracePat = { ts ->
   if (isNextRBrace ts)
-    { bindRight (nextTok ts) { {rest = ts2} -> Right {val = PatLit LitUnit, rest = ts2} } }
+    { bindRight (nextTok ts) { {.rest -> ts2} -> Right {.val -> PatLit LitUnit, .rest -> ts2} } }
     { if (isRecordStart ts)
-        { bindRight (parseRecordPatFields ts) { {val = fs, rest = ts2} ->
-            Right {val = PatRecord fs, rest = ts2}
+        { bindRight (parseRecordPatFields ts) { {.val -> fs, .rest -> ts2} ->
+            Right {.val -> PatRecord fs, .rest -> ts2}
           }
         }
-        { bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
+        { bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
         if (isNextComma ts2)
-          { bindRight (nextTok ts2) { {rest = ts3} ->
-              bindRight (parseTuplePatRestBrace ts3) { {val = ps, rest = ts4} ->
-                Right {val = PatTuple (Cons p ps), rest = ts4}
+          { bindRight (nextTok ts2) { {.rest -> ts3} ->
+              bindRight (parseTuplePatRestBrace ts3) { {.val -> ps, .rest -> ts4} ->
+                Right {.val -> PatTuple (Cons p ps), .rest -> ts4}
               }
             }
           }
-          { bindRight (expectRBrace ts2) { ts3 -> Right {val = p, rest = ts3} } }
+          { bindRight (expectRBrace ts2) { ts3 -> Right {.val -> p, .rest -> ts3} } }
       }
         }
     }
@@ -407,20 +407,22 @@ def parseBracePat = { ts ->
 
 def parseRecordPatFields : List Token -> Either String {val: List PatField, rest: List Token}
 def parseRecordPatFields = { ts ->
-  bindRight (eatIdent ts) { {val = name, rest = ts2} ->
-    bindRight (expectOp "=" ts2) { ts3 ->
-      bindRight (parseAtomPat ts3) { {val = pat, rest = ts4} ->
-        if (isNextComma ts4)
-          { bindRight (nextTok ts4) { {rest = ts5} ->
-              if (isNextRBrace ts5)
-                { bindRight (expectRBrace ts5) { ts6 -> Right {val = Cons (PatField(name, pat)) Nil, rest = ts6} } }
-                { bindRight (parseRecordPatFields ts5) { {val = fs, rest = ts6} ->
-                    Right {val = Cons (PatField(name, pat)) fs, rest = ts6}
+  bindRight (expectOp "." ts) { ts1 ->
+    bindRight (eatIdent ts1) { {.val -> name, .rest -> ts2} ->
+      bindRight (expectOp "->" ts2) { ts3 ->
+        bindRight (parseAtomPat ts3) { {.val -> pat, .rest -> ts4} ->
+          if (isNextComma ts4)
+            { bindRight (nextTok ts4) { {.rest -> ts5} ->
+                if (isNextRBrace ts5)
+                  { bindRight (expectRBrace ts5) { ts6 -> Right {.val -> Cons (PatField(name, pat)) Nil, .rest -> ts6} } }
+                  { bindRight (parseRecordPatFields ts5) { {.val -> fs, .rest -> ts6} ->
+                      Right {.val -> Cons (PatField(name, pat)) fs, .rest -> ts6}
+                    }
                   }
-                }
+              }
             }
-          }
-          { bindRight (expectRBrace ts4) { ts5 -> Right {val = Cons (PatField(name, pat)) Nil, rest = ts5} } }
+            { bindRight (expectRBrace ts4) { ts5 -> Right {.val -> Cons (PatField(name, pat)) Nil, .rest -> ts5} } }
+        }
       }
     }
   }
@@ -428,15 +430,15 @@ def parseRecordPatFields = { ts ->
 
 def parseTuplePatRestBrace : List Token -> Either String {val: List Pat, rest: List Token}
 def parseTuplePatRestBrace = { ts ->
-  bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
+  bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseTuplePatRestBrace ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseTuplePatRestBrace ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
-      { bindRight (expectRBrace ts2) { ts3 -> Right {val = Cons p Nil, rest = ts3} } }
+      { bindRight (expectRBrace ts2) { ts3 -> Right {.val -> Cons p Nil, .rest -> ts3} } }
   }
 }
 
@@ -446,18 +448,18 @@ def parseParenPat : List Token -> Either String {val: Pat, rest: List Token}
 def parseParenPat = { ts ->
   if (isNextRParen ts)
     -- "()" unit
-    { bindRight (nextTok ts) { {rest = ts2} -> Right {val = PatLit LitUnit, rest = ts2} } }
+    { bindRight (nextTok ts) { {.rest -> ts2} -> Right {.val -> PatLit LitUnit, .rest -> ts2} } }
     {
-      bindRight (nextTok ts) { {val = t, rest = ts2} ->
+      bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
         case t {
           (TkIdent s) ->
             if (isUpperFirst s)
               { if (isNextComma ts2)
                   { parseTupleOrGroupedPat (PatCon(s, Nil)) ts2 }
                   -- Constructor pattern: (Con p1 p2 ...)
-                  { bindRight (parseSpacePatArgs ts2) { {val = ps, rest = ts3} ->
+                  { bindRight (parseSpacePatArgs ts2) { {.val -> ps, .rest -> ts3} ->
                       bindRight (expectRParen ts3) { ts4 ->
-                        Right {val = PatCon(s, ps), rest = ts4}
+                        Right {.val -> PatCon(s, ps), .rest -> ts4}
                       }
                     }
                   }
@@ -469,7 +471,7 @@ def parseParenPat = { ts ->
           (TkChar c)   -> parseTupleOrGroupedPat (PatLit (LitChar c)) ts2,
           (TkString s) -> parseTupleOrGroupedPat (PatLit (LitString s)) ts2,
           TkLBrace ->
-            bindRight (parseBracePat ts2) { {val = p, rest = ts3} ->
+            bindRight (parseBracePat ts2) { {.val -> p, .rest -> ts3} ->
               parseTupleOrGroupedPat p ts3
             },
           _ -> Left (appendString "expected pattern inside '(' but got " (showToken t))
@@ -482,25 +484,25 @@ def parseParenPat = { ts ->
 def parseTupleOrGroupedPat : Pat -> List Token -> Either String {val: Pat, rest: List Token}
 def parseTupleOrGroupedPat = { p ts ->
   if (isNextComma ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (parseTuplePatRest ts2) { {val = ps, rest = ts3} ->
-          Right {val = PatTuple (Cons p ps), rest = ts3}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (parseTuplePatRest ts2) { {.val -> ps, .rest -> ts3} ->
+          Right {.val -> PatTuple (Cons p ps), .rest -> ts3}
         }
       }
     }
     { case p {
         (PatCon name Nil) ->
           if (isNextRParen ts)
-            { bindRight (expectRParen ts) { ts2 -> Right {val = p, rest = ts2} } }
-            { bindRight (parseSpacePatArgs ts) { {val = ps, rest = ts2} ->
+            { bindRight (expectRParen ts) { ts2 -> Right {.val -> p, .rest -> ts2} } }
+            { bindRight (parseSpacePatArgs ts) { {.val -> ps, .rest -> ts2} ->
                 bindRight (expectRParen ts2) { ts3 ->
-                  Right {val = PatCon(name, ps), rest = ts3}
+                  Right {.val -> PatCon(name, ps), .rest -> ts3}
                 }
               }
             },
         _ ->
           bindRight (expectRParen ts) { ts2 ->
-            Right {val = p, rest = ts2}
+            Right {.val -> p, .rest -> ts2}
           }
       }
     }
@@ -509,16 +511,16 @@ def parseTupleOrGroupedPat = { p ts ->
 -- Parse remaining tuple pattern elements: pat (',' pat)* ')'
 def parseTuplePatRest : List Token -> Either String {val: List Pat, rest: List Token}
 def parseTuplePatRest = { ts ->
-  bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
+  bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseTuplePatRest ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseTuplePatRest ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
       { bindRight (expectRParen ts2) { ts3 ->
-          Right {val = Cons p Nil, rest = ts3}
+          Right {.val -> Cons p Nil, .rest -> ts3}
         }
       }
   }
@@ -528,10 +530,10 @@ def parseTuplePatRest = { ts ->
 def parseSpacePatArgs : List Token -> Either String {val: List Pat, rest: List Token}
 def parseSpacePatArgs = { ts ->
   if (isNextRParen ts)
-    { Right {val = Nil, rest = ts} }
-    { bindRight (parseSpaceAtomPat ts) { {val = p, rest = ts2} ->
-        bindRight (parseSpacePatArgs ts2) { {val = ps, rest = ts3} ->
-          Right {val = Cons p ps, rest = ts3}
+    { Right {.val -> Nil, .rest -> ts} }
+    { bindRight (parseSpaceAtomPat ts) { {.val -> p, .rest -> ts2} ->
+        bindRight (parseSpacePatArgs ts2) { {.val -> ps, .rest -> ts3} ->
+          Right {.val -> Cons p ps, .rest -> ts3}
         }
       }
     }
@@ -540,16 +542,16 @@ def parseSpacePatArgs = { ts ->
 -- Parse comma-separated atom patterns inside Con(p1, p2, ...) — already past '('
 def parseCStylePatArgs : List Token -> Either String {val: List Pat, rest: List Token}
 def parseCStylePatArgs = { ts ->
-  bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
+  bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseCStylePatArgs ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseCStylePatArgs ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
       { bindRight (expectRParen ts2) { ts3 ->
-          Right {val = Cons p Nil, rest = ts3}
+          Right {.val -> Cons p Nil, .rest -> ts3}
         }
       }
   }
@@ -559,26 +561,26 @@ def parseCStylePatArgs = { ts ->
 def parseArmPats : List Token -> Either String {val: List Pat, rest: List Token}
 def parseArmPats = { ts ->
   if (isNextOpStr "->" ts)
-    { Right {val = Nil, rest = ts} }
+    { Right {.val -> Nil, .rest -> ts} }
     { case ts {
         (Cons TkLParen rest) ->
           if (hasTopLevelCommaBeforeRParen rest 0i32)
-            { bindRight (parseParenArmPats rest) { {val = headPats, rest = ts2} ->
-                bindRight (parseArmPats ts2) { {val = tailPats, rest = ts3} ->
-                  Right {val = append headPats tailPats, rest = ts3}
+            { bindRight (parseParenArmPats rest) { {.val -> headPats, .rest -> ts2} ->
+                bindRight (parseArmPats ts2) { {.val -> tailPats, .rest -> ts3} ->
+                  Right {.val -> append headPats tailPats, .rest -> ts3}
                 }
               }
             }
-            { bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
-                bindRight (parseArmPats ts2) { {val = ps, rest = ts3} ->
-                  Right {val = Cons p ps, rest = ts3}
+            { bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
+                bindRight (parseArmPats ts2) { {.val -> ps, .rest -> ts3} ->
+                  Right {.val -> Cons p ps, .rest -> ts3}
                 }
               }
             },
         _ ->
-          bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
-            bindRight (parseArmPats ts2) { {val = ps, rest = ts3} ->
-              Right {val = Cons p ps, rest = ts3}
+          bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
+            bindRight (parseArmPats ts2) { {.val -> ps, .rest -> ts3} ->
+              Right {.val -> Cons p ps, .rest -> ts3}
             }
           }
       }
@@ -590,7 +592,12 @@ def hasTopLevelCommaBeforeRParen = { ts depth ->
   case ts {
     Nil -> False,
     (Cons TkEof _) -> False,
-    (Cons TkComma _) -> eqInt32 depth 0i32,
+    (Cons TkComma rest) ->
+      -- Same fix as hasTopLevelArrow: a comma at nonzero depth belongs to a
+      -- nested structure (a nested tuple/list/record's own field
+      -- separator) -- keep scanning for a real top-level one instead of
+      -- bailing out.
+      if (eqInt32 depth 0i32) { True } { hasTopLevelCommaBeforeRParen rest depth },
     (Cons TkRParen rest) ->
       if (eqInt32 depth 0i32)
         { False }
@@ -606,29 +613,29 @@ def hasTopLevelCommaBeforeRParen = { ts depth ->
 
 def parseParenArmPats : List Token -> Either String {val: List Pat, rest: List Token}
 def parseParenArmPats = { ts ->
-  bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
+  bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseParenArmPatsRest ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseParenArmPatsRest ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
-      { bindRight (expectRParen ts2) { ts3 -> Right {val = Cons p Nil, rest = ts3} } }
+      { bindRight (expectRParen ts2) { ts3 -> Right {.val -> Cons p Nil, .rest -> ts3} } }
   }
 }
 
 def parseParenArmPatsRest : List Token -> Either String {val: List Pat, rest: List Token}
 def parseParenArmPatsRest = { ts ->
-  bindRight (parseAtomPat ts) { {val = p, rest = ts2} ->
+  bindRight (parseAtomPat ts) { {.val -> p, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseParenArmPatsRest ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseParenArmPatsRest ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
-      { bindRight (expectRParen ts2) { ts3 -> Right {val = Cons p Nil, rest = ts3} } }
+      { bindRight (expectRParen ts2) { ts3 -> Right {.val -> Cons p Nil, .rest -> ts3} } }
   }
 }
 
@@ -639,16 +646,16 @@ def parseParenArmPatsRest = { ts ->
 -- Parse an atom (non-left-recursive base expression)
 def parseAtom : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseAtom = { ftable ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       (TkIdent s)  ->
         if (eqString s "label")
           { parseLabelExpr ftable ts2 }
           { parseIdentExpr s ts2 },
-      (TkInt32 n)  -> Right {val = ExLit (LitInt32 n), rest = ts2},
-      (TkInt64 n)  -> Right {val = ExLit (LitInt64 n), rest = ts2},
-      (TkChar c)   -> Right {val = ExLit (LitChar c), rest = ts2},
-      (TkString s) -> Right {val = ExLit (LitString s), rest = ts2},
+      (TkInt32 n)  -> Right {.val -> ExLit (LitInt32 n), .rest -> ts2},
+      (TkInt64 n)  -> Right {.val -> ExLit (LitInt64 n), .rest -> ts2},
+      (TkChar c)   -> Right {.val -> ExLit (LitChar c), .rest -> ts2},
+      (TkString s) -> Right {.val -> ExLit (LitString s), .rest -> ts2},
       TkLParen     -> parseParenExpr ftable ts2,
       TkLBrace     -> parseCaseLambda ftable ts2,
       TkLBracket   -> parseListExpr ftable ts2,
@@ -659,11 +666,11 @@ def parseAtom = { ftable ts ->
 
 def parseLabelExpr : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseLabelExpr = { ftable ts ->
-  bindRight (eatIdent ts) { {val = name, rest = ts2} ->
-    bindRight (parseApp ftable ts2) { {val = body, rest = ts3} ->
+  bindRight (eatIdent ts) { {.val -> name, .rest -> ts2} ->
+    bindRight (parseApp ftable ts2) { {.val -> body, .rest -> ts3} ->
       let valueName = "__label_value";
       let identity = ExCase(Cons (ExArm(Cons (PatVar valueName) Nil, ExVar valueName)) Nil);
-      Right {val = ExLet(name, identity, body), rest = ts3}
+      Right {.val -> ExLet(name, identity, body), .rest -> ts3}
     }
   }
 }
@@ -674,21 +681,21 @@ def parseIdentExpr = { name ts ->
     (Cons (TkOp dot) (Cons (TkIdent field) rest)) ->
       if (eqString dot ".")
         { if (isUpperFirst name)
-            { Right {val = ExVar (appendString name (appendString "." field)), rest = rest} }
-            { Right {val = ExField(ExVar name, field), rest = rest} }
+            { Right {.val -> ExVar (appendString name (appendString "." field)), .rest -> rest} }
+            { Right {.val -> ExField(ExVar name, field), .rest -> rest} }
         }
-        { Right {val = ExVar name, rest = ts} },
-    _ -> Right {val = ExVar name, rest = ts}
+        { Right {.val -> ExVar name, .rest -> ts} },
+    _ -> Right {.val -> ExVar name, .rest -> ts}
   }
 }
 
 def parseListExpr : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseListExpr = { ftable ts ->
   if (isNextRBracket ts)
-    { bindRight (nextTok ts) { {rest = ts2} -> Right {val = ExVar "Nil", rest = ts2} } }
-    { bindRight (parseOp ftable ts) { {val = e, rest = ts2} ->
-        bindRight (parseListExprRest ftable ts2) { {val = es, rest = ts3} ->
-          Right {val = listExprFromItems (Cons e es), rest = ts3}
+    { bindRight (nextTok ts) { {.rest -> ts2} -> Right {.val -> ExVar "Nil", .rest -> ts2} } }
+    { bindRight (parseOp ftable ts) { {.val -> e, .rest -> ts2} ->
+        bindRight (parseListExprRest ftable ts2) { {.val -> es, .rest -> ts3} ->
+          Right {.val -> listExprFromItems (Cons e es), .rest -> ts3}
         }
       }
     }
@@ -697,15 +704,15 @@ def parseListExpr = { ftable ts ->
 def parseListExprRest : List FixityEntry -> List Token -> Either String {val: List Expr, rest: List Token}
 def parseListExprRest = { ftable ts ->
   if (isNextComma ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (parseOp ftable ts2) { {val = e, rest = ts3} ->
-          bindRight (parseListExprRest ftable ts3) { {val = es, rest = ts4} ->
-            Right {val = Cons e es, rest = ts4}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (parseOp ftable ts2) { {.val -> e, .rest -> ts3} ->
+          bindRight (parseListExprRest ftable ts3) { {.val -> es, .rest -> ts4} ->
+            Right {.val -> Cons e es, .rest -> ts4}
           }
         }
       }
     }
-    { bindRight (expectRBracket ts) { ts2 -> Right {val = Nil, rest = ts2} } }
+    { bindRight (expectRBracket ts) { ts2 -> Right {.val -> Nil, .rest -> ts2} } }
 }
 
 def listExprFromItems : List Expr -> Expr
@@ -719,16 +726,16 @@ def parseParenExpr : List FixityEntry -> List Token -> Either String {val: Expr,
 def parseParenExpr = { ftable ts ->
   if (isNextRParen ts)
     -- "()" unit
-    { bindRight (nextTok ts) { {rest = ts2} -> Right {val = ExUnit, rest = ts2} } }
+    { bindRight (nextTok ts) { {.rest -> ts2} -> Right {.val -> ExUnit, .rest -> ts2} } }
     {
       if (isNextIdentStr "let" ts)
-        { bindRight (parseStmts ftable ts) { {val = body, rest = ts2} ->
-            bindRight (expectRParen ts2) { ts3 -> Right {val = body, rest = ts3} }
+        { bindRight (parseStmts ftable ts) { {.val -> body, .rest -> ts2} ->
+            bindRight (expectRParen ts2) { ts3 -> Right {.val -> body, .rest -> ts3} }
           }
         }
         { if (isNextIdentStr "with" ts)
-            { bindRight (parseStmts ftable ts) { {val = body, rest = ts2} ->
-                bindRight (expectRParen ts2) { ts3 -> Right {val = body, rest = ts3} }
+            { bindRight (parseStmts ftable ts) { {.val -> body, .rest -> ts2} ->
+                bindRight (expectRParen ts2) { ts3 -> Right {.val -> body, .rest -> ts3} }
               }
             }
             {
@@ -736,14 +743,14 @@ def parseParenExpr = { ftable ts ->
       case ts {
         (Cons (TkOp s) ts2) ->
           if (isNextRParen ts2)
-            { bindRight (nextTok ts2) { {rest = ts3} -> Right {val = ExVar s, rest = ts3} } }
+            { bindRight (nextTok ts2) { {.rest -> ts3} -> Right {.val -> ExVar s, .rest -> ts3} } }
             { -- Not a simple op ref; parse as expression
-              bindRight (parseOp ftable ts) { {val = e, rest = ts2b} ->
+              bindRight (parseOp ftable ts) { {.val -> e, .rest -> ts2b} ->
                 parseTupleOrGroupedExpr ftable e ts2b
               }
             },
         _ ->
-          bindRight (parseOp ftable ts) { {val = e, rest = ts2} ->
+          bindRight (parseOp ftable ts) { {.val -> e, .rest -> ts2} ->
             parseTupleOrGroupedExpr ftable e ts2
           }
       }
@@ -756,16 +763,16 @@ def parseParenExpr = { ftable ts ->
 def parseTupleOrGroupedExpr : List FixityEntry -> Expr -> List Token -> Either String {val: Expr, rest: List Token}
 def parseTupleOrGroupedExpr = { ftable e ts ->
   if (isNextComma ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (parseTupleExprRest ftable ts2) { {val = es, rest = ts3} ->
-          Right {val = ExTuple (Cons e es), rest = ts3}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (parseTupleExprRest ftable ts2) { {.val -> es, .rest -> ts3} ->
+          Right {.val -> ExTuple (Cons e es), .rest -> ts3}
         }
       }
     }
     { if (isNextOpStr ":" ts)
-        { bindRight (skipAscriptionToRParen 0i32 ts) { ts2 -> Right {val = e, rest = ts2} } }
+        { bindRight (skipAscriptionToRParen 0i32 ts) { ts2 -> Right {.val -> e, .rest -> ts2} } }
         { bindRight (expectRParen ts) { ts2 ->
-            Right {val = e, rest = ts2}
+            Right {.val -> e, .rest -> ts2}
           }
         }
     }
@@ -773,7 +780,7 @@ def parseTupleOrGroupedExpr = { ftable e ts ->
 
 def skipAscriptionToRParen : Int32 -> List Token -> Either String (List Token)
 def skipAscriptionToRParen = { depth ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRParen ->
         if (eqInt32 depth 0i32)
@@ -789,16 +796,16 @@ def skipAscriptionToRParen = { depth ts ->
 -- Parse remaining tuple elements: expr (',' expr)* ')'
 def parseTupleExprRest : List FixityEntry -> List Token -> Either String {val: List Expr, rest: List Token}
 def parseTupleExprRest = { ftable ts ->
-  bindRight (parseOp ftable ts) { {val = e, rest = ts2} ->
+  bindRight (parseOp ftable ts) { {.val -> e, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseTupleExprRest ftable ts3) { {val = es, rest = ts4} ->
-            Right {val = Cons e es, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseTupleExprRest ftable ts3) { {.val -> es, .rest -> ts4} ->
+            Right {.val -> Cons e es, .rest -> ts4}
           }
         }
       }
       { bindRight (expectRParen ts2) { ts3 ->
-          Right {val = Cons e Nil, rest = ts3}
+          Right {.val -> Cons e Nil, .rest -> ts3}
         }
       }
   }
@@ -808,39 +815,39 @@ def parseTupleExprRest = { ftable ts ->
 def parseCaseLambda : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseCaseLambda = { ftable ts ->
   if (isCopatternStart ts)
-    { bindRight (parseCoArms ftable ts) { {val = arms, rest = ts2} ->
+    { bindRight (parseCoArms ftable ts) { {.val -> arms, .rest -> ts2} ->
         bindRight (expectRBrace ts2) { ts3 ->
-          Right {val = ExCoCase arms, rest = ts3}
+          Right {.val -> ExCoCase arms, .rest -> ts3}
         }
       }
     }
     { if (isRecordStart ts)
-        { bindRight (parseRecordExprFields ftable ts) { {val = fs, rest = ts2} ->
-            Right {val = ExRecord fs, rest = ts2}
+        { bindRight (parseRecordExprFields ftable ts) { {.val -> fs, .rest -> ts2} ->
+            Right {.val -> ExRecord fs, .rest -> ts2}
           }
         }
         { if (hasTopLevelArrow ts 0i32)
-    { bindRight (parseArms ftable ts) { {val = arms, rest = ts2} ->
+    { bindRight (parseArms ftable ts) { {.val -> arms, .rest -> ts2} ->
         bindRight (expectRBrace ts2) { ts3 ->
-          Right {val = ExCase arms, rest = ts3}
+          Right {.val -> ExCase arms, .rest -> ts3}
         }
       }
     }
     { if (isNextRBrace ts)
         { bindRight (expectRBrace ts) { ts2 ->
-            Right {val = ExCase (Cons (ExArm(Cons PatWild Nil, ExUnit)) Nil), rest = ts2}
+            Right {.val -> ExCase (Cons (ExArm(Cons PatWild Nil, ExUnit)) Nil), .rest -> ts2}
           }
         }
-        { bindRight (parseStmts ftable ts) { {val = body, rest = ts2} ->
+        { bindRight (parseStmts ftable ts) { {.val -> body, .rest -> ts2} ->
             if (isNextComma ts2)
-              { bindRight (nextTok ts2) { {rest = ts3} ->
-                  bindRight (parseBracedTupleRest ftable ts3) { {val = es, rest = ts4} ->
-                    Right {val = ExTuple (Cons body es), rest = ts4}
+              { bindRight (nextTok ts2) { {.rest -> ts3} ->
+                  bindRight (parseBracedTupleRest ftable ts3) { {.val -> es, .rest -> ts4} ->
+                    Right {.val -> ExTuple (Cons body es), .rest -> ts4}
                   }
                 }
               }
               { bindRight (expectRBrace ts2) { ts3 ->
-                  Right {val = ExCase (Cons (ExArm(Cons PatWild Nil, body)) Nil), rest = ts3}
+                  Right {.val -> ExCase (Cons (ExArm(Cons PatWild Nil, body)) Nil), .rest -> ts3}
                 }
               }
           }
@@ -852,20 +859,22 @@ def parseCaseLambda = { ftable ts ->
 
 def parseRecordExprFields : List FixityEntry -> List Token -> Either String {val: List ExprField, rest: List Token}
 def parseRecordExprFields = { ftable ts ->
-  bindRight (eatIdent ts) { {val = name, rest = ts2} ->
-    bindRight (expectOp "=" ts2) { ts3 ->
-      bindRight (parseOp ftable ts3) { {val = expr, rest = ts4} ->
-        if (isNextComma ts4)
-          { bindRight (nextTok ts4) { {rest = ts5} ->
-              if (isNextRBrace ts5)
-                { bindRight (expectRBrace ts5) { ts6 -> Right {val = Cons (ExprField(name, expr)) Nil, rest = ts6} } }
-                { bindRight (parseRecordExprFields ftable ts5) { {val = fs, rest = ts6} ->
-                    Right {val = Cons (ExprField(name, expr)) fs, rest = ts6}
+  bindRight (expectOp "." ts) { ts1 ->
+    bindRight (eatIdent ts1) { {.val -> name, .rest -> ts2} ->
+      bindRight (expectOp "->" ts2) { ts3 ->
+        bindRight (parseOp ftable ts3) { {.val -> expr, .rest -> ts4} ->
+          if (isNextComma ts4)
+            { bindRight (nextTok ts4) { {.rest -> ts5} ->
+                if (isNextRBrace ts5)
+                  { bindRight (expectRBrace ts5) { ts6 -> Right {.val -> Cons (ExprField(name, expr)) Nil, .rest -> ts6} } }
+                  { bindRight (parseRecordExprFields ftable ts5) { {.val -> fs, .rest -> ts6} ->
+                      Right {.val -> Cons (ExprField(name, expr)) fs, .rest -> ts6}
+                    }
                   }
-                }
+              }
             }
-          }
-          { bindRight (expectRBrace ts4) { ts5 -> Right {val = Cons (ExprField(name, expr)) Nil, rest = ts5} } }
+            { bindRight (expectRBrace ts4) { ts5 -> Right {.val -> Cons (ExprField(name, expr)) Nil, .rest -> ts5} } }
+        }
       }
     }
   }
@@ -873,41 +882,41 @@ def parseRecordExprFields = { ftable ts ->
 
 def parseCoArms : List FixityEntry -> List Token -> Either String {val: List Expr, rest: List Token}
 def parseCoArms = { ftable ts ->
-  bindRight (parseCoArm ftable ts) { {val = arm, rest = ts2} ->
+  bindRight (parseCoArm ftable ts) { {.val -> arm, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
           if (isNextRBrace ts3)
-            { Right {val = Cons arm Nil, rest = ts3} }
-            { bindRight (parseCoArms ftable ts3) { {val = arms, rest = ts4} ->
-                Right {val = Cons arm arms, rest = ts4}
+            { Right {.val -> Cons arm Nil, .rest -> ts3} }
+            { bindRight (parseCoArms ftable ts3) { {.val -> arms, .rest -> ts4} ->
+                Right {.val -> Cons arm arms, .rest -> ts4}
               }
             }
         }
       }
-      { Right {val = Cons arm Nil, rest = ts2} }
+      { Right {.val -> Cons arm Nil, .rest -> ts2} }
   }
 }
 
 def parseCoArm : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseCoArm = { ftable ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       (TkOp op) ->
         if (eqString op "#")
-          { bindRight (parseCoSegments ts2) { {val = segs, rest = ts3} ->
+          { bindRight (parseCoSegments ts2) { {.val -> segs, .rest -> ts3} ->
               bindRight (expectOp "->" ts3) { ts4 ->
-                bindRight (parseStmts ftable ts4) { {val = body, rest = ts5} ->
-                  Right {val = ExCoArm(segs, body), rest = ts5}
+                bindRight (parseStmts ftable ts4) { {.val -> body, .rest -> ts5} ->
+                  Right {.val -> ExCoArm(segs, body), .rest -> ts5}
                 }
               }
             }
           }
           { if (eqString op "#.")
-              { bindRight (eatIdent ts2) { {val = field, rest = ts3} ->
-                  bindRight (parseCoSegments ts3) { {val = segs, rest = ts4} ->
+              { bindRight (eatIdent ts2) { {.val -> field, .rest -> ts3} ->
+                  bindRight (parseCoSegments ts3) { {.val -> segs, .rest -> ts4} ->
                     bindRight (expectOp "->" ts4) { ts5 ->
-                      bindRight (parseStmts ftable ts5) { {val = body, rest = ts6} ->
-                        Right {val = ExCoArm(Cons (CoField field) segs, body), rest = ts6}
+                      bindRight (parseStmts ftable ts5) { {.val -> body, .rest -> ts6} ->
+                        Right {.val -> ExCoArm(Cons (CoField field) segs, body), .rest -> ts6}
                       }
                     }
                   }
@@ -923,21 +932,21 @@ def parseCoArm = { ftable ts ->
 def parseCoSegments : List Token -> Either String {val: List CoSeg, rest: List Token}
 def parseCoSegments = { ts ->
   if (isNextOpStr "->" ts)
-    { Right {val = Nil, rest = ts} }
+    { Right {.val -> Nil, .rest -> ts} }
     { if (isNextLParen ts)
         { bindRight (expectLParen ts) { ts2 ->
-            bindRight (parseParenArmPats ts2) { {val = pats, rest = ts3} ->
-              bindRight (parseCoSegments ts3) { {val = segs, rest = ts4} ->
-                Right {val = Cons (CoApply pats) segs, rest = ts4}
+            bindRight (parseParenArmPats ts2) { {.val -> pats, .rest -> ts3} ->
+              bindRight (parseCoSegments ts3) { {.val -> segs, .rest -> ts4} ->
+                Right {.val -> Cons (CoApply pats) segs, .rest -> ts4}
               }
             }
           }
         }
         { if (isNextDot ts)
-            { bindRight (nextTok ts) { {rest = ts2} ->
-                bindRight (eatIdent ts2) { {val = field, rest = ts3} ->
-                  bindRight (parseCoSegments ts3) { {val = segs, rest = ts4} ->
-                    Right {val = Cons (CoField field) segs, rest = ts4}
+            { bindRight (nextTok ts) { {.rest -> ts2} ->
+                bindRight (eatIdent ts2) { {.val -> field, .rest -> ts3} ->
+                  bindRight (parseCoSegments ts3) { {.val -> segs, .rest -> ts4} ->
+                    Right {.val -> Cons (CoField field) segs, .rest -> ts4}
                   }
                 }
               }
@@ -949,15 +958,15 @@ def parseCoSegments = { ts ->
 
 def parseBracedTupleRest : List FixityEntry -> List Token -> Either String {val: List Expr, rest: List Token}
 def parseBracedTupleRest = { ftable ts ->
-  bindRight (parseOp ftable ts) { {val = e, rest = ts2} ->
+  bindRight (parseOp ftable ts) { {.val -> e, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
-          bindRight (parseBracedTupleRest ftable ts3) { {val = es, rest = ts4} ->
-            Right {val = Cons e es, rest = ts4}
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
+          bindRight (parseBracedTupleRest ftable ts3) { {.val -> es, .rest -> ts4} ->
+            Right {.val -> Cons e es, .rest -> ts4}
           }
         }
       }
-      { bindRight (expectRBrace ts2) { ts3 -> Right {val = Cons e Nil, rest = ts3} } }
+      { bindRight (expectRBrace ts2) { ts3 -> Right {.val -> Cons e Nil, .rest -> ts3} } }
   }
 }
 
@@ -977,7 +986,14 @@ def hasTopLevelArrow = { ts depth ->
     (Cons TkLBracket rest) -> hasTopLevelArrow rest (addInt32 depth 1i32),
     (Cons (TkOp op) rest) ->
       if (eqString op "->")
-        { eqInt32 depth 0i32 }
+        -- An arrow at nonzero depth belongs to a nested structure (e.g. a
+        -- record field's `.field -> value`, or a lambda used as a field's
+        -- value) -- keep scanning for a real top-level one, don't bail out.
+        -- Never triggered before the `.field -> value` record syntax
+        -- (malgo#434): old-style `field = value` records had no internal
+        -- `->` at all, so this branch's `depth != 0` case was unreachable
+        -- until every record literal/pattern started containing one.
+        { if (eqInt32 depth 0i32) { True } { hasTopLevelArrow rest depth } }
         { hasTopLevelArrow rest depth },
     (Cons _ rest) -> hasTopLevelArrow rest depth
   }
@@ -986,7 +1002,7 @@ def hasTopLevelArrow = { ts depth ->
 -- Parse function application chain: atom atom atom ...
 def parseApp : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseApp = { ftable ts ->
-  bindRight (parseAtom ftable ts) { {val = f, rest = ts2} ->
+  bindRight (parseAtom ftable ts) { {.val -> f, .rest -> ts2} ->
     parseAppRest ftable f ts2
   }
 }
@@ -995,29 +1011,29 @@ def parseApp = { ftable ts ->
 def parseAppRest : List FixityEntry -> Expr -> List Token -> Either String {val: Expr, rest: List Token}
 def parseAppRest = { ftable f ts ->
   if (isNextDot ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (eatIdent ts2) { {val = field, rest = ts3} ->
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (eatIdent ts2) { {.val -> field, .rest -> ts3} ->
           parseAppRest ftable (ExField(f, field)) ts3
         }
       }
     }
     { if (isNextLParen ts)
         { if (canCStyleCall f)
-    { bindRight (parseCStyleCallArgs ftable ts) { {val = args, rest = ts2} ->
+    { bindRight (parseCStyleCallArgs ftable ts) { {.val -> args, .rest -> ts2} ->
         parseAppRest ftable (applyExprArgs f args) ts2
       }
     }
-          { bindRight (parseAtom ftable ts) { {val = x, rest = ts2} ->
+          { bindRight (parseAtom ftable ts) { {.val -> x, .rest -> ts2} ->
               parseAppRest ftable (ExApp(f, x)) ts2
             }
           }
         }
     { if (isAtomStart ts)
-    { bindRight (parseAtom ftable ts) { {val = x, rest = ts2} ->
+    { bindRight (parseAtom ftable ts) { {.val -> x, .rest -> ts2} ->
         parseAppRest ftable (ExApp(f, x)) ts2
       }
     }
-    { Right {val = f, rest = ts} }
+    { Right {.val -> f, .rest -> ts} }
     }
     }
 }
@@ -1033,10 +1049,10 @@ def parseCStyleCallArgs : List FixityEntry -> List Token -> Either String {val: 
 def parseCStyleCallArgs = { ftable ts ->
   bindRight (expectLParen ts) { ts2 ->
     if (isNextRParen ts2)
-      { bindRight (expectRParen ts2) { ts3 -> Right {val = Cons ExUnit Nil, rest = ts3} } }
-      { bindRight (parseOp ftable ts2) { {val = e, rest = ts3} ->
-          bindRight (parseCStyleCallArgsRest ftable ts3) { {val = es, rest = ts4} ->
-            Right {val = Cons e es, rest = ts4}
+      { bindRight (expectRParen ts2) { ts3 -> Right {.val -> Cons ExUnit Nil, .rest -> ts3} } }
+      { bindRight (parseOp ftable ts2) { {.val -> e, .rest -> ts3} ->
+          bindRight (parseCStyleCallArgsRest ftable ts3) { {.val -> es, .rest -> ts4} ->
+            Right {.val -> Cons e es, .rest -> ts4}
           }
         }
       }
@@ -1046,15 +1062,15 @@ def parseCStyleCallArgs = { ftable ts ->
 def parseCStyleCallArgsRest : List FixityEntry -> List Token -> Either String {val: List Expr, rest: List Token}
 def parseCStyleCallArgsRest = { ftable ts ->
   if (isNextComma ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (parseOp ftable ts2) { {val = e, rest = ts3} ->
-          bindRight (parseCStyleCallArgsRest ftable ts3) { {val = es, rest = ts4} ->
-            Right {val = Cons e es, rest = ts4}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (parseOp ftable ts2) { {.val -> e, .rest -> ts3} ->
+          bindRight (parseCStyleCallArgsRest ftable ts3) { {.val -> es, .rest -> ts4} ->
+            Right {.val -> Cons e es, .rest -> ts4}
           }
         }
       }
     }
-    { bindRight (expectRParen ts) { ts2 -> Right {val = Nil, rest = ts2} } }
+    { bindRight (expectRParen ts) { ts2 -> Right {.val -> Nil, .rest -> ts2} } }
 }
 
 def applyExprArgs : Expr -> List Expr -> Expr
@@ -1156,7 +1172,7 @@ def fixityTableHas = {
 -- Parse operator expression using Pratt parsing with precedence
 def parseOp : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseOp = { ftable ts ->
-  bindRight (parseApp ftable ts) { {val = lhs, rest = ts2} ->
+  bindRight (parseApp ftable ts) { {.val -> lhs, .rest -> ts2} ->
     parseOpPrecLoop 0i32 ftable lhs ts2
   }
 }
@@ -1170,17 +1186,17 @@ def parseOpPrecLoop = { minPrec ftable lhs ts ->
           let (FixityEntry _ prec assoc) = lookupFixity opName ftable;
           if (geInt32 prec minPrec)
             { let nextMinPrec = if (assocIsRight assoc) { prec } { addInt32 prec 1i32 };
-              bindRight (parseApp ftable rest) { {val = rhs, rest = ts3} ->
-                bindRight (parseOpPrecLoop nextMinPrec ftable rhs ts3) { {val = rhs2, rest = ts4} ->
+              bindRight (parseApp ftable rest) { {.val -> rhs, .rest -> ts3} ->
+                bindRight (parseOpPrecLoop nextMinPrec ftable rhs ts3) { {.val -> rhs2, .rest -> ts4} ->
                   parseOpPrecLoop minPrec ftable (ExApp(ExApp(ExVar opName, lhs), rhs2)) ts4
                 }
               }
             }
-            { Right {val = lhs, rest = ts} },
-        _ -> Right {val = lhs, rest = ts}
+            { Right {.val -> lhs, .rest -> ts} },
+        _ -> Right {.val -> lhs, .rest -> ts}
       }
     }
-    { Right {val = lhs, rest = ts} }
+    { Right {.val -> lhs, .rest -> ts} }
 }
 
 -- ────────────────────────────────────────────────────────────────────────────
@@ -1203,30 +1219,30 @@ def mkLetExpr = {
 def parseStmts : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseStmts = { ftable ts ->
   if (isNextRBrace ts)
-    { Right {val = ExUnit, rest = ts} }
+    { Right {.val -> ExUnit, .rest -> ts} }
     { if (isNextIdentStr "with" ts)
-      { bindRight (nextTok ts) { {rest = ts2} ->
+      { bindRight (nextTok ts) { {.rest -> ts2} ->
           parseWithStmt ftable ts2
         }
       }
       { if (isNextIdentStr "let" ts)
     -- let pat = e; rest
-      { bindRight (nextTok ts) { {rest = ts2} ->        -- consume 'let'
-        bindRight (parseAtomPat ts2) { {val = pat, rest = ts3} ->
+      { bindRight (nextTok ts) { {.rest -> ts2} ->        -- consume 'let'
+        bindRight (parseAtomPat ts2) { {.val -> pat, .rest -> ts3} ->
           bindRight (expectOp "=" ts3) { ts4 ->
-            bindRight (parseOp ftable ts4) { {val = val, rest = ts5} ->
+            bindRight (parseOp ftable ts4) { {.val -> val, .rest -> ts5} ->
               if (isNextOpStr ";" ts5)
-                { bindRight (nextTok ts5) { {rest = ts6} ->
-                    bindRight (parseStmts ftable ts6) { {val = body, rest = ts7} ->
-                      Right {val = mkLetExpr pat val body, rest = ts7}
+                { bindRight (nextTok ts5) { {.rest -> ts6} ->
+                    bindRight (parseStmts ftable ts6) { {.val -> body, .rest -> ts7} ->
+                      Right {.val -> mkLetExpr pat val body, .rest -> ts7}
                     }
                   }
                 }
                 { if (isNextRBrace ts5)
-                    { Right {val = mkLetExpr pat val ExUnit, rest = ts5} }
+                    { Right {.val -> mkLetExpr pat val ExUnit, .rest -> ts5} }
                     { bindRight (expectOp ";" ts5) { ts6 ->
-                        bindRight (parseStmts ftable ts6) { {val = body, rest = ts7} ->
-                          Right {val = mkLetExpr pat val body, rest = ts7}
+                        bindRight (parseStmts ftable ts6) { {.val -> body, .rest -> ts7} ->
+                          Right {.val -> mkLetExpr pat val body, .rest -> ts7}
                         }
                       }
                     }
@@ -1237,15 +1253,15 @@ def parseStmts = { ftable ts ->
       }
       }
       -- final expression or e; rest
-      { bindRight (parseOp ftable ts) { {val = expr, rest = ts2} ->
+      { bindRight (parseOp ftable ts) { {.val -> expr, .rest -> ts2} ->
           if (isNextOpStr ";" ts2)
-            { bindRight (nextTok ts2) { {rest = ts3} ->
-                bindRight (parseStmts ftable ts3) { {val = body, rest = ts4} ->
-                  Right {val = ExLet("_", expr, body), rest = ts4}
+            { bindRight (nextTok ts2) { {.rest -> ts3} ->
+                bindRight (parseStmts ftable ts3) { {.val -> body, .rest -> ts4} ->
+                  Right {.val -> ExLet("_", expr, body), .rest -> ts4}
                 }
               }
             }
-            { Right {val = expr, rest = ts2} }
+            { Right {.val -> expr, .rest -> ts2} }
         }
       }
     }
@@ -1255,22 +1271,22 @@ def parseStmts = { ftable ts ->
 def parseWithStmt : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseWithStmt = { ftable ts ->
   if (isWithBindStart ts)
-    { bindRight (eatIdent ts) { {val = name, rest = ts2} ->
+    { bindRight (eatIdent ts) { {.val -> name, .rest -> ts2} ->
         bindRight (expectOp "=" ts2) { ts3 ->
-          bindRight (parseOp ftable ts3) { {val = action, rest = ts4} ->
+          bindRight (parseOp ftable ts3) { {.val -> action, .rest -> ts4} ->
             bindRight (expectOp ";" ts4) { ts5 ->
-              bindRight (parseStmts ftable ts5) { {val = body, rest = ts6} ->
-                Right {val = ExApp(action, ExCase(Cons (ExArm(Cons (PatVar name) Nil, body)) Nil)), rest = ts6}
+              bindRight (parseStmts ftable ts5) { {.val -> body, .rest -> ts6} ->
+                Right {.val -> ExApp(action, ExCase(Cons (ExArm(Cons (PatVar name) Nil, body)) Nil)), .rest -> ts6}
               }
             }
           }
         }
       }
     }
-    { bindRight (parseOp ftable ts) { {val = action, rest = ts2} ->
+    { bindRight (parseOp ftable ts) { {.val -> action, .rest -> ts2} ->
         bindRight (expectOp ";" ts2) { ts3 ->
-          bindRight (parseStmts ftable ts3) { {val = body, rest = ts4} ->
-            Right {val = ExApp(action, ExCase(Cons (ExArm(Cons PatWild Nil, body)) Nil)), rest = ts4}
+          bindRight (parseStmts ftable ts3) { {.val -> body, .rest -> ts4} ->
+            Right {.val -> ExApp(action, ExCase(Cons (ExArm(Cons PatWild Nil, body)) Nil)), .rest -> ts4}
           }
         }
       }
@@ -1284,10 +1300,10 @@ def parseWithStmt = { ftable ts ->
 -- Parse one case arm: pats -> stmts
 def parseArm : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
 def parseArm = { ftable ts ->
-  bindRight (parseArmPats ts) { {val = pats, rest = ts2} ->
+  bindRight (parseArmPats ts) { {.val -> pats, .rest -> ts2} ->
     bindRight (expectOp "->" ts2) { ts3 ->
-      bindRight (parseStmts ftable ts3) { {val = body, rest = ts4} ->
-        Right {val = ExArm(pats, body), rest = ts4}
+      bindRight (parseStmts ftable ts3) { {.val -> body, .rest -> ts4} ->
+        Right {.val -> ExArm(pats, body), .rest -> ts4}
       }
     }
   }
@@ -1296,18 +1312,18 @@ def parseArm = { ftable ts ->
 -- Parse arms separated by ',' until '}' (does not consume '}')
 def parseArms : List FixityEntry -> List Token -> Either String {val: List Expr, rest: List Token}
 def parseArms = { ftable ts ->
-  bindRight (parseArm ftable ts) { {val = arm, rest = ts2} ->
+  bindRight (parseArm ftable ts) { {.val -> arm, .rest -> ts2} ->
     if (isNextComma ts2)
-      { bindRight (nextTok ts2) { {rest = ts3} ->
+      { bindRight (nextTok ts2) { {.rest -> ts3} ->
           if (isNextRBrace ts3)
-            { Right {val = Cons arm Nil, rest = ts3} }
-            { bindRight (parseArms ftable ts3) { {val = arms, rest = ts4} ->
-                Right {val = Cons arm arms, rest = ts4}
+            { Right {.val -> Cons arm Nil, .rest -> ts3} }
+            { bindRight (parseArms ftable ts3) { {.val -> arms, .rest -> ts4} ->
+                Right {.val -> Cons arm arms, .rest -> ts4}
               }
             }
         }
       }
-      { Right {val = Cons arm Nil, rest = ts2} }
+      { Right {.val -> Cons arm Nil, .rest -> ts2} }
   }
 }
 
@@ -1321,7 +1337,7 @@ def skipNestedParens : Int32 -> List Token -> Either String (List Token)
 def skipNestedParens = { depth ts ->
   if (eqInt32 depth 0i32)
     { Right ts }
-    { bindRight (nextTok ts) { {val = t, rest = ts2} ->
+    { bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
         case t {
           TkLParen -> skipNestedParens (addInt32 depth 1i32) ts2,
           TkRParen ->
@@ -1338,11 +1354,11 @@ def skipNestedParens = { depth ts ->
 -- Counts top-level commas + 1; handles nested parens
 def countCStyleArity : Int32 -> Int32 -> List Token -> Either String {val: Int32, rest: List Token}
 def countCStyleArity = { count depth ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRParen ->
         if (eqInt32 depth 0i32)
-          { Right {val = count, rest = ts2} }
+          { Right {.val -> count, .rest -> ts2} }
           { countCStyleArity count (subInt32 depth 1i32) ts2 },
       TkLParen -> countCStyleArity count (addInt32 depth 1i32) ts2,
       TkComma ->
@@ -1369,7 +1385,7 @@ def isTypeTokenStart = {
 def countSpaceArity : Int32 -> List Token -> Either String {val: Int32, rest: List Token}
 def countSpaceArity = { count ts ->
   if (isTypeTokenStart ts)
-    { bindRight (nextTok ts) { {val = t, rest = ts2} ->
+    { bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
         case t {
           -- Skip over parenthesized type group (counts as 1 field)
           TkLParen ->
@@ -1392,13 +1408,13 @@ def countSpaceArity = { count ts ->
         }
       }
     }
-    { Right {val = count, rest = ts} }
+    { Right {.val -> count, .rest -> ts} }
 }
 
 -- Skip to end of bracket group
 def skipToRBracket : List Token -> Either String (List Token)
 def skipToRBracket = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRBracket -> Right ts2,
       TkLBracket ->
@@ -1412,25 +1428,25 @@ def skipToRBracket = { ts ->
 -- Parse a single constructor declaration: Name | Name(T1,T2) | Name T1 T2
 def parseConDecl : List Token -> Either String {val: ConDecl, rest: List Token}
 def parseConDecl = { ts ->
-  bindRight (eatIdent ts) { {val = name, rest = ts2} ->
+  bindRight (eatIdent ts) { {.val -> name, .rest -> ts2} ->
     if (isNextLParen ts2)
       -- C-style: Name(T1, T2, ...) — count commas
       { bindRight (expectLParen ts2) { ts3 ->
           if (isNextRParen ts3)
             -- Empty: Name()
             { bindRight (expectRParen ts3) { ts4 ->
-                Right {val = ConDecl(name, 0i32), rest = ts4}
+                Right {.val -> ConDecl(name, 0i32), .rest -> ts4}
               }
             }
-            { bindRight (countCStyleArity 1i32 0i32 ts3) { {val = arity, rest = ts4} ->
-                Right {val = ConDecl(name, arity), rest = ts4}
+            { bindRight (countCStyleArity 1i32 0i32 ts3) { {.val -> arity, .rest -> ts4} ->
+                Right {.val -> ConDecl(name, arity), .rest -> ts4}
               }
             }
         }
       }
       -- Space-separated or nullary: count type atoms
-      { bindRight (countSpaceArity 0i32 ts2) { {val = arity, rest = ts3} ->
-          Right {val = ConDecl(name, arity), rest = ts3}
+      { bindRight (countSpaceArity 0i32 ts2) { {.val -> arity, .rest -> ts3} ->
+          Right {.val -> ConDecl(name, arity), .rest -> ts3}
         }
       }
   }
@@ -1440,23 +1456,23 @@ def parseConDecl = { ts ->
 def parseConDeclsRest : List Token -> Either String {val: List ConDecl, rest: List Token}
 def parseConDeclsRest = { ts ->
   if (isNextOpStr "|" ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (parseConDecl ts2) { {val = con, rest = ts3} ->
-          bindRight (parseConDeclsRest ts3) { {val = cons, rest = ts4} ->
-            Right {val = Cons con cons, rest = ts4}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (parseConDecl ts2) { {.val -> con, .rest -> ts3} ->
+          bindRight (parseConDeclsRest ts3) { {.val -> cons, .rest -> ts4} ->
+            Right {.val -> Cons con cons, .rest -> ts4}
           }
         }
       }
     }
-    { Right {val = Nil, rest = ts} }
+    { Right {.val -> Nil, .rest -> ts} }
 }
 
 -- Parse list of constructor declarations: ConDecl ('|' ConDecl)*
 def parseConDecls : List Token -> Either String {val: List ConDecl, rest: List Token}
 def parseConDecls = { ts ->
-  bindRight (parseConDecl ts) { {val = first, rest = ts2} ->
-    bindRight (parseConDeclsRest ts2) { {val = rest, rest = ts3} ->
-      Right {val = Cons first rest, rest = ts3}
+  bindRight (parseConDecl ts) { {.val -> first, .rest -> ts2} ->
+    bindRight (parseConDeclsRest ts2) { {.val -> rest, .rest -> ts3} ->
+      Right {.val -> Cons first rest, .rest -> ts3}
     }
   }
 }
@@ -1469,12 +1485,12 @@ def parseConDecls = { ts ->
 def parseTypeParams : List Token -> Either String {val: List String, rest: List Token}
 def parseTypeParams = { ts ->
   if (isNextOpStr "=" ts)
-    { Right {val = Nil, rest = ts} }
+    { Right {.val -> Nil, .rest -> ts} }
     { if (isNextLParen ts)
         { bindRight (expectLParen ts) { ts2 -> parseCStyleTypeParams ts2 } }
-        { bindRight (eatIdent ts) { {val = p, rest = ts2} ->
-            bindRight (parseTypeParams ts2) { {val = ps, rest = ts3} ->
-              Right {val = Cons p ps, rest = ts3}
+        { bindRight (eatIdent ts) { {.val -> p, .rest -> ts2} ->
+            bindRight (parseTypeParams ts2) { {.val -> ps, .rest -> ts3} ->
+              Right {.val -> Cons p ps, .rest -> ts3}
             }
           }
         }
@@ -1484,10 +1500,10 @@ def parseTypeParams = { ts ->
 def parseCStyleTypeParams : List Token -> Either String {val: List String, rest: List Token}
 def parseCStyleTypeParams = { ts ->
   if (isNextRParen ts)
-    { bindRight (expectRParen ts) { ts2 -> Right {val = Nil, rest = ts2} } }
-    { bindRight (eatIdent ts) { {val = p, rest = ts2} ->
-        bindRight (parseCStyleTypeParamsRest ts2) { {val = ps, rest = ts3} ->
-          Right {val = Cons p ps, rest = ts3}
+    { bindRight (expectRParen ts) { ts2 -> Right {.val -> Nil, .rest -> ts2} } }
+    { bindRight (eatIdent ts) { {.val -> p, .rest -> ts2} ->
+        bindRight (parseCStyleTypeParamsRest ts2) { {.val -> ps, .rest -> ts3} ->
+          Right {.val -> Cons p ps, .rest -> ts3}
         }
       }
     }
@@ -1496,15 +1512,15 @@ def parseCStyleTypeParams = { ts ->
 def parseCStyleTypeParamsRest : List Token -> Either String {val: List String, rest: List Token}
 def parseCStyleTypeParamsRest = { ts ->
   if (isNextComma ts)
-    { bindRight (nextTok ts) { {rest = ts2} ->
-        bindRight (eatIdent ts2) { {val = p, rest = ts3} ->
-          bindRight (parseCStyleTypeParamsRest ts3) { {val = ps, rest = ts4} ->
-            Right {val = Cons p ps, rest = ts4}
+    { bindRight (nextTok ts) { {.rest -> ts2} ->
+        bindRight (eatIdent ts2) { {.val -> p, .rest -> ts3} ->
+          bindRight (parseCStyleTypeParamsRest ts3) { {.val -> ps, .rest -> ts4} ->
+            Right {.val -> Cons p ps, .rest -> ts4}
           }
         }
       }
     }
-    { bindRight (expectRParen ts) { ts2 -> Right {val = Nil, rest = ts2} } }
+    { bindRight (expectRParen ts) { ts2 -> Right {.val -> Nil, .rest -> ts2} } }
 }
 
 -- Collect rest of type string as tokens until next declaration
@@ -1515,11 +1531,11 @@ def collectTypeStr = { ts ->
 
 def collectTypeStrAcc : String -> List Token -> {val: String, rest: List Token}
 def collectTypeStrAcc = {
-  acc Nil -> {val = acc, rest = Nil},
-  acc (Cons TkEof rest) -> {val = acc, rest = Cons TkEof rest},
+  acc Nil -> {.val -> acc, .rest -> Nil},
+  acc (Cons TkEof rest) -> {.val -> acc, .rest -> Cons TkEof rest},
   acc (Cons (TkIdent s) rest) ->
     if (isDeclStart s)
-      { {val = acc, rest = Cons (TkIdent s) rest} }
+      { {.val -> acc, .rest -> Cons (TkIdent s) rest} }
       { collectTypeStrAcc (appendString acc (appendString " " s)) rest },
   acc (Cons t rest) ->
     collectTypeStrAcc (appendString acc (appendString " " (showToken t))) rest
@@ -1544,16 +1560,16 @@ def collectRawTypeStr = { ts ->
 -- Parse a 'def name = expr' or 'def name : Type' (preserve type sig)
 def parseDefDecl : List FixityEntry -> List Token -> Either String {val: Maybe Decl, rest: List Token}
 def parseDefDecl = { ftable ts ->
-  bindRight (eatDefName ts) { {val = name, rest = ts2} ->
+  bindRight (eatDefName ts) { {.val -> name, .rest -> ts2} ->
     if (isNextOpStr ":" ts2)
       -- Type annotation: 'def name : Type' — preserve as DeclTypeSig
-      { let {val = tyStr, rest = ts3} = collectRawTypeStr ts2;
-        Right {val = Just (DeclTypeSig(name, tyStr)), rest = ts3}
+      { let {.val -> tyStr, .rest -> ts3} = collectRawTypeStr ts2;
+        Right {.val -> Just (DeclTypeSig(name, tyStr)), .rest -> ts3}
       }
       { if (isNextOpStr "=" ts2)
           { bindRight (expectOp "=" ts2) { ts3 ->
-              bindRight (parseExpr ftable ts3) { {val = expr, rest = ts4} ->
-                Right {val = Just (DeclDef(name, expr)), rest = ts4}
+              bindRight (parseExpr ftable ts3) { {.val -> expr, .rest -> ts4} ->
+                Right {.val -> Just (DeclDef(name, expr)), .rest -> ts4}
               }
             }
           }
@@ -1565,13 +1581,13 @@ def parseDefDecl = { ftable ts ->
 def eatDefName : List Token -> Either String {val: String, rest: List Token}
 def eatDefName = { ts ->
   case ts {
-    (Cons TkLParen (Cons (TkOp op) (Cons TkRParen rest))) -> Right {val = op, rest = rest},
+    (Cons TkLParen (Cons (TkOp op) (Cons TkRParen rest))) -> Right {.val -> op, .rest -> rest},
     _ -> eatIdent ts
   }
 }
 
 def skipNonRuntimeDecl : List Token -> Either String {val: Maybe Decl, rest: List Token}
-def skipNonRuntimeDecl = { ts -> Right {val = Nothing, rest = skipToNextDecl ts} }
+def skipNonRuntimeDecl = { ts -> Right {.val -> Nothing, .rest -> skipToNextDecl ts} }
 
 -- Parse a full expression (entry point for expression parsing)
 def parseExpr : List FixityEntry -> List Token -> Either String {val: Expr, rest: List Token}
@@ -1580,11 +1596,11 @@ def parseExpr = { ftable ts -> parseOp ftable ts }
 -- Parse a 'data Name Params = ConDecls' declaration
 def parseDataDecl : List Token -> Either String {val: Decl, rest: List Token}
 def parseDataDecl = { ts ->
-  bindRight (eatIdent ts) { {val = name, rest = ts2} ->
-    bindRight (parseTypeParams ts2) { {val = params, rest = ts3} ->
+  bindRight (eatIdent ts) { {.val -> name, .rest -> ts2} ->
+    bindRight (parseTypeParams ts2) { {.val -> params, .rest -> ts3} ->
       bindRight (expectOp "=" ts3) { ts4 ->
-        bindRight (parseConDecls ts4) { {val = cons, rest = ts5} ->
-          Right {val = DeclData(name, params, cons), rest = ts5}
+        bindRight (parseConDecls ts4) { {.val -> cons, .rest -> ts5} ->
+          Right {.val -> DeclData(name, params, cons), .rest -> ts5}
         }
       }
     }
@@ -1595,7 +1611,7 @@ def parseDataDecl = { ts ->
 -- or 'module {foo, (<|)} = import "path"'
 def parseModuleImport : List Token -> Either String {val: Decl, rest: List Token}
 def parseModuleImport = { ts ->
-  bindRight (parseImportTarget ts) { {val = target, rest = ts2} ->
+  bindRight (parseImportTarget ts) { {.val -> target, .rest -> ts2} ->
     bindRight (expectOp "=" ts2) { ts3 -> parseImportPath target ts3 }
   }
 }
@@ -1605,7 +1621,7 @@ def parseImportTarget = {
   (Cons TkLBrace rest) ->
     parseBraceImportTarget rest,
   (Cons (TkIdent alias) rest) ->
-    Right {val = ImportQualified alias, rest = rest},
+    Right {.val -> ImportQualified alias, .rest -> rest},
   _ -> Left "expected module import target"
 }
 
@@ -1614,7 +1630,7 @@ def parseBraceImportTarget = { ts ->
   case ts {
     (Cons (TkOp dots) rest) ->
       if (eqString dots "..")
-        { bindRight (expectRBrace rest) { ts2 -> Right {val = ImportAll, rest = ts2} } }
+        { bindRight (expectRBrace rest) { ts2 -> Right {.val -> ImportAll, .rest -> ts2} } }
         { parseImportOnly ts },
     _ -> parseImportOnly ts
   }
@@ -1622,38 +1638,38 @@ def parseBraceImportTarget = { ts ->
 
 def parseImportOnly : List Token -> Either String {val: ImportTarget, rest: List Token}
 def parseImportOnly = { ts ->
-  bindRight (parseImportNames ts) { {val = names, rest = ts2} ->
-    Right {val = ImportOnly names, rest = ts2}
+  bindRight (parseImportNames ts) { {.val -> names, .rest -> ts2} ->
+    Right {.val -> ImportOnly names, .rest -> ts2}
   }
 }
 
 def parseImportNames : List Token -> Either String {val: List ImportName, rest: List Token}
 def parseImportNames = { ts ->
   if (isNextRBrace ts)
-    { bindRight (expectRBrace ts) { ts2 -> Right {val = Nil, rest = ts2} } }
-    { bindRight (parseImportName ts) { {val = name, rest = ts2} ->
+    { bindRight (expectRBrace ts) { ts2 -> Right {.val -> Nil, .rest -> ts2} } }
+    { bindRight (parseImportName ts) { {.val -> name, .rest -> ts2} ->
         if (isNextComma ts2)
-          { bindRight (nextTok ts2) { {rest = ts3} ->
-              bindRight (parseImportNames ts3) { {val = names, rest = ts4} ->
-                Right {val = Cons name names, rest = ts4}
+          { bindRight (nextTok ts2) { {.rest -> ts3} ->
+              bindRight (parseImportNames ts3) { {.val -> names, .rest -> ts4} ->
+                Right {.val -> Cons name names, .rest -> ts4}
               }
             }
           }
-          { bindRight (expectRBrace ts2) { ts3 -> Right {val = Cons name Nil, rest = ts3} } }
+          { bindRight (expectRBrace ts2) { ts3 -> Right {.val -> Cons name Nil, .rest -> ts3} } }
       }
     }
 }
 
 def parseImportName : List Token -> Either String {val: ImportName, rest: List Token}
 def parseImportName = {
-  (Cons (TkIdent name) rest) -> Right {val = ImportName name, rest = rest},
-  (Cons TkLParen (Cons (TkOp op) (Cons TkRParen rest))) -> Right {val = ImportName op, rest = rest},
+  (Cons (TkIdent name) rest) -> Right {.val -> ImportName name, .rest -> rest},
+  (Cons TkLParen (Cons (TkOp op) (Cons TkRParen rest))) -> Right {.val -> ImportName op, .rest -> rest},
   _ -> Left "expected import name"
 }
 
 def skipToRBrace : List Token -> Either String (List Token)
 def skipToRBrace = { ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       TkRBrace -> Right ts2,
       TkLBrace ->
@@ -1666,12 +1682,12 @@ def skipToRBrace = { ts ->
 
 def parseImportPath : ImportTarget -> List Token -> Either String {val: Decl, rest: List Token}
 def parseImportPath = { target ts ->
-  bindRight (eatIdent ts) { {val = kw, rest = ts2} ->
+  bindRight (eatIdent ts) { {.val -> kw, .rest -> ts2} ->
     if (eqString kw "import")
-      { bindRight (nextTok ts2) { {val = t, rest = ts3} ->
+      { bindRight (nextTok ts2) { {.val -> t, .rest -> ts3} ->
           case t {
-            (TkString path) -> Right {val = DeclImport(target, path), rest = ts3},
-            (TkIdent path) -> Right {val = DeclImport(target, path), rest = ts3},
+            (TkString path) -> Right {.val -> DeclImport(target, path), .rest -> ts3},
+            (TkIdent path) -> Right {.val -> DeclImport(target, path), .rest -> ts3},
             _ -> Left (appendString "expected path string after 'import' but got " (showToken t))
           }
         }
@@ -1684,11 +1700,11 @@ def parseImportPath = { target ts ->
 def parseForeignDecl : List Token -> Either String {val: Decl, rest: List Token}
 def parseForeignDecl = { ts ->
   -- already consumed 'foreign', next should be 'import'
-  bindRight (eatIdent ts) { {val = kw, rest = ts2} ->
+  bindRight (eatIdent ts) { {.val -> kw, .rest -> ts2} ->
     if (eqString kw "import")
-      { bindRight (eatIdent ts2) { {val = name, rest = ts3} ->
-          let {val = tyStr, rest = ts4} = collectTypeStr ts3;
-          Right {val = DeclForeign(name, tyStr), rest = ts4}
+      { bindRight (eatIdent ts2) { {.val -> name, .rest -> ts3} ->
+          let {.val -> tyStr, .rest -> ts4} = collectTypeStr ts3;
+          Right {.val -> DeclForeign(name, tyStr), .rest -> ts4}
         }
       }
       { Left (appendString "expected 'import' after 'foreign' but got " kw) }
@@ -1698,22 +1714,22 @@ def parseForeignDecl = { ts ->
 -- Parse one declaration, returning Nothing for skipped forms
 def parseSingleDecl : List FixityEntry -> List Token -> Either String {val: Maybe Decl, rest: List Token}
 def parseSingleDecl = { ftable ts ->
-  bindRight (nextTok ts) { {val = t, rest = ts2} ->
+  bindRight (nextTok ts) { {.val -> t, .rest -> ts2} ->
     case t {
       (TkIdent s) ->
         case s {
           "def" -> parseDefDecl ftable ts2,
           "data" ->
-            bindRight (parseDataDecl ts2) { {val = d, rest = ts3} ->
-              Right {val = Just d, rest = ts3}
+            bindRight (parseDataDecl ts2) { {.val -> d, .rest -> ts3} ->
+              Right {.val -> Just d, .rest -> ts3}
             },
           "module" ->
-            bindRight (parseModuleImport ts2) { {val = d, rest = ts3} ->
-              Right {val = Just d, rest = ts3}
+            bindRight (parseModuleImport ts2) { {.val -> d, .rest -> ts3} ->
+              Right {.val -> Just d, .rest -> ts3}
             },
           "foreign" ->
-            bindRight (parseForeignDecl ts2) { {val = d, rest = ts3} ->
-              Right {val = Just d, rest = ts3}
+            bindRight (parseForeignDecl ts2) { {.val -> d, .rest -> ts3} ->
+              Right {.val -> Just d, .rest -> ts3}
             },
           "type" -> parseTypeSynonymDecl ts2,
           "infix" -> parseInfixDecl "none" ts2,
@@ -1730,11 +1746,11 @@ def parseSingleDecl = { ftable ts ->
 -- Parse 'type Name params = rawType'
 def parseTypeSynonymDecl : List Token -> Either String {val: Maybe Decl, rest: List Token}
 def parseTypeSynonymDecl = { ts ->
-  bindRight (eatIdent ts) { {val = name, rest = ts2} ->
-    bindRight (parseTypeParams ts2) { {val = params, rest = ts3} ->
+  bindRight (eatIdent ts) { {.val -> name, .rest -> ts2} ->
+    bindRight (parseTypeParams ts2) { {.val -> params, .rest -> ts3} ->
       bindRight (expectOp "=" ts3) { ts4 ->
-        let {val = tyStr, rest = ts5} = collectTypeStr ts4;
-        Right {val = Just (DeclTypeSynonym(name, params, tyStr)), rest = ts5}
+        let {.val -> tyStr, .rest -> ts5} = collectTypeStr ts4;
+        Right {.val -> Just (DeclTypeSynonym(name, params, tyStr)), .rest -> ts5}
       }
     }
   }
@@ -1745,10 +1761,10 @@ def parseInfixDecl : String -> List Token -> Either String {val: Maybe Decl, res
 def parseInfixDecl = { assocStr ts ->
   case ts {
     (Cons (TkInt32 prec) (Cons (TkOp op) rest)) ->
-      Right {val = Just (DeclInfix(assocStr, prec, op)), rest = rest},
+      Right {.val -> Just (DeclInfix(assocStr, prec, op)), .rest -> rest},
     (Cons (TkInt32 prec) (Cons TkLParen (Cons (TkOp op) (Cons TkRParen rest)))) ->
-      Right {val = Just (DeclInfix(assocStr, prec, op)), rest = rest},
-    _ -> Right {val = Nothing, rest = skipToNextDecl ts}
+      Right {.val -> Just (DeclInfix(assocStr, prec, op)), .rest -> rest},
+    _ -> Right {.val -> Nothing, .rest -> skipToNextDecl ts}
   }
 }
 
@@ -1756,12 +1772,12 @@ def parseInfixDecl = { assocStr ts ->
 def parseAllDecls : List FixityEntry -> List Token -> Either String {val: List Decl, rest: List Token}
 def parseAllDecls = { ftable ts ->
   if (isNextEof ts)
-    { Right {val = Nil, rest = ts} }
-    { bindRight (parseSingleDecl ftable ts) { {val = md, rest = ts2} ->
-        bindRight (parseAllDecls ftable ts2) { {val = ds, rest = ts3} ->
+    { Right {.val -> Nil, .rest -> ts} }
+    { bindRight (parseSingleDecl ftable ts) { {.val -> md, .rest -> ts2} ->
+        bindRight (parseAllDecls ftable ts2) { {.val -> ds, .rest -> ts3} ->
           case md {
-            Nothing -> Right {val = ds, rest = ts3},
-            (Just d) -> Right {val = Cons d ds, rest = ts3}
+            Nothing -> Right {.val -> ds, .rest -> ts3},
+            (Just d) -> Right {.val -> Cons d ds, .rest -> ts3}
           }
         }
       }
@@ -1776,7 +1792,7 @@ def parseModule : List Token -> Either String Module
 def parseModule = { ts ->
   let userFixity = collectFixityTable ts;
   let ftable = mergeFixityTables userFixity defaultFixityTable;
-  bindRight (parseAllDecls ftable ts) { {val = decls, rest = _} ->
+  bindRight (parseAllDecls ftable ts) { {.val -> decls, .rest -> _} ->
     Right (Module decls)
   }
 }

--- a/runtime/malgo/compiler/ToFun.mlg
+++ b/runtime/malgo/compiler/ToFun.mlg
@@ -7,16 +7,16 @@ module {..} = import "../../../runtime/malgo/compiler/FunIR.mlg"
 
 def freshName : Int32 -> String -> {count: Int32, name: String}
 def freshName = { count prefix ->
-  {count = addInt32 count 1i32, name = appendString prefix (toStringInt32 count)}
+  {.count -> addInt32 count 1i32, .name -> appendString prefix (toStringInt32 count)}
 }
 
 def makeNFreshParams : Int32 -> Int32 -> String -> {count: Int32, params: List String}
 def makeNFreshParams = { count n prefix ->
   if (eqInt32 n 0i32)
-    { {count = count, params = Nil} }
+    { {.count -> count, .params -> Nil} }
     { let nr = freshName count prefix;
       let restr = makeNFreshParams nr.count (subInt32 n 1i32) prefix;
-      {count = restr.count, params = append (Cons nr.name Nil) restr.params}
+      {.count -> restr.count, .params -> append (Cons nr.name Nil) restr.params}
     }
 }
 
@@ -91,45 +91,45 @@ def caseArity = {
 def lowerExpr : Int32 -> Expr -> {count: Int32, expr: FunExpr}
 def lowerExpr = {
   count (ExVar name) ->
-    {count = count, expr = FunVar name},
+    {.count -> count, .expr -> FunVar name},
   count (ExLit lit) ->
-    {count = count, expr = FunLiteral (lowerLit lit)},
+    {.count -> count, .expr -> FunLiteral (lowerLit lit)},
   count ExUnit ->
-    {count = count, expr = FunConstruct(FunTagTuple, Nil)},
+    {.count -> count, .expr -> FunConstruct(FunTagTuple, Nil)},
   count (ExApp f x) ->
     let fr = lowerExpr count f;
     let xr = lowerExpr fr.count x;
-    {count = xr.count, expr = FunApply(fr.expr, Cons xr.expr Nil)},
+    {.count -> xr.count, .expr -> FunApply(fr.expr, Cons xr.expr Nil)},
   count (ExLet name bindE body) ->
     let er = lowerExpr count bindE;
     let br = lowerExpr er.count body;
-    {count = br.count, expr = FunLet(name, er.expr, br.expr)},
+    {.count -> br.count, .expr -> FunLet(name, er.expr, br.expr)},
   count (ExCase arms) ->
     lowerCase count arms,
   count (ExCoCase arms) ->
     lowerCoCase count arms,
   count (ExRecord fields) ->
     let fr = lowerExprFields count fields;
-    {count = fr.count, expr = FunObject fr.fields},
+    {.count -> fr.count, .expr -> FunObject fr.fields},
   count (ExField e field) ->
     let er = lowerExpr count e;
-    {count = er.count, expr = FunProject(er.expr, field)},
+    {.count -> er.count, .expr -> FunProject(er.expr, field)},
   count (ExTuple exprs) ->
     let er = lowerExprs count exprs;
-    {count = er.count, expr = FunConstruct(FunTagTuple, er.exprs)},
+    {.count -> er.count, .expr -> FunConstruct(FunTagTuple, er.exprs)},
   count (ExArm _ _) ->
-    {count = count, expr = FunLiteral(FunLitString "error: bare arm")},
+    {.count -> count, .expr -> FunLiteral(FunLitString "error: bare arm")},
   count (ExCoArm _ _) ->
-    {count = count, expr = FunLiteral(FunLitString "error: bare coarm")}
+    {.count -> count, .expr -> FunLiteral(FunLitString "error: bare coarm")}
 }
 
 def lowerExprs : Int32 -> List Expr -> {count: Int32, exprs: List FunExpr}
 def lowerExprs = {
-  count Nil -> {count = count, exprs = Nil},
+  count Nil -> {.count -> count, .exprs -> Nil},
   count (Cons e rest) ->
     let er = lowerExpr count e;
     let restr = lowerExprs er.count rest;
-    {count = restr.count, exprs = Cons er.expr restr.exprs}
+    {.count -> restr.count, .exprs -> Cons er.expr restr.exprs}
 }
 
 -- ── ExCase lowering ───────────────────────────────────────────────────────────
@@ -143,7 +143,7 @@ def lowerCase = { count arms ->
       let outerParam = headParam pr.params;
       let restParams = tailParams pr.params;
       let br = lowerCaseArms pr.count restParams arms;
-      {count = br.count, expr = FunLambda(pr.params, FunSelect(FunVar outerParam, br.branches))}
+      {.count -> br.count, .expr -> FunLambda(pr.params, FunSelect(FunVar outerParam, br.branches))}
     }
 }
 
@@ -151,21 +151,21 @@ def lowerCase = { count arms ->
 def lowerZeroArityCase : Int32 -> List Expr -> {count: Int32, expr: FunExpr}
 def lowerZeroArityCase = {
   count Nil ->
-    {count = count, expr = FunLambda(Nil, FunLiteral(FunLitString "error: no arm"))},
+    {.count -> count, .expr -> FunLambda(Nil, FunLiteral(FunLitString "error: no arm"))},
   count (Cons (ExArm _ body) _) ->
     let br = lowerExpr count body;
-    {count = br.count, expr = FunLambda(Nil, br.expr)},
+    {.count -> br.count, .expr -> FunLambda(Nil, br.expr)},
   count (Cons _ _) ->
-    {count = count, expr = FunLambda(Nil, FunLiteral(FunLitString "error: bad arm"))}
+    {.count -> count, .expr -> FunLambda(Nil, FunLiteral(FunLitString "error: bad arm"))}
 }
 
 def lowerCaseArms : Int32 -> List String -> List Expr -> {count: Int32, branches: List FunBranch}
 def lowerCaseArms = {
-  count restParams Nil -> {count = count, branches = Nil},
+  count restParams Nil -> {.count -> count, .branches -> Nil},
   count restParams (Cons arm rest) ->
     let ar = lowerCaseArm count restParams arm;
     let restr = lowerCaseArms ar.count restParams rest;
-    {count = restr.count, branches = Cons ar.branch restr.branches}
+    {.count -> restr.count, .branches -> Cons ar.branch restr.branches}
 }
 
 def lowerCaseArm : Int32 -> List String -> Expr -> {count: Int32, branch: FunBranch}
@@ -174,13 +174,13 @@ def lowerCaseArm = {
     let br = lowerExpr count body;
     case pats {
       Nil ->
-        {count = br.count, branch = FunBranch(FunPWild, br.expr)},
+        {.count -> br.count, .branch -> FunBranch(FunPWild, br.expr)},
       (Cons outerPat restPats) ->
         let branchBody = buildBranchBody restParams restPats br.expr;
-        {count = br.count, branch = FunBranch(lowerPat outerPat, branchBody)}
+        {.count -> br.count, .branch -> FunBranch(lowerPat outerPat, branchBody)}
     },
   count restParams _ ->
-    {count = count, branch = FunBranch(FunPWild, FunLiteral(FunLitString "error: bad arm"))}
+    {.count -> count, .branch -> FunBranch(FunPWild, FunLiteral(FunLitString "error: bad arm"))}
 }
 
 -- ── ExCoCase lowering ─────────────────────────────────────────────────────────
@@ -196,32 +196,32 @@ def lowerCoCase : Int32 -> List Expr -> {count: Int32, expr: FunExpr}
 def lowerCoCase = { count arms ->
   if (allFieldCoArms arms)
     { let fr = lowerCoArmFields count arms;
-      {count = fr.count, expr = FunObject fr.fields}
+      {.count -> fr.count, .expr -> FunObject fr.fields}
     }
     { let nr = freshName count "co";
       let br = lowerCoApplyBranches nr.count arms;
-      {count = br.count, expr = FunLambda(Cons nr.name Nil, FunSelect(FunVar nr.name, br.branches))}
+      {.count -> br.count, .expr -> FunLambda(Cons nr.name Nil, FunSelect(FunVar nr.name, br.branches))}
     }
 }
 
 def lowerCoArmFields : Int32 -> List Expr -> {count: Int32, fields: List FunField}
 def lowerCoArmFields = {
-  count Nil -> {count = count, fields = Nil},
+  count Nil -> {.count -> count, .fields -> Nil},
   count (Cons (ExCoArm (Cons (CoField field) _) body) rest) ->
     let br = lowerExpr count body;
     let restr = lowerCoArmFields br.count rest;
-    {count = restr.count, fields = Cons (FunField(field, br.expr)) restr.fields},
+    {.count -> restr.count, .fields -> Cons (FunField(field, br.expr)) restr.fields},
   count (Cons _ rest) -> lowerCoArmFields count rest
 }
 
 def lowerCoApplyBranches : Int32 -> List Expr -> {count: Int32, branches: List FunBranch}
 def lowerCoApplyBranches = {
-  count Nil -> {count = count, branches = Nil},
+  count Nil -> {.count -> count, .branches -> Nil},
   count (Cons (ExCoArm segs body) rest) ->
     let pat = coSegsToFunPat segs;
     let br = lowerExpr count body;
     let restr = lowerCoApplyBranches br.count rest;
-    {count = restr.count, branches = Cons (FunBranch(pat, br.expr)) restr.branches},
+    {.count -> restr.count, .branches -> Cons (FunBranch(pat, br.expr)) restr.branches},
   count (Cons _ rest) -> lowerCoApplyBranches count rest
 }
 
@@ -238,11 +238,11 @@ def coSegsToFunPat = {
 
 def lowerExprFields : Int32 -> List ExprField -> {count: Int32, fields: List FunField}
 def lowerExprFields = {
-  count Nil -> {count = count, fields = Nil},
+  count Nil -> {.count -> count, .fields -> Nil},
   count (Cons (ExprField n e) rest) ->
     let er = lowerExpr count e;
     let restr = lowerExprFields er.count rest;
-    {count = restr.count, fields = Cons (FunField(n, er.expr)) restr.fields}
+    {.count -> restr.count, .fields -> Cons (FunField(n, er.expr)) restr.fields}
 }
 
 -- ── Declaration lowering ──────────────────────────────────────────────────────
@@ -251,48 +251,48 @@ def lowerDecl : Int32 -> Decl -> {count: Int32, defs: List FunDef}
 def lowerDecl = {
   count (DeclDef name expr) ->
     let er = lowerExpr count expr;
-    {count = er.count, defs = Cons (FunDef(name, er.expr)) Nil},
+    {.count -> er.count, .defs -> Cons (FunDef(name, er.expr)) Nil},
   count (DeclData _ _ cons) ->
     lowerConstructors count cons,
   count (DeclForeign name _) ->
-    {count = count, defs = Cons (FunDef(name, FunPrimitive(name, Nil))) Nil},
+    {.count -> count, .defs -> Cons (FunDef(name, FunPrimitive(name, Nil))) Nil},
   count (DeclImport _ _) ->
-    {count = count, defs = Nil},
+    {.count -> count, .defs -> Nil},
   count (DeclTypeSig _ _) ->
-    {count = count, defs = Nil},
+    {.count -> count, .defs -> Nil},
   count (DeclTypeSynonym _ _ _) ->
-    {count = count, defs = Nil},
+    {.count -> count, .defs -> Nil},
   count (DeclInfix _ _ _) ->
-    {count = count, defs = Nil}
+    {.count -> count, .defs -> Nil}
 }
 
 def lowerConstructors : Int32 -> List ConDecl -> {count: Int32, defs: List FunDef}
 def lowerConstructors = {
-  count Nil -> {count = count, defs = Nil},
+  count Nil -> {.count -> count, .defs -> Nil},
   count (Cons (ConDecl name arity) rest) ->
     let dr = makeConstructorDef count name arity;
     let restr = lowerConstructors dr.count rest;
-    {count = restr.count, defs = append dr.defs restr.defs}
+    {.count -> restr.count, .defs -> append dr.defs restr.defs}
 }
 
 def makeConstructorDef : Int32 -> String -> Int32 -> {count: Int32, defs: List FunDef}
 def makeConstructorDef = { count name arity ->
   if (eqInt32 arity 0i32)
-    { {count = count, defs = Cons (FunDef(name, FunConstruct(FunTagCon name, Nil))) Nil} }
+    { {.count -> count, .defs -> Cons (FunDef(name, FunConstruct(FunTagCon name, Nil))) Nil} }
     { let pr = makeNFreshParams count arity "con";
       let params = pr.params;
       let body = FunConstruct(FunTagCon name, mapList { s -> FunVar s } params);
-      {count = pr.count, defs = Cons (FunDef(name, FunLambda(params, body))) Nil}
+      {.count -> pr.count, .defs -> Cons (FunDef(name, FunLambda(params, body))) Nil}
     }
 }
 
 def lowerDecls : Int32 -> List Decl -> {count: Int32, defs: List FunDef}
 def lowerDecls = {
-  count Nil -> {count = count, defs = Nil},
+  count Nil -> {.count -> count, .defs -> Nil},
   count (Cons d rest) ->
     let dr = lowerDecl count d;
     let restr = lowerDecls dr.count rest;
-    {count = restr.count, defs = append dr.defs restr.defs}
+    {.count -> restr.count, .defs -> append dr.defs restr.defs}
 }
 
 -- ── Module lowering ───────────────────────────────────────────────────────────

--- a/scripts/migrate-record-syntax.py
+++ b/scripts/migrate-record-syntax.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Rewrite malgo record-literal/pattern field syntax from `{field = v}` to
+`{.field -> v}` (malgo#434 -- unifies record syntax with codata's `.field`
+projection sigil).
+
+A single left-to-right scan tracks: string literals (`"..."`, with `\\`
+escapes), line comments (`--`), block comments (`{- ... -}`, non-nesting --
+matches the real lexer in lean/Malgo/Parser/Prim.lean), and a delimiter
+stack ('{'/'('/'['). Entering a brace is classified as a record context
+exactly the way the real parser does: an identifier immediately followed
+by a lone `=` (not `==`, not `=>`) -- same signal `pRecordField`/
+`isRecordStart` already key off. Once inside a record context, the same
+check re-fires after each top-level `,` for the next field. Every matched
+field's `ident = ` is rewritten to `.ident -> ` in place; nothing else in
+the file is touched, so nested records, unrelated `def`/`let` bindings,
+tuples (`{e1, e2}`, no `=`), type-level records (`{field: T}`, `:` not
+`=`), and import selectors (`{..}`/`{foo, bar}`) are left alone.
+
+Usage:
+    python3 scripts/migrate-record-syntax.py [--check] PATH...
+
+    --check   Report files that would change (exit 1 if any) without
+              writing them. Otherwise rewrites files in place.
+
+PATH may be a file or a directory (recursed for *.mlg).
+"""
+
+import sys
+from pathlib import Path
+
+IDENT_START = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_")
+IDENT_CONT = IDENT_START | set("0123456789")
+OP_CHARS = set("+-*/\\%=><:;|&!#.~")
+
+
+def skip_ws_and_comments(s, i):
+    """Advance i past whitespace, line comments, and block comments."""
+    n = len(s)
+    while i < n:
+        c = s[i]
+        if c in " \t\r\n":
+            i += 1
+        elif s.startswith("--", i):
+            j = s.find("\n", i)
+            i = n if j == -1 else j
+        elif s.startswith("{-", i):
+            j = s.find("-}", i + 2)
+            if j == -1:
+                return n  # unterminated block comment; let the compiler complain
+            i = j + 2
+        else:
+            break
+    return i
+
+
+def read_ident(s, i):
+    """If s[i:] starts with an identifier, return (ident, end_index); else None."""
+    if i >= len(s) or s[i] not in IDENT_START:
+        return None
+    j = i + 1
+    while j < len(s) and s[j] in IDENT_CONT:
+        j += 1
+    return s[i:j], j
+
+
+def read_op_run(s, i):
+    """Return (op_text, end_index) for the maximal run of operator chars at i."""
+    j = i
+    while j < len(s) and s[j] in OP_CHARS:
+        j += 1
+    return s[i:j], j
+
+
+def check_record_field_start(s, i):
+    """At position i (past '{' or a top-level ','), check for `ident '=' `
+    (a lone `=`, not `==`/`=>`/etc). Returns (ident, ident_start, ident_end,
+    eq_start, eq_end) or None."""
+    j = skip_ws_and_comments(s, i)
+    ident_hit = read_ident(s, j)
+    if ident_hit is None:
+        return None
+    ident, ident_end = ident_hit
+    k = skip_ws_and_comments(s, ident_end)
+    op, op_end = read_op_run(s, k)
+    if op != "=":
+        return None
+    return (ident, j, ident_end, k, op_end)
+
+
+def migrate(text):
+    """Return (new_text, changed) with every record field's `ident = `
+    rewritten to `.ident -> `."""
+    edits = []  # (start, end, replacement), start<end, non-overlapping, in order
+    stack = []  # 'record' | 'other', one entry per currently-open '{'/'('/'['
+    i = 0
+    n = len(text)
+    in_string = False
+
+    while i < n:
+        c = text[i]
+
+        if in_string:
+            if c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if c == '"':
+            in_string = True
+            i += 1
+            continue
+
+        if c == "'":
+            # Char literal: 'x' or an escape like '\n'/'\''/'\\' -- always
+            # exactly one logical character between quotes. Must be skipped
+            # as an atomic unit: a literal like '{'/'['/'('/','/'"' would
+            # otherwise be misread as a real delimiter and corrupt the
+            # brace-depth stack for everything that follows in the file.
+            j = i + 1
+            if j < n and text[j] == "\\":
+                j += 2
+            else:
+                j += 1
+            if j < n and text[j] == "'":
+                j += 1
+            i = j
+            continue
+
+        if text.startswith("--", i):
+            j = text.find("\n", i)
+            i = n if j == -1 else j
+            continue
+
+        if text.startswith("{-", i):
+            j = text.find("-}", i + 2)
+            i = n if j == -1 else j + 2
+            continue
+
+        if c == "{":
+            hit = check_record_field_start(text, i + 1)
+            if hit is not None:
+                ident, ident_start, ident_end, eq_start, eq_end = hit
+                edits.append((ident_start, ident_start, "."))
+                edits.append((eq_start, eq_end, "->"))
+                stack.append("record")
+                i = eq_end
+                continue
+            stack.append("other")
+            i += 1
+            continue
+
+        if c in "([":
+            stack.append("other")
+            i += 1
+            continue
+
+        if c in "}])":
+            if stack:
+                stack.pop()
+            i += 1
+            continue
+
+        if c == "," and stack and stack[-1] == "record":
+            hit = check_record_field_start(text, i + 1)
+            if hit is not None:
+                ident, ident_start, ident_end, eq_start, eq_end = hit
+                edits.append((ident_start, ident_start, "."))
+                edits.append((eq_start, eq_end, "->"))
+                i = eq_end
+                continue
+            i += 1
+            continue
+
+        i += 1
+
+    if not edits:
+        return text, False
+
+    out = []
+    pos = 0
+    for start, end, replacement in edits:
+        out.append(text[pos:start])
+        out.append(replacement)
+        pos = end
+    out.append(text[pos:])
+    return "".join(out), True
+
+
+def iter_mlg_files(paths):
+    for p in paths:
+        path = Path(p)
+        if path.is_dir():
+            yield from sorted(path.rglob("*.mlg"))
+        elif path.suffix == ".mlg":
+            yield path
+        else:
+            yield path  # let it fail loudly if it's not actually text
+
+
+def main(argv):
+    check = "--check" in argv
+    args = [a for a in argv if a != "--check"]
+    if not args:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    changed_files = []
+    for path in iter_mlg_files(args):
+        text = path.read_text()
+        new_text, changed = migrate(text)
+        if changed:
+            changed_files.append(path)
+            if not check:
+                path.write_text(new_text)
+
+    for path in changed_files:
+        print(f"{'would change' if check else 'rewrote'}: {path}")
+    print(f"{len(changed_files)} file(s) {'would change' if check else 'rewritten'}")
+
+    return 1 if (check and changed_files) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/testcases/malgo/Eventually.mlg
+++ b/test/testcases/malgo/Eventually.mlg
@@ -11,8 +11,8 @@ type EventuallyBuilder a b = {
 
 def eventually : EventuallyBuilder a b
 def eventually = {
-  bind = eventuallyBind,
-  return = Done,
+  .bind -> eventuallyBind,
+  .return -> Done,
 }
 
 def eventuallyBind : Eventually a -> (a -> Eventually b) -> Eventually b
@@ -27,10 +27,10 @@ def step =
   }
 
 def bind : EventuallyBuilder a b -> Eventually a -> (a -> Eventually b) -> Eventually b
-def bind = { { bind = x, return = _ } -> x }
+def bind = { { .bind -> x, .return -> _ } -> x }
 
 def return : EventuallyBuilder a b -> a -> Eventually a
-def return = { { bind = _, return = x } -> x }
+def return = { { .bind -> _, .return -> x } -> x }
 
 def comp : Eventually Int32
 def comp =

--- a/test/testcases/malgo/Fib.mlg
+++ b/test/testcases/malgo/Fib.mlg
@@ -4,14 +4,14 @@ module {..} = import "../../../runtime/malgo/Prelude.mlg"
 type Stream a = { head: a, tail: Stream a }
 
 def streamZipWith = { f xs ys ->
-  { head = f(xs.head, ys.head),
-    tail = streamZipWith(f, xs.tail, ys.tail)
+  { .head -> f(xs.head, ys.head),
+    .tail -> streamZipWith(f, xs.tail, ys.tail)
   }
 }
 
 def fib = {
-  head = 1i64,
-  tail = { head = 1i64, tail = streamZipWith(addInt64, fib, fib.tail) }
+  .head -> 1i64,
+  .tail -> { .head -> 1i64, .tail -> streamZipWith(addInt64, fib, fib.tail) }
 }
 
 def main = {

--- a/test/testcases/malgo/FieldPrefix.mlg
+++ b/test/testcases/malgo/FieldPrefix.mlg
@@ -5,23 +5,23 @@ type Point2D = { x : Int32, y : Int32 }
 
 type Point3D = { x : Float, y : Float, z : Float }
 
-def print2D = { { x = x, y = y } ->
+def print2D = { { .x -> x, .y -> y } ->
   printString (toStringInt32 x);
   printString ", ";
   printString (toStringInt32 y)
 }
 
 def x2D : Point2D -> Int32
-def x2D = { { x = x, y = _ } -> x }
+def x2D = { { .x -> x, .y -> _ } -> x }
 
 def y2D : Point2D -> Int32
-def y2D = { { x = _, y = y } -> y }
+def y2D = { { .x -> _, .y -> y } -> y }
 
 def zero2D : Point2D
-def zero2D = { x = 0, y = 0 }
+def zero2D = { .x -> 0, .y -> 0 }
 
 def zero3D : Point3D
-def zero3D = { x = 0.0f32, y = 0.0f32, z = 0.0f32 }
+def zero3D = { .x -> 0.0f32, .y -> 0.0f32, .z -> 0.0f32 }
 
 def main = {
   print2D zero2D

--- a/test/testcases/malgo/LetPattern.mlg
+++ b/test/testcases/malgo/LetPattern.mlg
@@ -6,10 +6,10 @@ module {..} = import "../../../runtime/malgo/Prelude.mlg"
 
 data Pair a b = Pair a b
 
-def mkRec = { a b -> {fst = a, snd = b} }
+def mkRec = { a b -> {.fst -> a, .snd -> b} }
 
 def main = {
-  let {fst = x, snd = y} = mkRec "hello" "world";
+  let {.fst -> x, .snd -> y} = mkRec "hello" "world";
   let (Pair p q) = Pair x y;
   let _ = putStrLn p;
   putStrLn q

--- a/test/testcases/malgo/NestedRecursive.mlg
+++ b/test/testcases/malgo/NestedRecursive.mlg
@@ -25,11 +25,11 @@ type A = { getB: B, val: Int32 }
 type B = { getA: A, val: Int32 }
 
 def mkA = { n ->
-  { val = n, getB = mkB(addInt32(n, 1)) }
+  { .val -> n, .getB -> mkB(addInt32(n, 1)) }
 }
 
 def mkB = { n ->
-  { val = n, getA = mkA(addInt32(n, 1)) }
+  { .val -> n, .getA -> mkA(addInt32(n, 1)) }
 }
 
 def main = { (_) ->

--- a/test/testcases/malgo/PrintFormats.mlg
+++ b/test/testcases/malgo/PrintFormats.mlg
@@ -25,6 +25,6 @@ module {..} = import "../../../runtime/malgo/Prelude.mlg"
 data Marker = Marker#
 
 def main = { () ->
-  print({ a = 1, b = 2 });
+  print({ .a -> 1, .b -> 2 });
   print(Marker#)
 }

--- a/test/testcases/malgo/RecordFieldAccess.mlg
+++ b/test/testcases/malgo/RecordFieldAccess.mlg
@@ -3,11 +3,11 @@ module {..} = import "../../../runtime/malgo/Prelude.mlg"
 
 data B = B { a: Int32, b: Int32 }
 
-def f = { { a = a, b = _ } -> a }
+def f = { { .a -> a, .b -> _ } -> a }
 
-def g = { B { a = a, b = _ } -> a }
+def g = { B { .a -> a, .b -> _ } -> a }
 
 def main = {
-  let x = { a = 32, b = 10 };
+  let x = { .a -> 32, .b -> 10 };
   printString (toStringInt32 (addInt32(f x, x.b)))
 }

--- a/test/testcases/malgo/RecordTest.mlg
+++ b/test/testcases/malgo/RecordTest.mlg
@@ -7,11 +7,11 @@ data B = B A
 
 type C a = { x: a, y: a }
 
-def f = { { a = a, b = _ } -> a }
+def f = { { .a -> a, .b -> _ } -> a }
 
-def g = { (B { a = a, b = _ }) -> a }
+def g = { (B { .a -> a, .b -> _ }) -> a }
 
 def main = {
-  let x = { a = 32, b = 10 };
-  printString (toStringInt32 (addInt32 (f x) ({{a=_,b=b} -> b} x)))
+  let x = { .a -> 32, .b -> 10 };
+  printString (toStringInt32 (addInt32 (f x) ({{.a->_,.b->b} -> b} x)))
 }

--- a/test/testcases/malgo/RowPoly.mlg
+++ b/test/testcases/malgo/RowPoly.mlg
@@ -20,15 +20,15 @@ def handleOption =
     fallback None -> fallback }
 
 def wideRecord : { x: Int64#, y: Int64# }
-def wideRecord = { x = 20i64#, y = 99i64# }
+def wideRecord = { .x -> 20i64#, .y -> 99i64# }
 
 def someOrNone : [Some Int64# | None]
 def someOrNone = Some 30i64#
 
 def main = { (_) ->
-  let fromNarrowRecord = getX({ x = 10i64# });
+  let fromNarrowRecord = getX({ .x -> 10i64# });
   let fromWideRecord = getX(wideRecord);
-  let fromWiderRecord = sumXY({ x = 1i64#, y = 2i64#, z = 3i64# });
+  let fromWiderRecord = sumXY({ .x -> 1i64#, .y -> 2i64#, .z -> 3i64# });
   let fromClosedVariant = handleSome someOrNone;
   let fromOpenVariant = handleOption 7i64# someOrNone;
   let fallbackFromNone = handleOption 7i64# None;

--- a/test/testcases/malgo/Show.mlg
+++ b/test/testcases/malgo/Show.mlg
@@ -11,16 +11,16 @@ type Show a = {
 
 def showInt32 : Show Int32
 def showInt32 = {
-  show = { x -> toStringInt32 x },
+  .show -> { x -> toStringInt32 x },
 }
 
 def show : Show a -> a -> String
-def show = { { show = show } -> show }
+def show = { { .show -> show } -> show }
 
 def showTuple2 : Show a -> Show b -> Show (a, b)
 def showTuple2 = {
   showDictA showDictB -> {
-    show = { {a, b} ->
+    .show -> { {a, b} ->
       "(" <> show showDictA a <> ", " <> show showDictB b <> ")"
     },
   }

--- a/test/testcases/malgo/ShowSimple.mlg
+++ b/test/testcases/malgo/ShowSimple.mlg
@@ -19,12 +19,12 @@ type Show a = {
 }
 
 def show : Show a -> a -> String
-def show = { { show = show } -> show }
+def show = { { .show -> show } -> show }
 
 def wrap : (Int32 -> String) -> Show Int32
 def wrap = {
   fn -> {
-    show = fn
+    .show -> fn
   }
 }
 

--- a/test/testcases/malgo/TestPolySynonym.mlg
+++ b/test/testcases/malgo/TestPolySynonym.mlg
@@ -6,10 +6,10 @@ type Fun0 a = {a}
 type Pair a b = { fst: b, snd: a }
 
 def first : { fst: a, snd: b } -> a
-def first = { { fst = x, snd = _ } -> x }
+def first = { { .fst -> x, .snd -> _ } -> x }
 
 def main : Fun0 ()
 def main = {
-  let x = { fst = 1, snd = "hoge" };
+  let x = { .fst -> 1, .snd -> "hoge" };
   first x |> printInt32
 }

--- a/test/testcases/malgo/error/ConstructorArity.mlg
+++ b/test/testcases/malgo/error/ConstructorArity.mlg
@@ -7,11 +7,11 @@ data B = B A
 
 type C a = { x: a, y: a }
 
-def f = { { a = a, b = _ } -> a }
+def f = { { .a -> a, .b -> _ } -> a }
 
-def g = { (B { a = a, b = _ }) -> a }
+def g = { (B { .a -> a, .b -> _ }) -> a }
 
 def main = {
-  let x = { a = 32, b = 10 };
-  printString (toStringInt32 (addInt32 (f x) ({{a=_,b=b} -> b} x)))
+  let x = { .a -> 32, .b -> 10 };
+  printString (toStringInt32 (addInt32 (f x) ({{.a->_,.b->b} -> b} x)))
 }


### PR DESCRIPTION
BREAKING CHANGE: record literals and patterns change from `{field = v}`
to `{.field -> v}` (malgo#434).

Reuses the `.field` sigil already meaning "field projection" everywhere
else in the language (`.field` expressions, `#.field` codata copatterns)
instead of inventing a new symbol. `lean/Malgo/Elaborate.lean`'s
`buildObject`/`buildLambda` already classify codata clauses this way
internally -- a record literal is semantically "codata with no scrutinee,
every clause a bare `.field` projection" -- so this makes an existing
compiler-internal classification visible in the surface syntax, rather
than introducing a new concept. Literal and pattern use the identical
`.field -> x` syntax (deliberate, over an initial asymmetric proposal
that kept `=` for patterns).

Disambiguates record from lambda/case (`{pat -> v}`) on a single-token
lookahead -- no pattern production starts with a bare `.` -- rather than
the previous `P.attempt`-based backtracking over `=` vs `->`.

Parser changes:
- lean/Malgo/Parser/CStyle.lean: pRecordField/pRecordPField now parse
  `"." ident "->" pExpr/pPat` instead of `ident "=" pExpr/pPat`. pAtom/
  pAtomPat's dispatch order is unchanged -- pRecord/pRecordP are still
  tried in the same position, just fail-fast on a missing leading `.`.
- runtime/malgo/compiler/Parser.mlg (the self-hosted mirror):
  isRecordStart now checks for a leading `TkOp "."` instead of the old
  two-token "ident then =" lookahead; parseRecordExprFields/
  parseRecordPatFields consume the new `. ident ->` shape. The `Con{...}`
  shortcuts (parseAtomPat/parseSpaceAtomPat) needed no changes -- they
  already delegate to parseRecordPatFields unconditionally.

Two real, pre-existing self-hosted-parser bugs found and fixed along the
way (neither introduced by this change, both newly *exposed* by it, since
old-style records never contained an internal `->`/`,` for a nested
depth-tracking scan to trip over): hasTopLevelArrow and
hasTopLevelCommaBeforeRParen both returned false outright the instant
they saw a `->`/`,` at nonzero bracket depth, instead of continuing to
scan for the real top-level one -- breaking any record (which now always
contains an internal `->`) nested inside a lambda/case clause or a
tuple/paren context. Fixed both to continue scanning past a nested
occurrence; only bail out (true) when depth is actually 0.

Migration: new scripts/migrate-record-syntax.py, a one-shot codemod (no
prior migration-tooling precedent existed in this repo) that tracks
string literals, char literals, line comments (--), block comments
(`{- -}`), and bracket depth to find `{ident = expr}`-shaped fields and
rewrite the separator in place, leaving type-level `{field: T}`, tuples
`{e1, e2}`, import selectors, and lambda/codata untouched. Applied across
runtime/, test/testcases/, examples/, and the doc code samples in
docs/{tour,reference,c-style}.md -- 25 files. Not applied to nix-config
(cross-repo boundary); the script itself is handed to the peer session
coordinating that port.

Expr.record/Pat.record AST nodes are unchanged (confirmed against
Elaborate.lean before starting) -- only the surface parser changed, so
this needed zero golden-snapshot regeneration; the full suite (588/588,
including infer/zig-corpus/ir-invariants) passed clean on the first run
after the codemod + parser change, before the two hasTopLevelArrow-class
bugs were even found (those only surfaced under selfhost-golden.sh).
perf-baseline reseeded once for the self-hosted compiler's own behavior
change from the two bugfixes.

Direction A (removing the redundant `{a, b}` C-style tuple syntax that
fully duplicates `(a, b)`) was scoped into malgo#434 as a follow-up but
is NOT done here -- deliberately out of scope for this change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>