### PR TITLE
perf(bench): restore the l2-ratio Zig-vs-Chez comparison tier (#407)

### DIFF
--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -1,7 +1,7 @@
 {
   "$comment": "LIVE Zig-backend perf baseline for #385. Unrelated to bench/baseline-*.json, which are 2026-03 GHC *build*-time records. Regenerate with `mise run perf-baseline -- --update`; the diff of this file IS the before/after claim #385 requires. Gates are directional -- see scripts/perf-baseline.sh.",
   "compiler": {
-    "commit": "ccd43830",
+    "commit": "af1ab1cb",
     "zig": "0.16.0"
   },
   "tiers": {
@@ -49,5 +49,13 @@
         "reuse_rate": 0.036
       }
     }
+  },
+  "l2_ratio": {
+    "$comment": "#385's success metric: Level 2 wall clock through Zig over Chez, one serial case each, back-to-back on one machine. Absolute seconds are not comparable across machines; the ratio is. Needs the Scheme backend as the control (#400). Local only -- never gated in CI, since running L2 there is the 16 minutes #385 exists to remove.",
+    "chez_s": 47,
+    "zig_s": 245,
+    "ratio": 5.21,
+    "machine": "Darwin arm64",
+    "commit": "af1ab1cb"
   }
 }

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -40,7 +40,10 @@
 #   scripts/perf-baseline.sh [--tier=LIST] [--update] [--timing]
 #
 #   --tier=LIST   comma-separated: fib-shallow,fib-deep,selfhost-l1,selfhost-l2,
-#                 or `all`. Default: fib-shallow,fib-deep (the cheap tiers).
+#                 l2-ratio, or `all`. Default: fib-shallow,fib-deep (the cheap
+#                 tiers). `l2-ratio` is the Zig-vs-Chez wall-clock ratio on Level
+#                 2 -- #385's actual success metric -- and needs the Scheme
+#                 backend, so it only works before #400 lands. Local only.
 #   --update      rewrite the baseline JSON from this run instead of comparing.
 #   --timing      also measure wall clock with hyperfine (local only; never CI).
 #
@@ -59,6 +62,7 @@ MALGO="${MALGO:-lean/.lake/build/bin/malgo}"
 BASELINE="${BASELINE:-bench/perf-baseline.json}"
 COMPILE_TIMEOUT="${COMPILE_TIMEOUT:-600}"
 CASE_TIMEOUT="${CASE_TIMEOUT:-900}"
+SCHEME="${SCHEME:-scheme}"
 
 TIERS="fib-shallow,fib-deep"
 UPDATE=0
@@ -75,7 +79,7 @@ for arg in "$@"; do
 done
 
 if [ "$TIERS" = "all" ]; then
-  TIERS="fib-shallow,fib-deep,selfhost-l1,selfhost-l2"
+  TIERS="fib-shallow,fib-deep,selfhost-l1,selfhost-l2,l2-ratio"
 fi
 
 if [ -n "${ZIG_BIN_DIR:-}" ]; then
@@ -190,6 +194,69 @@ ensure_selfhost_evaluator() {
   compile_fixture selfhost runtime/malgo/compiler/Main.mlg "$WORK/malgoc"
 }
 
+# The same Level 1 evaluator through the Scheme backend, for the ratio tier.
+# Shares the precompile above, so only the emit is extra.
+ensure_selfhost_scheme() {
+  [ -s "$WORK/main.scm" ] && return 0
+  ensure_selfhost_evaluator || return 1
+  if ! command -v "$SCHEME" >/dev/null 2>&1; then
+    echo "FAIL: '$SCHEME' not on PATH (run 'mise install' for chezscheme, or set SCHEME)." >&2
+    return 1
+  fi
+  echo "  emitting Main.mlg through the Scheme backend" >&2
+  if ! timeout "$COMPILE_TIMEOUT" "$MALGO" eval --target scheme \
+        runtime/malgo/compiler/Main.mlg >"$WORK/main.scm"; then
+    echo "FAIL: 'malgo eval --target scheme' failed (needs the Scheme backend; see #400)." >&2
+    return 1
+  fi
+}
+
+# Wall-clock seconds for one serial Level 2 case. Echoes an integer.
+time_l2_case() {
+  local label="$1"; shift
+  local start=$SECONDS out
+  out="$(printf 'Hello\n' | timeout "$CASE_TIMEOUT" "$@" \
+        runtime/malgo/compiler/Main.mlg test/testcases/malgo/Fib.mlg 2>/dev/null)"
+  local status=$? elapsed=$((SECONDS - start))
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL($label): exited $status after ${elapsed}s" >&2
+    return 1
+  fi
+  if [ "$out" != "8" ]; then
+    echo "FAIL($label): expected '8', got '$out'" >&2
+    return 1
+  fi
+  echo "  $label: ${elapsed}s" >&2
+  printf '%s\n' "$elapsed"
+}
+
+# Echoes "<chez_s> <zig_s> <ratio>".
+#
+# This is the quantity #385 is actually about, and the only one that survives
+# moving between machines: absolute wall clock does not compare across hardware
+# or CI runner generations, but Chez and Zig measured back-to-back in one run on
+# one machine do. That is what the retained Scheme backend is for -- it is the
+# control, not nostalgia (see #400).
+#
+# Serial and single-case on purpose. selfhost-level2.sh runs five cases as
+# unbounded parallel jobs, so its per-case seconds are contended and cannot be
+# compared against a serial figure -- which is exactly the trap that made the
+# original 220s-vs-29s pairing non-comparable.
+run_ratio_tier() {
+  echo "=== l2-ratio ===" >&2
+  ensure_selfhost_scheme || return 1
+  local zig_s chez_s
+  zig_s="$(time_l2_case zig "$WORK/malgoc")" || return 1
+  chez_s="$(time_l2_case chez "$SCHEME" --script "$WORK/main.scm")" || return 1
+  if [ "$chez_s" -le 0 ]; then
+    echo "FAIL(l2-ratio): chez run measured ${chez_s}s -- too fast to form a ratio" >&2
+    return 1
+  fi
+  # Two decimal places without bc: integer arithmetic on hundredths.
+  local hundredths=$(( zig_s * 100 / chez_s ))
+  printf '%s %s %s.%02d\n' "$chez_s" "$zig_s" "$((hundredths / 100))" "$((hundredths % 100))"
+}
+
 # Echoes "<tier> <total_allocs> <reuse_hits> <dispatches> <force_depth_max>".
 run_tier() {
   local tier="$1" counters
@@ -215,7 +282,7 @@ run_tier() {
       counters="$(measure_binary "$tier" 8 "$WORK/malgoc" runtime/malgo/compiler/Main.mlg test/testcases/malgo/Fib.mlg)" || return 1
       ;;
     *)
-      echo "unknown tier '$tier' (fib-shallow|fib-deep|selfhost-l1|selfhost-l2|all)" >&2
+      echo "unknown tier '$tier' (fib-shallow|fib-deep|selfhost-l1|selfhost-l2|l2-ratio|all)" >&2
       return 1
       ;;
   esac
@@ -230,9 +297,20 @@ RESULTS="$WORK/results"
 : >"$RESULTS"
 failed=0
 
+RATIO="$WORK/ratio"
+: >"$RATIO"
+
 old_ifs="$IFS"; IFS=','
 for tier in $TIERS; do
   IFS="$old_ifs"
+  if [ "$tier" = "l2-ratio" ]; then
+    if ! run_ratio_tier >>"$RATIO"; then
+      failed=1
+      [ "$UPDATE" -eq 1 ] && { echo "refusing to --update from a failed run" >&2; exit 1; }
+    fi
+    IFS=','
+    continue
+  fi
   if ! run_tier "$tier" >>"$RESULTS"; then
     failed=1
     [ "$UPDATE" -eq 1 ] && { echo "refusing to --update from a failed run" >&2; exit 1; }
@@ -244,6 +322,23 @@ IFS="$old_ifs"
 # ---------------------------------------------------------------------------
 # Compare or update
 # ---------------------------------------------------------------------------
+
+# Stores the ratio tier under its own top-level key: it is wall clock plus a
+# derived ratio, not counters, and it carries the machine it was taken on --
+# absolute seconds mean nothing without that.
+record_ratio() {
+  [ -s "$RATIO" ] || return 0
+  read -r chez_s zig_s ratio <"$RATIO"
+  jq --argjson chez "$chez_s" --argjson zig "$zig_s" --argjson ratio "$ratio" \
+     --arg machine "$(uname -s) $(uname -m)" \
+     --arg commit "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" '
+     .l2_ratio = {
+       "$comment": "#385'"'"'s success metric: Level 2 wall clock through Zig over Chez, one serial case each, back-to-back on one machine. Absolute seconds are not comparable across machines; the ratio is. Needs the Scheme backend as the control (#400). Local only -- never gated in CI, since running L2 there is the 16 minutes #385 exists to remove.",
+       chez_s: $chez, zig_s: $zig, ratio: $ratio,
+       machine: $machine, commit: $commit
+     }' "$BASELINE" >"$WORK/ratio.json" || return 1
+  mv "$WORK/ratio.json" "$BASELINE"
+}
 
 results_to_json() {
   jq -n --rawfile raw "$RESULTS" --arg commit "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
@@ -279,8 +374,10 @@ if [ "$UPDATE" -eq 1 ]; then
     results_to_json >"$WORK/new.json" || exit 1
     jq -s '.[0] * .[1]' "$BASELINE" "$WORK/new.json" >"$WORK/merged.json" || exit 1
     mv "$WORK/merged.json" "$BASELINE"
+    record_ratio || exit 1
   else
     results_to_json >"$BASELINE" || exit 1
+    record_ratio || exit 1
   fi
   echo "updated $BASELINE:"
   jq . "$BASELINE"
@@ -331,6 +428,35 @@ while read -r tier ta rh di fd; do
     echo "  IMPROVED -- re-run with --update to record it"
   fi
 done <"$RESULTS"
+
+# The ratio gate. Wall clock is noisy even on one quiet machine, so this allows a
+# 15% band rather than pretending to more precision than it has -- it is here to
+# catch "the gap got materially worse", not to score single-digit percentages.
+# That is also why it is never run in CI: hosted runners vary far more than 15%.
+if [ -s "$RATIO" ] && [ -f "$BASELINE" ]; then
+  read -r chez_s zig_s ratio <"$RATIO"
+  base_ratio="$(jq -r '.l2_ratio.ratio // empty' "$BASELINE")"
+  base_machine="$(jq -r '.l2_ratio.machine // empty' "$BASELINE")"
+  this_machine="$(uname -s) $(uname -m)"
+  echo "--- l2-ratio ---"
+  printf '  chez %ss  zig %ss  ratio %sx  (baseline %sx)\n' \
+    "$chez_s" "$zig_s" "$ratio" "${base_ratio:-none}"
+  if [ -z "$base_ratio" ]; then
+    echo "  NOTICE: no baseline ratio -- record it with --tier=l2-ratio --update"
+  elif [ -n "$base_machine" ] && [ "$base_machine" != "$this_machine" ]; then
+    echo "  NOTICE: baseline was taken on '$base_machine', this is '$this_machine' -- not comparing"
+  else
+    # Integer hundredths again, to stay free of bc.
+    now_h=$(printf '%s' "$ratio" | awk -F. '{printf "%d", $1*100 + ($2 == "" ? 0 : substr($2 "00",1,2))}')
+    base_h=$(printf '%s' "$base_ratio" | awk -F. '{printf "%d", $1*100 + ($2 == "" ? 0 : substr($2 "00",1,2))}')
+    if [ "$now_h" -gt $(( base_h * 115 / 100 )) ]; then
+      echo "  REGRESSION: the Zig/Chez gap widened by more than 15%"
+      regressions=1
+    elif [ "$now_h" -lt "$base_h" ]; then
+      echo "  IMPROVED: gap narrowed -- re-run with --update to record it"
+    fi
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Wall clock (informational, local only)

--- a/scripts/selfhost-level2.sh
+++ b/scripts/selfhost-level2.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # selfhost-level2.sh — Level 2 metacircular interpreter test
 #
-# Level 1: the Malgo evaluator (Main.mlg), built into a runnable artifact via
-#          the Zig backend, evaluates a .mlg program directly
+# Level 1: the Malgo evaluator (Main.mlg), built into a runnable artifact,
+#          evaluates a .mlg program directly
 # Level 2: that artifact evaluates Main.mlg, which evaluates a .mlg program
+#
+# TARGET selects how Main.mlg becomes runnable:
+#   TARGET=zig    (default) `malgo compile --opt release-fast` -> native binary
+#   TARGET=scheme           `malgo eval --target scheme` -> main.scm, run under Chez
+#
+# The Scheme path is retained as the cross-implementation performance reference
+# for #385: it is the only baseline the Zig backend's numbers can be read
+# against. Do not delete it until #385 closes -- see #400.
 #
 # Building the evaluator and running the cases can be separated, which is how CI
 # keeps any one job under 10 minutes:
@@ -29,10 +37,19 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 MALGO=${MALGO:-lean/.lake/build/bin/malgo}
-# Level 2 is ~50-200x slower than Level 1. 600 gives ~3-4x headroom over the
-# slowest case measured running alone on a CI runner (~460s; see #385 and
-# `mise run perf-baseline`).
-CASE_TIMEOUT=${CASE_TIMEOUT:-600}
+TARGET=${TARGET:-zig}
+SCHEME=${SCHEME:-scheme}
+# Level 2 is ~50-200x slower than Level 1, and the Zig backend is a further
+# ~5x slower per case than the Chez Scheme path it replaced (measured serially
+# on an M-series Mac: 154s vs 31s on Fib; was ~7.5x before #403/#405 -- see
+# `mise run perf-baseline -- --tier=l2-ratio`). Hence the per-target default:
+# 300 is the value the Chez path shipped with before #384, and 600 gives the Zig
+# path ~3.4x headroom over the slowest case measured (177s).
+case "$TARGET" in
+  zig)    CASE_TIMEOUT=${CASE_TIMEOUT:-600} ;;
+  scheme) CASE_TIMEOUT=${CASE_TIMEOUT:-300} ;;
+  *) echo "unknown TARGET '$TARGET' (expected zig|scheme)" >&2; exit 1 ;;
+esac
 PRECOMPILE_TIMEOUT=${PRECOMPILE_TIMEOUT:-180}
 # Concurrent cases. Deliberately 2 rather than selfhost-golden.sh's `nproc`: a
 # Level 2 case runs for minutes and allocates billions of times, so
@@ -57,6 +74,13 @@ if [[ -z "${L2_CASES// /}" ]]; then
 fi
 
 if [[ -n "$EVAL_BIN" ]]; then
+  # The Scheme path's evaluator is a .scm run through `scheme --script`, not a
+  # binary, and the ratio measurement it exists for wants both halves built the
+  # same way in one place. Rather than guess which, refuse the combination.
+  if [[ "$TARGET" != "zig" ]]; then
+    echo "EVAL_BIN is TARGET=zig only (got TARGET=$TARGET)" >&2
+    exit 1
+  fi
   if [[ "$BUILD_ONLY" == "1" ]]; then
     echo "BUILD_ONLY and EVAL_BIN are mutually exclusive: one builds, the other skips building" >&2
     exit 1
@@ -138,18 +162,39 @@ else
 
   mkdir -p "$MALGO_WORK_DIR"
 
-  EVAL_MAIN="$MALGO_WORK_DIR/malgoc"
-  RUNNER=("$EVAL_MAIN")
-  if ! command -v zig >/dev/null 2>&1; then
-    echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
-    exit 1
-  fi
-  log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
-  if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$EVAL_MAIN" --opt release-fast; then
-    log "native compilation failed"
-    exit 1
-  fi
-  log "native compilation done: $EVAL_MAIN"
+  # Every arm must set RUNNER: under `set -u`, bash 3.2 errors on "${RUNNER[@]}"
+  # for an unset/empty array. The `*)` arm above already exited, so RUNNER is
+  # always populated by the time run_case uses it.
+  case "$TARGET" in
+    zig)
+      EVAL_MAIN="$MALGO_WORK_DIR/malgoc"
+      RUNNER=("$EVAL_MAIN")
+      if ! command -v zig >/dev/null 2>&1; then
+        echo "zig not found on PATH (set ZIG_BIN_DIR or run 'mise install' / activate mise)." >&2
+        exit 1
+      fi
+      log "compiling Main.mlg to a native binary (Level 1 evaluator) via the Zig backend"
+      if ! "$MALGO" compile runtime/malgo/compiler/Main.mlg -o "$EVAL_MAIN" --opt release-fast; then
+        log "native compilation failed"
+        exit 1
+      fi
+      log "native compilation done: $EVAL_MAIN"
+      ;;
+    scheme)
+      EVAL_MAIN="$MALGO_WORK_DIR/main.scm"
+      RUNNER=("$SCHEME" --script "$EVAL_MAIN")
+      if ! command -v "$SCHEME" >/dev/null 2>&1; then
+        echo "'$SCHEME' not found on PATH (run 'mise install' to get chezscheme, or set SCHEME)." >&2
+        exit 1
+      fi
+      log "compiling Main.mlg to Scheme (Level 1 evaluator)"
+      if ! "$MALGO" eval --target scheme runtime/malgo/compiler/Main.mlg > "$EVAL_MAIN"; then
+        log "Scheme compilation failed"
+        exit 1
+      fi
+      log "Scheme compilation done: $EVAL_MAIN"
+      ;;
+  esac
 
   if [[ "$BUILD_ONLY" == "1" ]]; then
     log "BUILD_ONLY: evaluator built, stopping before the case sweep"
@@ -166,7 +211,7 @@ fi
 level2_cases=($L2_CASES)
 
 total_cases=${#level2_cases[@]}
-log "starting Level 2 metacircular checks: ${total_cases} cases (parallelism: ${PARALLEL_JOBS}, CASE_TIMEOUT: ${CASE_TIMEOUT}s)"
+log "starting Level 2 metacircular checks: ${total_cases} cases (TARGET=$TARGET, parallelism: ${PARALLEL_JOBS}, CASE_TIMEOUT: ${CASE_TIMEOUT}s)"
 log "command: ${RUNNER[*]} runtime/malgo/compiler/Main.mlg <case.mlg>"
 
 results_dir="$MALGO_WORK_DIR/level2-results"


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary
- Restores the `l2-ratio` tier in `scripts/perf-baseline.sh` and the `TARGET=zig|scheme` switch in `scripts/selfhost-level2.sh`, both removed in #404 once #385 closed.
- #407's own acceptance criteria call for `mise run perf-baseline -- --tier=l2-ratio`, but that harness never came back when the Scheme backend itself was restored a third time (#416/#417) -- so #407 currently has no way to measure progress against its stated "~2x" target.
- Restored by reverse-applying #404's removal diff onto the current tree (no other commit touched either script since, so it applied cleanly) and re-verified against the current Scheme backend's `malgo eval --target scheme` invocation (matches `scripts/scheme-golden.sh`).
- Records an initial baseline: `chez 47s / zig 245s` (ratio 5.21x) on this machine.

## Test plan
- [x] `bash -n` syntax check on both scripts
- [x] `mise run perf-baseline -- --tier=l2-ratio` runs clean
- [x] `mise run perf-baseline -- --tier=l2-ratio --update` records the baseline in `bench/perf-baseline.json`
- [ ] CI (fast tiers only; `l2-ratio` stays local-only per the harness's own design, same as before #404)

Related: #407, #385, #404, #416