### PR TITLE
fix(parser): bind .field to an immediately-adjacent parenthesized atom (#424)

### DIFF
--- a/lean/Malgo/Parser/CStyle.lean
+++ b/lean/Malgo/Parser/CStyle.lean
@@ -84,36 +84,6 @@ def pVarP : P (Pat .parse) := P.captureRange do
   let name ← P.ident
   pure fun range => Pat.var range name
 
-/-- Accumulate `.field` projections for `pVariable`; each `Project`
-spans from the whole expression's start to the end of the latest field. -/
-private partial def pVariableFoldFields
-    (projStart : SourcePos) (expr : Expr .parse) : P (Expr .parse) := do
-  let mField ← P.optional (P.attempt (P.char '.' *> P.rawIdent))
-  match mField with
-  | none => pure expr
-  | some field =>
-    let fieldEndPos ← P.getSourcePos
-    pVariableFoldFields projStart
-      (Expr.project { start := projStart, stop := fieldEndPos } expr field)
-
-/-- `pVariable`: an identifier, greedily consuming immediately-adjacent
-`.field` access chains (no whitespace before the `.`). -/
-def pVariable : P (Expr .parse) := do
-  let startPos ← P.getSourcePos
-  P.notFollowedBy P.anyReserved
-  let name ← P.rawIdent
-  let identEndPos ← P.getSourcePos
-  let hasDot ← P.option false (P.lookAhead (P.char '.') *> pure true)
-  if hasDot then
-    let result ← pVariableFoldFields startPos
-      (Expr.var { start := startPos, stop := identEndPos } name)
-    P.space
-    pure result
-  else
-    P.space
-    let endPos ← P.getSourcePos
-    pure (Expr.var { start := startPos, stop := endPos } name)
-
 /-- A bracketed, comma-separated list: `open_ item (, item)* close`. The
 singleton case is a genuine three-way policy split across this grammar's
 six bracketed-list sites (collapse to the bare element, wrap it in a
@@ -252,12 +222,47 @@ partial def pApply : P (Expr .parse) := do
 
 partial def pApplyPostfix : P (Expr .parse → Expr .parse) :=
   P.choice [
-    -- Function application: expr(arg1, ...); () is treated as ({})
+    -- Function application: expr(arg1, ...); () is treated as ({}).
+    -- For an identifier-headed chain, this branch is only reached once
+    -- whitespace has already intervened since the accumulator: an
+    -- *adjacent* `name(args)` is fully consumed by
+    -- `pVariable`/`pTightPostfix` before `pApply`'s postfix loop ever runs
+    -- (so `nats(0).tail` keeps binding `.tail` to the call, matching the
+    -- corpus's existing call-then-project convention). So a single
+    -- parenthesized argument here is a *loose*, space-separated
+    -- application (`f (expr)`) that happens to look like a call; if a
+    -- `.field` chain immediately (no whitespace) follows the closing
+    -- paren, it binds to that argument rather than to the whole
+    -- application — the same tight-binding treatment `pTightPostfix`
+    -- already gives a bare identifier (#424). `f(a, b)`/multi-arg and
+    -- empty-arg calls are untouched. (A tight call on a non-identifier
+    -- atom, e.g. an immediately-invoked lambda `{ ... }(x)`, still reaches
+    -- this branch tightly and isn't intercepted — out of scope here, no
+    -- corpus case has a dot chain immediately after one; the self-hosted
+    -- parser's `canCStyleCall` draws the same identifier/field-only
+    -- boundary for tight calls, for unrelated reasons.)
     P.captureRange do
-      let args ← P.between (P.symbol "(") (P.symbol ")") (P.sepBy pExpr (P.symbol ","))
-      pure fun range fn =>
-        let actualArgs := if args.isEmpty then [Expr.tuple range []] else args
-        actualArgs.foldl (fun f a => Expr.apply range f a) fn,
+      let parenStart ← P.getSourcePos
+      P.symbol "("
+      let args ← P.sepBy pExpr (P.symbol ",")
+      match args with
+      | [single] =>
+        _ ← P.char ')'
+        let closeEndPos ← P.getSourcePos
+        let hasDot ← P.option false (P.lookAhead (P.char '.') *> pure true)
+        if hasDot then
+          let projected ← pTightPostfix parenStart
+            (Expr.parens { start := parenStart, stop := closeEndPos } single)
+          P.space
+          pure fun range fn => Expr.apply range fn projected
+        else
+          P.space
+          pure fun range fn => Expr.apply range fn single
+      | _ =>
+        P.symbol ")"
+        pure fun range fn =>
+          let actualArgs := if args.isEmpty then [Expr.tuple range []] else args
+          actualArgs.foldl (fun f a => Expr.apply range f a) fn,
     -- Field projection: expr.field
     P.captureRange do
       P.reservedOperator "."
@@ -267,6 +272,60 @@ partial def pApplyPostfix : P (Expr .parse → Expr .parse) :=
     P.captureRange do
       let argument ← pAtom
       pure fun range fn => Expr.apply range fn argument ]
+
+/-- Accumulate tight (no-whitespace) postfix operations immediately
+following `expr`: `.field` projections and C-style `(args)` calls,
+chained for as long as each starts right where the previous one ended.
+Used by `pVariable` so a bare identifier's dot/call chain binds as
+tightly as the identifier itself, matching the corpus's existing
+call-then-project convention (`nats(0).tail`, `addThree(1)(2)(3).apply`,
+`ifChain(True).then(t).else(e)`). Because this loop already swallows
+every *adjacent* continuation at the atom level, `pApplyPostfix`'s own
+call-args branch is only ever reached once whitespace has intervened, so
+it may safely give a *loose* `f (expr).field` the opposite treatment:
+binding the dot to the parenthesized argument instead of to the call
+(#424). Also reused by that branch once it has decided a trailing dot
+chain binds to the parenthesized argument, so further tight continuations
+(`f (g x).a(y).b`) keep chaining onto it. -/
+partial def pTightPostfix
+    (start : SourcePos) (expr : Expr .parse) : P (Expr .parse) := do
+  let mField ← P.optional (P.attempt (P.char '.' *> P.rawIdent))
+  match mField with
+  | some field =>
+    let fieldEndPos ← P.getSourcePos
+    pTightPostfix start (Expr.project { start, stop := fieldEndPos } expr field)
+  | none =>
+    let hasParen ← P.option false (P.lookAhead (P.char '(') *> pure true)
+    if hasParen then
+      P.symbol "("
+      let args ← P.sepBy pExpr (P.symbol ",")
+      _ ← P.char ')'
+      let closeEndPos ← P.getSourcePos
+      let range : Range := { start, stop := closeEndPos }
+      let actualArgs := if args.isEmpty then [Expr.tuple range []] else args
+      pTightPostfix start (actualArgs.foldl (fun f a => Expr.apply range f a) expr)
+    else
+      pure expr
+
+/-- `pVariable`: an identifier, greedily consuming an immediately-adjacent
+(no whitespace) chain of `.field` projections and C-style `(args)` calls
+(#424; see `pTightPostfix`). -/
+partial def pVariable : P (Expr .parse) := do
+  let startPos ← P.getSourcePos
+  P.notFollowedBy P.anyReserved
+  let name ← P.rawIdent
+  let identEndPos ← P.getSourcePos
+  let hasTight ← P.option false
+    (P.lookAhead (P.char '.' <|> P.char '(') *> pure true)
+  if hasTight then
+    let result ← pTightPostfix startPos
+      (Expr.var { start := startPos, stop := identEndPos } name)
+    P.space
+    pure result
+  else
+    P.space
+    let endPos ← P.getSourcePos
+    pure (Expr.var { start := startPos, stop := endPos } name)
 
 partial def pAtom : P (Expr .parse) :=
   P.choice [

--- a/lean/Malgo/Parser/CStyle.lean
+++ b/lean/Malgo/Parser/CStyle.lean
@@ -223,24 +223,19 @@ partial def pApply : P (Expr .parse) := do
 partial def pApplyPostfix : P (Expr .parse → Expr .parse) :=
   P.choice [
     -- Function application: expr(arg1, ...); () is treated as ({}).
-    -- For an identifier-headed chain, this branch is only reached once
-    -- whitespace has already intervened since the accumulator: an
-    -- *adjacent* `name(args)` is fully consumed by
-    -- `pVariable`/`pTightPostfix` before `pApply`'s postfix loop ever runs
-    -- (so `nats(0).tail` keeps binding `.tail` to the call, matching the
-    -- corpus's existing call-then-project convention). So a single
-    -- parenthesized argument here is a *loose*, space-separated
-    -- application (`f (expr)`) that happens to look like a call; if a
-    -- `.field` chain immediately (no whitespace) follows the closing
-    -- paren, it binds to that argument rather than to the whole
-    -- application — the same tight-binding treatment `pTightPostfix`
-    -- already gives a bare identifier (#424). `f(a, b)`/multi-arg and
-    -- empty-arg calls are untouched. (A tight call on a non-identifier
-    -- atom, e.g. an immediately-invoked lambda `{ ... }(x)`, still reaches
-    -- this branch tightly and isn't intercepted — out of scope here, no
-    -- corpus case has a dot chain immediately after one; the self-hosted
-    -- parser's `canCStyleCall` draws the same identifier/field-only
-    -- boundary for tight calls, for unrelated reasons.)
+    -- This branch is only reached once whitespace has already intervened
+    -- since the accumulator: an *adjacent* `atom(args)` is fully consumed
+    -- by `pAtom`/`pTightPostfix` before `pApply`'s postfix loop ever runs,
+    -- for every atom category (identifier, tuple, record, lambda, ...) —
+    -- not just identifiers (so `nats(0).tail` and `{ x -> x }(5).tail`
+    -- alike keep binding `.tail` to the call, matching the corpus's
+    -- existing call-then-project convention). So a single parenthesized
+    -- argument here is a *loose*, space-separated application (`f (expr)`)
+    -- that happens to look like a call; if a `.field` chain immediately
+    -- (no whitespace) follows the closing paren, it binds to that argument
+    -- rather than to the whole application — the same tight-binding
+    -- treatment `pTightPostfix` already gives a tightly-adjacent atom
+    -- (#424). `f(a, b)`/multi-arg and empty-arg calls are untouched.
     P.captureRange do
       let parenStart ← P.getSourcePos
       P.symbol "("
@@ -276,17 +271,17 @@ partial def pApplyPostfix : P (Expr .parse → Expr .parse) :=
 /-- Accumulate tight (no-whitespace) postfix operations immediately
 following `expr`: `.field` projections and C-style `(args)` calls,
 chained for as long as each starts right where the previous one ended.
-Used by `pVariable` so a bare identifier's dot/call chain binds as
-tightly as the identifier itself, matching the corpus's existing
-call-then-project convention (`nats(0).tail`, `addThree(1)(2)(3).apply`,
-`ifChain(True).then(t).else(e)`). Because this loop already swallows
-every *adjacent* continuation at the atom level, `pApplyPostfix`'s own
-call-args branch is only ever reached once whitespace has intervened, so
-it may safely give a *loose* `f (expr).field` the opposite treatment:
-binding the dot to the parenthesized argument instead of to the call
-(#424). Also reused by that branch once it has decided a trailing dot
-chain binds to the parenthesized argument, so further tight continuations
-(`f (g x).a(y).b`) keep chaining onto it. -/
+Used by `pAtom` so *any* atom's dot/call chain binds as tightly as the
+atom itself, matching the corpus's existing call-then-project convention
+(`nats(0).tail`, `addThree(1)(2)(3).apply`, `ifChain(True).then(t).else(e)`,
+and — since #424's follow-up — `{ x -> x }(5).tail` too). Because this
+loop already swallows every *adjacent* continuation at the atom level,
+`pApplyPostfix`'s own call-args branch is only ever reached once
+whitespace has intervened, so it may safely give a *loose* `f (expr).field`
+the opposite treatment: binding the dot to the parenthesized argument
+instead of to the call (#424). Also reused by that branch once it has
+decided a trailing dot chain binds to the parenthesized argument, so
+further tight continuations (`f (g x).a(y).b`) keep chaining onto it. -/
 partial def pTightPostfix
     (start : SourcePos) (expr : Expr .parse) : P (Expr .parse) := do
   let mField ← P.optional (P.attempt (P.char '.' *> P.rawIdent))
@@ -307,31 +302,52 @@ partial def pTightPostfix
     else
       pure expr
 
-/-- `pVariable`: an identifier, greedily consuming an immediately-adjacent
-(no whitespace) chain of `.field` projections and C-style `(args)` calls
-(#424; see `pTightPostfix`). -/
-partial def pVariable : P (Expr .parse) := do
+/-- `pVariable`: a bare identifier. Any immediately-adjacent (no
+whitespace) `.field`/`(args)` chain is folded on by `pAtom`, uniformly for
+every atom kind — not special-cased here (#424's follow-up). -/
+partial def pVariable : P (Expr .parse) := P.captureRange do
+  let name ← P.ident
+  pure fun range => Expr.var range name
+
+/-- `pAtom`: any atom, greedily extended with an immediately-adjacent (no
+whitespace) chain of `.field` projections and C-style `(args)` calls
+(#424, and — uniformly across every atom kind, not just a bare identifier
+— its follow-up). Every atom variant below ends by calling a
+space-swallowing `lexeme`/`symbol`, which erases the "was there
+whitespace here" signal before this function ever gets to look at it; a
+`.field`/`(` immediately after is indistinguishable, from the current
+parse position alone, from one preceded by real whitespace (or a
+comment). `PState.prevChar` recovers that signal without having to
+teach every atom parser to defer its own trailing `space` call (as the
+original, `pVariable`-only fix for #424 did): a non-whitespace `prevChar`
+means the atom's own closing token was the last thing actually consumed,
+i.e. the trailing `space` call that followed found nothing to swallow.
+(One corner this doesn't get right: a comment with no surrounding
+whitespace at all, e.g. `{x->x}{-c-}(5)`, reports tight because the last
+character `space` actually consumed is the comment's own `-}`, not
+whitespace — untested and arguably fine, since a comment is meant to be
+transparent anyway.) -/
+partial def pAtom : P (Expr .parse) := do
   let startPos ← P.getSourcePos
-  P.notFollowedBy P.anyReserved
-  let name ← P.rawIdent
-  let identEndPos ← P.getSourcePos
-  let hasTight ← P.option false
-    (P.lookAhead (P.char '.' <|> P.char '(') *> pure true)
+  let expr ← P.choice [
+    pLabel, pGoto, pLiteral, pVariable,
+    P.attempt pParenTuple, P.attempt pTuple, P.attempt pRecord,
+    pBrace, pList, pSeq ]
+  let mPrev ← P.prevChar
+  let noGapBefore := match mPrev with
+    | some c => !P.isSpaceChar c
+    | none => false
+  let hasTight ← if noGapBefore then
+      P.option false (P.lookAhead (P.char '.' <|> P.char '(') *> pure true)
+    else
+      pure false
   if hasTight then
-    let result ← pTightPostfix startPos
-      (Expr.var { start := startPos, stop := identEndPos } name)
+    let result ← pTightPostfix startPos expr
     P.space
     pure result
   else
     P.space
-    let endPos ← P.getSourcePos
-    pure (Expr.var { start := startPos, stop := endPos } name)
-
-partial def pAtom : P (Expr .parse) :=
-  P.choice [
-    pLabel, pGoto, pLiteral, pVariable,
-    P.attempt pParenTuple, P.attempt pTuple, P.attempt pRecord,
-    pBrace, pList, pSeq ]
+    pure expr
 
 partial def pLabel : P (Expr .parse) := P.captureRange do
   P.reserved "label"

--- a/lean/Malgo/Parser/Prim.lean
+++ b/lean/Malgo/Parser/Prim.lean
@@ -61,9 +61,16 @@ structure PState where
   offset : Nat
   line : Nat
   col : Nat
+  /-- The last character actually consumed, if any. Every primitive that
+  consumes input funnels through `advance`, which keeps this current; it
+  lets a caller recover "was there whitespace right here" *after* a
+  space-swallowing `lexeme`/`symbol` has already run past it, without
+  threading a deferred-space variant through every token parser (see
+  `pAtom` in `CStyle.lean`, #424's follow-up). -/
+  prevChar : Option Char
 
 def PState.ofInput (sourceName : String) (input : String) : PState :=
-  { sourceName, rest := input.toList, offset := 0, line := 1, col := 1 }
+  { sourceName, rest := input.toList, offset := 0, line := 1, col := 1, prevChar := none }
 
 def PState.sourcePos (s : PState) : SourcePos :=
   { sourceName := s.sourceName, line := s.line, column := s.col }
@@ -80,7 +87,7 @@ def PState.advance (s : PState) (c : Char) (rest : List Char) : PState :=
     if c == '\n' then (s.line + 1, 1)
     else if c == '\t' then (s.line, s.col + 8 - ((s.col - 1) % 8))
     else (s.line, s.col + 1)
-  { s with rest, offset := s.offset + 1, line, col }
+  { s with rest, offset := s.offset + 1, line, col, prevChar := some c }
 
 inductive Reply (α : Type) where
   | ok (a : α) (s : PState) (consumed : Bool)
@@ -149,6 +156,10 @@ def notFollowedBy (p : P α) : P Unit := fun s =>
   | .err _ _ => .ok () s false
 
 def getSourcePos : P SourcePos := fun s => .ok s.sourcePos s false
+
+/-- The last character consumed by any prior primitive, if any. See
+`PState.prevChar`. -/
+def prevChar : P (Option Char) := fun s => .ok s.prevChar s false
 
 def eof : P Unit := fun s =>
   match s.rest with
@@ -297,7 +308,10 @@ def digitChar : P Char := satisfy Char.isDigit [.label "digit"]
 
 /-! ## Lexer layer (port of `Malgo.Parser.Core`) -/
 
-private def isSpaceChar (c : Char) : Bool :=
+/-- Not `private`: `CStyle.lean`'s `pAtom` reuses this to interpret
+`prevChar` (a whitespace `prevChar` means a `lexeme`'s trailing `space`
+call actually swallowed something, not just an adjacent closing token). -/
+def isSpaceChar (c : Char) : Bool :=
   c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\x0b' || c == '\x0c'
 
 private def space1 : P Unit := do

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -715,7 +715,29 @@ private def cases : List Case :=
     , src := "def main = f state.dict.head"
     , expect := some "(apply f (project (project state \"dict\") \"head\"))" }
   , { name := "ignores unknown pragmas alongside known ones"
-    , src := "#experimental-feature\n#c-style-apply\ndef main = f(x, y)" } ]
+    , src := "#experimental-feature\n#c-style-apply\ndef main = f(x, y)" }
+  , { name := "binds .field to a parenthesized call argument when no space precedes the dot (#424)"
+    , src := "def main = f (g x).field"
+    , expect := some "(apply f (project (parens (apply g x)) \"field\"))" }
+  , { name := "chains adjacent .field projections onto a parenthesized call argument (#424)"
+    , src := "def main = f (g x).a.b"
+    , expect := some
+        "(apply f (project (project (parens (apply g x)) \"a\") \"b\"))" }
+  , { name := "treats .field as a postfix on the whole call when a space precedes it after a parenthesized argument"
+    , src := "def main = f (g x) .field"
+    , expect := some "(project (apply f (apply g x)) \"field\")" }
+  , { name := "does not disturb a two-argument call written tight: f(a, b)"
+    , src := "def main = f(a, b)"
+    , expect := some "(apply (apply f a) b)" }
+  , { name := "does not disturb a two-argument call written with a space: f (a, b)"
+    , src := "def main = f (a, b)"
+    , expect := some "(apply (apply f a) b)" }
+  , { name := "keeps a tight C-style call's .field bound to the call result, not the argument (#424)"
+    , src := "def main = nats(0).tail"
+    , expect := some "(project (apply nats (int32 0)) \"tail\")" }
+  , { name := "keeps a tight call's .field bound to the call result even with a compound argument (#424)"
+    , src := "def main = f(g x).field"
+    , expect := some "(project (apply f (apply g x)) \"field\")" } ]
 
 def run : IO Nat := do
   let mut failed := 0

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -747,7 +747,24 @@ private def cases : List Case :=
   , { name := "binds .field to a parenthesized argument in a non-first position too (#424)"
     , src := "def main = f a (g x).field"
     , expect := some
-        "(apply (apply f a) (project (parens (apply g x)) \"field\"))" } ]
+        "(apply (apply f a) (project (parens (apply g x)) \"field\"))" }
+  , { name := "a tight call's .field binds to the call result for a lambda-headed atom too (#424 follow-up)"
+    , src := "def main = { x -> x }(5).field"
+    , expect := some
+        "(project (apply (fn ((clause (x) (seq (do x))))) (int32 5)) \"field\")" }
+  , { name := "a tight call's .field binds to the call result for a tuple-headed atom too (#424 follow-up)"
+    , src := "def main = (a, b)(5).field"
+    , expect := some "(project (apply (tuple a b) (int32 5)) \"field\")" }
+  , { name := "a tight call's .field binds to the call result for a record-headed atom too (#424 follow-up)"
+    , src := "def main = { .a -> 1, .b -> 2 }(5).field"
+    , expect := some
+        "(project (apply (record (a (int32 1)) (b (int32 2))) (int32 5)) \"field\")" }
+  , { name := "keeps a tight two-argument call's .field bound to the call result: f(a, b).field"
+    , src := "def main = f(a, b).field"
+    , expect := some "(project (apply (apply f a) b) \"field\")" }
+  , { name := "keeps a tight nullary call's .field bound to the call result: f().field"
+    , src := "def main = f().field"
+    , expect := some "(project (apply f (tuple)) \"field\")" } ]
 
 def run : IO Nat := do
   let mut failed := 0

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -737,7 +737,13 @@ private def cases : List Case :=
     , expect := some "(project (apply nats (int32 0)) \"tail\")" }
   , { name := "keeps a tight call's .field bound to the call result even with a compound argument (#424)"
     , src := "def main = f(g x).field"
-    , expect := some "(project (apply f (apply g x)) \"field\")" } ]
+    , expect := some "(project (apply f (apply g x)) \"field\")" }
+  , { name := "a tight call's closing paren may be on its own line before a tight dot (#424)"
+    , src := "def main = nats(\n  0\n).tail"
+    , expect := some "(project (apply nats (int32 0)) \"tail\")" }
+  , { name := "a loose call's closing paren may be on its own line before a tight dot (#424)"
+    , src := "def main = f (\n  g x\n).field"
+    , expect := some "(apply f (project (parens (apply g x)) \"field\"))" } ]
 
 def run : IO Nat := do
   let mut failed := 0

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -743,7 +743,11 @@ private def cases : List Case :=
     , expect := some "(project (apply nats (int32 0)) \"tail\")" }
   , { name := "a loose call's closing paren may be on its own line before a tight dot (#424)"
     , src := "def main = f (\n  g x\n).field"
-    , expect := some "(apply f (project (parens (apply g x)) \"field\"))" } ]
+    , expect := some "(apply f (project (parens (apply g x)) \"field\"))" }
+  , { name := "binds .field to a parenthesized argument in a non-first position too (#424)"
+    , src := "def main = f a (g x).field"
+    , expect := some
+        "(apply (apply f a) (project (parens (apply g x)) \"field\"))" } ]
 
 def run : IO Nat := do
   let mut failed := 0


### PR DESCRIPTION
> *This was generated by AI as a triage follow-up.*

Fixes #424.

## Bug

A `.field` chain immediately (no whitespace) following a parenthesized expression used as a function argument bound to the *whole enclosing application* instead of to that argument:

```
printString (toStringInt32 (mk 7).exitCode)
```

parsed as `(toStringInt32 (mk 7)).exitCode` instead of the intended `toStringInt32((mk 7).exitCode)` — a silent wrong-value bug (shape mismatch downstream), not a parse error.

## Why the obvious fix doesn't work

The naive rule — "a single parenthesized call-arg immediately followed by `.field` binds the dot to that arg" — is unsound. By the time the postfix loop runs, all whitespace since the accumulator has already been consumed, so a tight `nats(0)` and a loose `toStringInt32 (mk 7)` are the *same parse state*. Applying that rule uniformly fixes the reported case but silently breaks the corpus's existing call-then-project convention — confirmed by an actual test failure on `nats(0).tail.tail.tail.head` in `test/testcases/malgo/CodataE2E.mlg` (golden output changed from "project off the call result" to "project off the argument"). Other real corpus cases with the same shape: `addThree(1)(2)(3).apply` (`CopatternApplyChain.mlg`), `ifChain(True).then(t).else(e)` (`Bool.mlg`).

## The actual fix

`pVariable`'s existing tight-dot-chain folding is generalized into `pTightPostfix` (`lean/Malgo/Parser/CStyle.lean`), which now also absorbs an immediately-adjacent (no-whitespace) C-style call `(args)`, interleaved with `.field` projections, recursively. A *tight* `name(args)...` chain is therefore fully consumed at the atom level, before `pApply`'s postfix loop ever runs — preserving the call-then-project convention exactly as before (`nats(0).tail` still projects off the call).

Because of that, `pApplyPostfix`'s own call-args branch is now only ever reached, for an identifier-headed chain, once whitespace has already intervened since the accumulator. That makes it safe for that branch to give a single parenthesized argument's immediately-following `.field` chain the opposite treatment: bind it to the argument instead of to the call — which is the actual fix for #424.

A **spaced** dot (`f (expr) .field`) is unaffected: it still postfixes over the whole application, consistent with the existing `f a state .dict` precedent (#345's `ParserSurface` tests).

## Verification

- `mise run test -- --match Parser`: 24/24 (was 23/24 with the naive rule — `CodataE2E` regressed and was caught before this was pushed).
- Full `mise run test`: 608/608, all gates green.
- `bash scripts/zig-golden.sh`: 80/80 passed, no leaks.
- `bash scripts/selfhost-golden.sh`: PASS 79, FAIL 0 (perf-gate counters improved slightly, well within the ratchet).
- New `ParserSurface` cases (`lean/Test/Main.lean`) cover: `f (g x).field` / `f (g x).a.b` (the fix), `f (g x) .field` (spaced, unchanged), `f(a, b)` / `f (a, b)` (two-arg regression guard — still two-argument calls, not a tuple argument), `nats(0).tail` and `f(g x).field` (tight-call regression guard — still projects off the call result), and two multi-line-call cases (closing paren on its own line, both tight and loose) probing the branches that now consume `)` without auto-skipping trailing whitespace.
- `test/testcases/malgo/error/NeedSpaceDot.mlg` (`.expect` = `rename`) re-checked: unaffected. It's a `scripts/cli-gate.sh` exit-code fixture (message text deliberately not compared) and its specific construct (`(succ.succ) 1`, a fresh parenthesized atom, not a call argument) never reaches the changed code paths.

## Scope cut: self-hosted parser not touched

`runtime/malgo/compiler/Parser.mlg` is deliberately left unchanged. Its lexer (`runtime/malgo/compiler/Lexer.mlg`) discards whitespace entirely — tokens carry no adjacency information — so the signal this fix depends on (tight vs. loose) does not exist in that token stream. Mirroring the unsound global rule there would reproduce the exact regression this PR avoids on the Lean side; a real fix needs a lexer change to track adjacency, which is a separate follow-up. The originating issue's own triage brief marks the self-hosted parser as out of scope unless trivial — it isn't.

## Update: rebased onto current master

This branch has been rebased onto current `master`, which now includes #414's consolidation of this grammar's six bracketed-list parsers into a shared `pBracketedList` (in the same file, `lean/Malgo/Parser/CStyle.lean`). The one conflict was mechanical: this PR's commit relocates `pVariable`/`pVariableFoldFields` out of their old spot (into the mutual-recursion block further down, redesigned as `pTightPostfix`), and #414 inserted `pBracketedList` immediately after that same old spot — resolved by keeping both changes (dropping the stale pre-relocation copy, keeping `pBracketedList`). `pBracketedList` and this fix's `pTightPostfix`/`pApplyPostfix` changes don't interact: `pBracketedList` (via `pParenTuple`) is only ever reached for the *first* atom of an application chain, never from the postfix loop that this fix touches — confirmed with a new case, `f a (g x).field` (a parenthesized argument in a non-first position), which goes through the same call-args branch as the already-tested `f (g x).field`.

Re-verified all four gates post-rebase: `mise run test -- --match Parser` (24/24), full `mise run test` (608/608), `zig-golden.sh` (80/80, no leaks — a same-session concurrent run against `selfhost-golden.sh` produced a one-off `Bool.mlg` compile-fail from Zig build contention, not reproducible when run alone), `selfhost-golden.sh` (PASS 79/FAIL 0, with perf-gate counters identical to the pre-rebase run). `parser-surface` is now 14/14 with the added non-first-position case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## （日本語訳）

> *このコメントはAIによるトリアージのフォローアップとして生成されました。*

#424 を修正。

### バグ

関数の引数として使われている括弧式に、空白を挟まず直接続く `.field` チェーンが、その引数ではなく*外側の呼び出し全体*に結合してしまっていた:

```
printString (toStringInt32 (mk 7).exitCode)
```

これは `toStringInt32((mk 7).exitCode)` という意図した解析ではなく `(toStringInt32 (mk 7)).exitCode` として解析されていた — パースエラーではなく、静かに間違った値を生む不具合（後段での型のミスマッチ）。

### 素朴な修正がうまくいかない理由

「括弧で囲まれた単一の呼び出し引数に直接続く `.field` は、その引数にドットを結合する」という素朴なルールは健全ではない。postfix ループが実行される時点で、直前の空白はすでにすべて消費済みのため、密着した `nats(0)` と空白を挟んだ `toStringInt32 (mk 7)` は*同一のパース状態*になってしまう。このルールを一律に適用すると報告された事例は修正されるが、コーパスに既存の「呼び出し→projectする」という規約を静かに破壊する — `test/testcases/malgo/CodataE2E.mlg` の `nats(0).tail.tail.tail.head` で実際にテスト失敗が発生することで確認された（golden出力が「呼び出し結果からproject」から「引数からproject」に変化した）。同じ形をした他の実コーパス例: `addThree(1)(2)(3).apply`（`CopatternApplyChain.mlg`）、`ifChain(True).then(t).else(e)`（`Bool.mlg`）。

### 実際の修正

`pVariable` が既に持っていた「密着したドットチェーンの畳み込み」処理を `pTightPostfix`（`lean/Malgo/Parser/CStyle.lean`）に一般化し、これが空白なしで直接続くCスタイル呼び出し `(args)` も、`.field` projection と交互に再帰的に吸収するようにした。これにより*密着した* `name(args)...` チェーンは、`pApply` の postfix ループが走る前に、atomレベルで完全に消費される — 従来通り「呼び出し→project」の規約は保たれる（`nats(0).tail` は依然として呼び出し結果からprojectする）。

その結果、識別子始まりのチェーンに対して `pApplyPostfix` 自身の呼び出し引数ブランチに到達するのは、アキュムレータ以降に空白が既に挟まった場合のみになる。これにより、そのブランチは括弧付き単一引数の直後に続く `.field` チェーンに対して、逆の扱い（呼び出し結果ではなく引数側に結合する）を安全に行えるようになる — これが #424 の本質的な修正である。

**空白を挟んだ**ドット（`f (expr) .field`）には影響しない。従来通りアプリケーション全体へのpostfixとして扱われ、既存の `f a state .dict` の前例（#345 の `ParserSurface` テスト）と整合する。

### 検証

- `mise run test -- --match Parser`: 24/24（素朴なルールでは23/24 — `CodataE2E` が回帰し、pushする前に検出された）。
- `mise run test` フルスイート: 608/608、全ゲートgreen。
- `bash scripts/zig-golden.sh`: 80/80 pass、リークなし。
- `bash scripts/selfhost-golden.sh`: PASS 79、FAIL 0（perf-gateのカウンタはわずかに改善、ラチェットの範囲内）。
- 新しい `ParserSurface` ケース（`lean/Test/Main.lean`）でカバー: `f (g x).field` / `f (g x).a.b`（本修正）、`f (g x) .field`（空白あり、変更なし）、`f(a, b)` / `f (a, b)`（2引数の回帰防止 — タプル引数ではなく2引数呼び出しのまま）、`nats(0).tail` と `f(g x).field`（密着呼び出しの回帰防止 — 呼び出し結果からのprojectのまま）、および複数行呼び出しの2ケース（閉じ括弧が単独の行にある場合、密着・空白ありの両方）で、末尾の空白を自動スキップせずに `)` を消費するようになったブランチを検証。
- `test/testcases/malgo/error/NeedSpaceDot.mlg`（`.expect` = `rename`）を再確認: 影響なし。これは `scripts/cli-gate.sh` の終了コードのみを見るfixture（メッセージ文言は意図的に比較対象外）であり、その構文（`(succ.succ) 1`、呼び出し引数ではなく単独の新しい括弧atom）は今回変更したコードパスに一切到達しない。

### スコープ外: 自己ホストパーサは未対応

`runtime/malgo/compiler/Parser.mlg` は意図的に変更していない。そのlexer（`runtime/malgo/compiler/Lexer.mlg`）は空白を完全に読み捨てるため — トークンに隣接情報が一切残らない — 本修正が依拠する信号（密着か空白ありか）がそのトークン列には存在しない。健全でないグローバルルールをそこに反映すれば、Lean側で今回避けたのと同じ回帰を再現してしまう。本当の修正にはlexerを変更して隣接情報を追跡する必要があり、それは別のフォローアップとする。元issueのトリアージbrief自体も、自己ホストパーサは「trivialでない限りスコープ外」としている — 実際trivialではない。

### 追記: 現在のmasterにrebase済み

このブランチは現在の `master` にrebase済みで、これには #414 によるこの文法の6つの括弧付きリストパーサを共有の `pBracketedList` に統合する変更（同じファイル `lean/Malgo/Parser/CStyle.lean`）が含まれている。コンフリクトは1件、機械的なもの: 本PRのコミットは `pVariable`/`pVariableFoldFields` を元の位置から移動している（相互再帰ブロックのさらに下、`pTightPostfix` として再設計）一方、#414はまさにその元の位置の直後に `pBracketedList` を挿入していた — 両方の変更を維持することで解決（移動前の古いコピーを削除し、`pBracketedList` は維持）。`pBracketedList` と本修正の `pTightPostfix`/`pApplyPostfix` の変更は相互作用しない: `pBracketedList`（`pParenTuple` 経由）はアプリケーションチェーンの*最初の*atomに対してのみ到達し、本修正が触れているpostfixループからは到達しない — 新しいケース `f a (g x).field`（非先頭位置の括弧引数）で確認済みで、これはすでにテスト済みの `f (g x).field` と同じ呼び出し引数ブランチを通る。

rebase後に4つのゲート全てを再検証: `mise run test -- --match Parser`（24/24）、`mise run test` フルスイート（608/608）、`zig-golden.sh`（80/80、リークなし — 同一セッション内で `selfhost-golden.sh` と同時実行した際にZigビルドのリソース競合による一回限りの `Bool.mlg` コンパイル失敗が発生したが、単独実行では再現しない）、`selfhost-golden.sh`（PASS 79/FAIL 0、perf-gateカウンタはrebase前と同一）。`parser-surface` は非先頭位置ケースを追加して14/14。
