### PR TITLE
fix(eval): implement malgo_panic in the Lean interpreter (#426)

### DIFF
--- a/.golden/Malgo.Debug.PrettyIR/testcases/CondPanic/golden
+++ b/.golden/Malgo.Debug.PrettyIR/testcases/CondPanic/golden
@@ -1,0 +1,1449 @@
+=== Parse ===
+import runtime/malgo/Builtin.mlg 
+
+import runtime/malgo/Prelude.mlg 
+
+def main =
+  fn {
+    _ ->
+      {
+        let _ = putStrLn("before cond")
+        cond( [ ( False
+        , fn {
+          _ ->
+            {
+              ()
+            }
+        } ) ] )
+      }
+  }
+
+=== Rename ===
+import runtime/malgo/Builtin.mlg 
+
+import runtime/malgo/Prelude.mlg 
+
+def main =
+  fn {
+    _#0 ->
+      {
+        let _#1 = putStrLn(String#("before cond"))
+        cond( Cons( ( False
+        , fn {
+          _#2 ->
+            {
+              ()
+            }
+        } ) )(Nil) )
+      }
+  }
+
+=== ToFun ===
+def main =
+  \param$3 ->
+    case param$3 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before cond"))
+        in
+          invoke cond( invoke Cons( Tuple( invoke False
+          , \param$4 ->
+            case param$4 of {
+              _#2 -> Tuple()
+            } ) )(invoke Nil) )
+    }
+
+=== SaturateCtor ===
+def main =
+  \param$3 ->
+    case param$3 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before cond"))
+        in
+          invoke cond( invoke Cons( Tuple( invoke False
+          , \param$4 ->
+            case param$4 of {
+              _#2 -> Tuple()
+            } ) )(invoke Nil) )
+    }
+
+=== ReuseSpecialize ===
+def main =
+  \param$3 ->
+    case param$3 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before cond"))
+        in
+          invoke cond( invoke Cons( Tuple( invoke False
+          , \param$4 ->
+            case param$4 of {
+              _#2 -> Tuple()
+            } ) )(invoke Nil) )
+    }
+
+=== ToCore ===
+def main(return$5) =
+  \param$3 return$6 . {
+    param$3 ~ select {
+      _#0 ->
+        invoke putStrLn ~ ( do return$11 . {
+          invoke String# ~ ("before cond", return$11)
+        }
+        , then _#1 -> {
+          invoke cond ~ ( do return$7 . {
+            invoke Cons ~ ( Tuple( do return$9 . {
+              invoke False ~ return$9
+            }
+            , \param$4 return$10 . {
+              param$4 ~ select {
+                _#2 -> Tuple() ~ return$10
+              }
+            } )
+            , ( do return$8 . {
+              invoke Nil ~ return$8
+            }
+            , return$7 ) )
+          }
+          , return$6 )
+        } )
+    }
+  } ~ return$5
+
+=== Flat ===
+def main(return$5) =
+  \param$3 return$6 . {
+    param$3 ~ select {
+      _#0 ->
+        invoke putStrLn ~ then outer$12 -> {
+          join return$11 = then inner$13 -> {
+            outer$12 ~ ( inner$13
+            , then _#1 -> {
+              invoke cond ~ then outer$14 -> {
+                join return$7 = then inner$15 -> {
+                  outer$14 ~ (inner$15, return$6)
+                }
+                in invoke Cons ~ then outer$16 -> {
+                  join label$20 = then inner$17 -> {
+                    outer$16 ~ ( inner$17
+                    , then outer$18 -> {
+                      join return$8 = then inner$19 -> {
+                        outer$18 ~ (inner$19, return$7)
+                      }
+                      in invoke Nil ~ return$8
+                    } )
+                  }
+                  in join return$9 = then var$21 -> {
+                    Tuple( var$21
+                    , \param$4 return$10 . {
+                      param$4 ~ select {
+                        _#2 -> Tuple() ~ return$10
+                      }
+                    } ) ~ label$20
+                  }
+                  in invoke False ~ return$9
+                }
+              }
+            } )
+          }
+          in invoke String# ~ ("before cond", return$11)
+        }
+    }
+  } ~ return$5
+
+=== Join ===
+def main(return$5) =
+  \param$3 return$6 . {
+    join select$33 = select {
+      _#0 ->
+        join then$32 = then outer$12 -> {
+          join return$11 = then inner$13 -> {
+            join then$30 = then _#1 -> {
+              join then$29 = then outer$14 -> {
+                join return$7 = then inner$15 -> {
+                  join apply$28 = (inner$15, return$6)
+                  in outer$14 ~ apply$28
+                }
+                in join then$27 = then outer$16 -> {
+                  join label$20 = then inner$17 -> {
+                    join then$25 = then outer$18 -> {
+                      join return$8 = then inner$19 -> {
+                        join apply$24 = (inner$19, return$7)
+                        in outer$18 ~ apply$24
+                      }
+                      in invoke Nil ~ return$8
+                    }
+                    in join apply$26 = (inner$17, then$25)
+                    in outer$16 ~ apply$26
+                  }
+                  in join return$9 = then var$21 -> {
+                    Tuple( var$21
+                    , \param$4 return$10 . {
+                      join select$23 = select {
+                        _#2 -> Tuple() ~ return$10
+                      }
+                      in param$4 ~ select$23
+                    } ) ~ label$20
+                  }
+                  in invoke False ~ return$9
+                }
+                in invoke Cons ~ then$27
+              }
+              in invoke cond ~ then$29
+            }
+            in join apply$31 = (inner$13, then$30)
+            in outer$12 ~ apply$31
+          }
+          in join apply$22 = ("before cond", return$11)
+          in invoke String# ~ apply$22
+        }
+        in invoke putStrLn ~ then$32
+    }
+    in param$3 ~ select$33
+  } ~ return$5
+
+=== ClosureConv ===
+toplevel fn main(return$5) =
+  let closure$76 = closure lambda$35()
+  return return$5(closure$76)
+
+closure fn lambda$35(self$36, param$3, return$6) =
+  if  then {
+    let _#0 = param$3
+    let then$32 = closure join$37(return$6)
+    return putStrLn(then$32)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$37(self$38, value$39) =
+  let return$6 = self$38.cap[0]
+  let return$11 = closure join$40(return$6, value$39)
+  let apply$22 = closure join$72(return$11)
+  return String#(apply$22)
+
+closure fn join$40(self$41, value$42) =
+  let return$6 = self$41.cap[0]
+  let value$39 = self$41.cap[1]
+  let then$30 = closure join$43(return$6)
+  return value$39(value$42, then$30)
+
+closure fn join$43(self$44, value$45) =
+  let return$6 = self$44.cap[0]
+  let then$29 = closure join$46(return$6)
+  return cond(then$29)
+
+closure fn join$46(self$47, value$48) =
+  let return$6 = self$47.cap[0]
+  let return$7 = closure join$49(return$6, value$48)
+  let then$27 = closure join$52(return$7)
+  return Cons(then$27)
+
+closure fn join$49(self$50, value$51) =
+  let return$6 = self$50.cap[0]
+  let value$48 = self$50.cap[1]
+  return value$48(value$51, return$6)
+
+closure fn join$52(self$53, value$54) =
+  let return$7 = self$53.cap[0]
+  let label$20 = closure join$55(return$7, value$54)
+  let return$9 = closure join$64(label$20)
+  return False(return$9)
+
+closure fn join$55(self$56, value$57) =
+  let return$7 = self$56.cap[0]
+  let value$54 = self$56.cap[1]
+  let then$25 = closure join$58(return$7)
+  return value$54(value$57, then$25)
+
+closure fn join$58(self$59, value$60) =
+  let return$7 = self$59.cap[0]
+  let return$8 = closure join$61(return$7, value$60)
+  return Nil(return$8)
+
+closure fn join$61(self$62, value$63) =
+  let return$7 = self$62.cap[0]
+  let value$60 = self$62.cap[1]
+  return value$60(value$63, return$7)
+
+closure fn join$64(self$65, value$66) =
+  let label$20 = self$65.cap[0]
+  let closure$70 = closure lambda$67()
+  let struct$71 = Tuple(value$66, closure$70)
+  return label$20(struct$71)
+
+closure fn lambda$67(self$68, param$4, return$10) =
+  if  then {
+    let _#2 = param$4
+    let struct$69 = Tuple()
+    return return$10(struct$69)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$72(self$73, value$74) =
+  let return$11 = self$73.cap[0]
+  let lit$75 = "before cond"
+  return value$74(lit$75, return$11)
+
+toplevel fn zig_main$79() =
+  let finish$77 = closure join$81()
+  let after_main$78 = closure join$84(finish$77)
+  return main(after_main$78)
+
+closure fn join$81(self$82, value$83) = return value$83
+
+closure fn join$84(self$85, value$86) =
+  let finish$77 = self$85.cap[0]
+  let struct$87 = Tuple()
+  return value$86(struct$87, finish$77)
+
+entry = zig_main$79
+
+=== Peephole ===
+toplevel fn main(return$5) =
+  let closure$76 = closure lambda$35()
+  return return$5(closure$76)
+
+closure fn lambda$35(self$36, param$3, return$6) =
+  if  then {
+    let then$32 = closure join$37(return$6)
+    return putStrLn(then$32)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$37(self$38, value$39) =
+  let return$6 = self$38.cap[0]
+  let return$11 = closure join$40(return$6, value$39)
+  let apply$22 = closure join$72(return$11)
+  return String#(apply$22)
+
+closure fn join$40(self$41, value$42) =
+  let return$6 = self$41.cap[0]
+  let value$39 = self$41.cap[1]
+  let then$30 = closure join$43(return$6)
+  return value$39(value$42, then$30)
+
+closure fn join$43(self$44, value$45) =
+  let return$6 = self$44.cap[0]
+  let then$29 = closure join$46(return$6)
+  return cond(then$29)
+
+closure fn join$46(self$47, value$48) =
+  let return$6 = self$47.cap[0]
+  let return$7 = closure join$49(return$6, value$48)
+  let then$27 = closure join$52(return$7)
+  return Cons(then$27)
+
+closure fn join$49(self$50, value$51) =
+  let return$6 = self$50.cap[0]
+  let value$48 = self$50.cap[1]
+  return value$48(value$51, return$6)
+
+closure fn join$52(self$53, value$54) =
+  let return$7 = self$53.cap[0]
+  let label$20 = closure join$55(return$7, value$54)
+  let return$9 = closure join$64(label$20)
+  return False(return$9)
+
+closure fn join$55(self$56, value$57) =
+  let return$7 = self$56.cap[0]
+  let value$54 = self$56.cap[1]
+  let then$25 = closure join$58(return$7)
+  return value$54(value$57, then$25)
+
+closure fn join$58(self$59, value$60) =
+  let return$7 = self$59.cap[0]
+  let return$8 = closure join$61(return$7, value$60)
+  return Nil(return$8)
+
+closure fn join$61(self$62, value$63) =
+  let return$7 = self$62.cap[0]
+  let value$60 = self$62.cap[1]
+  return value$60(value$63, return$7)
+
+closure fn join$64(self$65, value$66) =
+  let label$20 = self$65.cap[0]
+  let closure$70 = closure lambda$67()
+  let struct$71 = Tuple(value$66, closure$70)
+  return label$20(struct$71)
+
+closure fn lambda$67(self$68, param$4, return$10) =
+  if  then {
+    let struct$69 = Tuple()
+    return return$10(struct$69)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$72(self$73, value$74) =
+  let return$11 = self$73.cap[0]
+  let lit$75 = "before cond"
+  return value$74(lit$75, return$11)
+
+toplevel fn zig_main$79() =
+  let finish$77 = closure join$81()
+  let after_main$78 = closure join$84(finish$77)
+  return main(after_main$78)
+
+closure fn join$81(self$82, value$83) = return value$83
+
+closure fn join$84(self$85, value$86) =
+  let finish$77 = self$85.cap[0]
+  let struct$87 = Tuple()
+  return value$86(struct$87, finish$77)
+
+entry = zig_main$79
+
+=== Perceus ===
+toplevel fn main(return$5) =
+  let closure$76 = closure lambda$35()
+  return return$5(closure$76)
+
+closure fn lambda$35(self$36, param$3, return$6) =
+  drop param$3
+  drop self$36
+  if  then {
+    let then$32 = closure join$37(return$6)
+    return putStrLn(then$32)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$37(self$38, value$39) =
+  let return$6 = self$38.cap[0]
+  dup return$6
+  drop self$38
+  let return$11 = closure join$40(return$6, value$39)
+  let apply$22 = closure join$72(return$11)
+  return String#(apply$22)
+
+closure fn join$40(self$41, value$42) =
+  let return$6 = self$41.cap[0]
+  dup return$6
+  let value$39 = self$41.cap[1]
+  dup value$39
+  drop self$41
+  let then$30 = closure join$43(return$6)
+  return value$39(value$42, then$30)
+
+closure fn join$43(self$44, value$45) =
+  drop value$45
+  let return$6 = self$44.cap[0]
+  dup return$6
+  drop self$44
+  let then$29 = closure join$46(return$6)
+  return cond(then$29)
+
+closure fn join$46(self$47, value$48) =
+  let return$6 = self$47.cap[0]
+  dup return$6
+  drop self$47
+  let return$7 = closure join$49(return$6, value$48)
+  let then$27 = closure join$52(return$7)
+  return Cons(then$27)
+
+closure fn join$49(self$50, value$51) =
+  let return$6 = self$50.cap[0]
+  dup return$6
+  let value$48 = self$50.cap[1]
+  dup value$48
+  drop self$50
+  return value$48(value$51, return$6)
+
+closure fn join$52(self$53, value$54) =
+  let return$7 = self$53.cap[0]
+  dup return$7
+  drop self$53
+  let label$20 = closure join$55(return$7, value$54)
+  let return$9 = closure join$64(label$20)
+  return False(return$9)
+
+closure fn join$55(self$56, value$57) =
+  let return$7 = self$56.cap[0]
+  dup return$7
+  let value$54 = self$56.cap[1]
+  dup value$54
+  drop self$56
+  let then$25 = closure join$58(return$7)
+  return value$54(value$57, then$25)
+
+closure fn join$58(self$59, value$60) =
+  let return$7 = self$59.cap[0]
+  dup return$7
+  drop self$59
+  let return$8 = closure join$61(return$7, value$60)
+  return Nil(return$8)
+
+closure fn join$61(self$62, value$63) =
+  let return$7 = self$62.cap[0]
+  dup return$7
+  let value$60 = self$62.cap[1]
+  dup value$60
+  drop self$62
+  return value$60(value$63, return$7)
+
+closure fn join$64(self$65, value$66) =
+  let label$20 = self$65.cap[0]
+  dup label$20
+  drop self$65
+  let closure$70 = closure lambda$67()
+  let struct$71 = Tuple(value$66, closure$70)
+  return label$20(struct$71)
+
+closure fn lambda$67(self$68, param$4, return$10) =
+  drop param$4
+  drop self$68
+  if  then {
+    let struct$69 = Tuple()
+    return return$10(struct$69)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$72(self$73, value$74) =
+  let return$11 = self$73.cap[0]
+  dup return$11
+  drop self$73
+  let lit$75 = "before cond"
+  return value$74(lit$75, return$11)
+
+toplevel fn zig_main$79() =
+  let finish$77 = closure join$81()
+  let after_main$78 = closure join$84(finish$77)
+  return main(after_main$78)
+
+closure fn join$81(self$82, value$83) =
+  drop self$82
+  return value$83
+
+closure fn join$84(self$85, value$86) =
+  let finish$77 = self$85.cap[0]
+  dup finish$77
+  drop self$85
+  let struct$87 = Tuple()
+  return value$86(struct$87, finish$77)
+
+entry = zig_main$79
+
+=== Reuse ===
+toplevel fn main(return$5) =
+  let closure$76 = closure lambda$35()
+  return return$5(closure$76)
+
+closure fn lambda$35(self$36, param$3, return$6) =
+  drop param$3
+  drop self$36
+  if  then {
+    let then$32 = closure join$37(return$6)
+    return putStrLn(then$32)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$37(self$38, value$39) =
+  let return$6 = self$38.cap[0]
+  dup return$6
+  let return$11 = closure join$40(return$6, value$39)
+  let apply$22 = closure join$72(return$11)
+  drop self$38
+  return String#(apply$22)
+
+closure fn join$40(self$41, value$42) =
+  let return$6 = self$41.cap[0]
+  dup return$6
+  let value$39 = self$41.cap[1]
+  dup value$39
+  let then$30 = closure join$43(return$6)
+  drop self$41
+  return value$39(value$42, then$30)
+
+closure fn join$43(self$44, value$45) =
+  let return$6 = self$44.cap[0]
+  dup return$6
+  let then$29 = closure join$46(return$6)
+  drop value$45
+  drop self$44
+  return cond(then$29)
+
+closure fn join$46(self$47, value$48) =
+  let return$6 = self$47.cap[0]
+  dup return$6
+  let return$7 = closure join$49(return$6, value$48)
+  let then$27 = closure join$52(return$7)
+  drop self$47
+  return Cons(then$27)
+
+closure fn join$49(self$50, value$51) =
+  let return$6 = self$50.cap[0]
+  dup return$6
+  let value$48 = self$50.cap[1]
+  dup value$48
+  drop self$50
+  return value$48(value$51, return$6)
+
+closure fn join$52(self$53, value$54) =
+  let return$7 = self$53.cap[0]
+  dup return$7
+  let label$20 = closure join$55(return$7, value$54)
+  let return$9 = closure join$64(label$20)
+  drop self$53
+  return False(return$9)
+
+closure fn join$55(self$56, value$57) =
+  let return$7 = self$56.cap[0]
+  dup return$7
+  let value$54 = self$56.cap[1]
+  dup value$54
+  let then$25 = closure join$58(return$7)
+  drop self$56
+  return value$54(value$57, then$25)
+
+closure fn join$58(self$59, value$60) =
+  let return$7 = self$59.cap[0]
+  dup return$7
+  let return$8 = closure join$61(return$7, value$60)
+  drop self$59
+  return Nil(return$8)
+
+closure fn join$61(self$62, value$63) =
+  let return$7 = self$62.cap[0]
+  dup return$7
+  let value$60 = self$62.cap[1]
+  dup value$60
+  drop self$62
+  return value$60(value$63, return$7)
+
+closure fn join$64(self$65, value$66) =
+  let label$20 = self$65.cap[0]
+  dup label$20
+  let closure$70 = closure lambda$67()
+  dropReuse reuse$88 = self$65 /2
+  let struct$71 = reuse reuse$88 Tuple(value$66, closure$70)
+  return label$20(struct$71)
+
+closure fn lambda$67(self$68, param$4, return$10) =
+  if  then {
+    drop param$4
+    dropReuse reuse$89 = self$68 /0
+    let struct$69 = reuse reuse$89 Tuple()
+    return return$10(struct$69)
+  } else {
+    drop param$4
+    drop self$68
+    panic "no matching branch"
+  }
+
+closure fn join$72(self$73, value$74) =
+  let return$11 = self$73.cap[0]
+  dup return$11
+  let lit$75 = "before cond"
+  drop self$73
+  return value$74(lit$75, return$11)
+
+toplevel fn zig_main$79() =
+  let finish$77 = closure join$81()
+  let after_main$78 = closure join$84(finish$77)
+  return main(after_main$78)
+
+closure fn join$81(self$82, value$83) =
+  drop self$82
+  return value$83
+
+closure fn join$84(self$85, value$86) =
+  let finish$77 = self$85.cap[0]
+  dup finish$77
+  dropReuse reuse$90 = self$85 /0
+  let struct$87 = reuse reuse$90 Tuple()
+  return value$86(struct$87, finish$77)
+
+entry = zig_main$79
+
+=== DIFFS ===
+
+=== Parse -> Rename ===
+  import runtime/malgo/Builtin.mlg 
+  
+  import runtime/malgo/Prelude.mlg 
+  
+  def main =
+    fn {
+-     _ ->
++     _#0 ->
+        {
+-         let _ = putStrLn("before cond")
++         let _#1 = putStrLn(String#("before cond"))
+-         cond( [ ( False
++         cond( Cons( ( False
+          , fn {
+-           _ ->
++           _#2 ->
+              {
+                ()
+              }
+-         } ) ] )
++         } ) )(Nil) )
+        }
+    }
+
+
+=== Rename -> ToFun ===
+- import runtime/malgo/Builtin.mlg 
+- 
+- import runtime/malgo/Prelude.mlg 
+- 
+  def main =
+-   fn {
++   \param$3 ->
+-     _#0 ->
++     case param$3 of {
+-       {
++       _#0 ->
+-         let _#1 = putStrLn(String#("before cond"))
++         let _#1 =
+-         cond( Cons( ( False
++           invoke putStrLn(invoke String#("before cond"))
+-         , fn {
++         in
+-           _#2 ->
++           invoke cond( invoke Cons( Tuple( invoke False
+-             {
++           , \param$4 ->
+-               ()
++             case param$4 of {
+-             }
++               _#2 -> Tuple()
+-         } ) )(Nil) )
++             } ) )(invoke Nil) )
+-       }
++     }
+-   }
+
+
+=== ToFun -> SaturateCtor ===
+  def main =
+    \param$3 ->
+      case param$3 of {
+        _#0 ->
+          let _#1 =
+            invoke putStrLn(invoke String#("before cond"))
+          in
+            invoke cond( invoke Cons( Tuple( invoke False
+            , \param$4 ->
+              case param$4 of {
+                _#2 -> Tuple()
+              } ) )(invoke Nil) )
+      }
+
+
+=== SaturateCtor -> ReuseSpecialize ===
+  def main =
+    \param$3 ->
+      case param$3 of {
+        _#0 ->
+          let _#1 =
+            invoke putStrLn(invoke String#("before cond"))
+          in
+            invoke cond( invoke Cons( Tuple( invoke False
+            , \param$4 ->
+              case param$4 of {
+                _#2 -> Tuple()
+              } ) )(invoke Nil) )
+      }
+
+
+=== ReuseSpecialize -> ToCore ===
+- def main =
++ def main(return$5) =
+-   \param$3 ->
++   \param$3 return$6 . {
+-     case param$3 of {
++     param$3 ~ select {
+        _#0 ->
+-         let _#1 =
++         invoke putStrLn ~ ( do return$11 . {
+-           invoke putStrLn(invoke String#("before cond"))
++           invoke String# ~ ("before cond", return$11)
+-         in
++         }
+-           invoke cond( invoke Cons( Tuple( invoke False
++         , then _#1 -> {
+-           , \param$4 ->
++           invoke cond ~ ( do return$7 . {
+-             case param$4 of {
++             invoke Cons ~ ( Tuple( do return$9 . {
+-               _#2 -> Tuple()
++               invoke False ~ return$9
+-             } ) )(invoke Nil) )
++             }
++             , \param$4 return$10 . {
++               param$4 ~ select {
++                 _#2 -> Tuple() ~ return$10
++               }
++             } )
++             , ( do return$8 . {
++               invoke Nil ~ return$8
++             }
++             , return$7 ) )
++           }
++           , return$6 )
++         } )
+      }
++   } ~ return$5
+
+
+=== ToCore -> Flat ===
+  def main(return$5) =
+    \param$3 return$6 . {
+      param$3 ~ select {
+        _#0 ->
+-         invoke putStrLn ~ ( do return$11 . {
++         invoke putStrLn ~ then outer$12 -> {
+-           invoke String# ~ ("before cond", return$11)
++           join return$11 = then inner$13 -> {
+-         }
++             outer$12 ~ ( inner$13
+-         , then _#1 -> {
++             , then _#1 -> {
+-           invoke cond ~ ( do return$7 . {
++               invoke cond ~ then outer$14 -> {
+-             invoke Cons ~ ( Tuple( do return$9 . {
++                 join return$7 = then inner$15 -> {
+-               invoke False ~ return$9
++                   outer$14 ~ (inner$15, return$6)
+-             }
++                 }
+-             , \param$4 return$10 . {
++                 in invoke Cons ~ then outer$16 -> {
+-               param$4 ~ select {
++                   join label$20 = then inner$17 -> {
+-                 _#2 -> Tuple() ~ return$10
++                     outer$16 ~ ( inner$17
++                     , then outer$18 -> {
++                       join return$8 = then inner$19 -> {
++                         outer$18 ~ (inner$19, return$7)
++                       }
++                       in invoke Nil ~ return$8
++                     } )
++                   }
++                   in join return$9 = then var$21 -> {
++                     Tuple( var$21
++                     , \param$4 return$10 . {
++                       param$4 ~ select {
++                         _#2 -> Tuple() ~ return$10
++                       }
++                     } ) ~ label$20
++                   }
++                   in invoke False ~ return$9
++                 }
+                }
+              } )
+-             , ( do return$8 . {
+-               invoke Nil ~ return$8
+-             }
+-             , return$7 ) )
+            }
+-           , return$6 )
++           in invoke String# ~ ("before cond", return$11)
+-         } )
++         }
+      }
+    } ~ return$5
+
+
+=== Flat -> Join ===
+  def main(return$5) =
+    \param$3 return$6 . {
+-     param$3 ~ select {
++     join select$33 = select {
+        _#0 ->
+-         invoke putStrLn ~ then outer$12 -> {
++         join then$32 = then outer$12 -> {
+            join return$11 = then inner$13 -> {
+-             outer$12 ~ ( inner$13
++             join then$30 = then _#1 -> {
+-             , then _#1 -> {
++               join then$29 = then outer$14 -> {
+-               invoke cond ~ then outer$14 -> {
+                  join return$7 = then inner$15 -> {
+-                   outer$14 ~ (inner$15, return$6)
++                   join apply$28 = (inner$15, return$6)
++                   in outer$14 ~ apply$28
+                  }
+-                 in invoke Cons ~ then outer$16 -> {
++                 in join then$27 = then outer$16 -> {
+                    join label$20 = then inner$17 -> {
+-                     outer$16 ~ ( inner$17
++                     join then$25 = then outer$18 -> {
+-                     , then outer$18 -> {
+                        join return$8 = then inner$19 -> {
+-                         outer$18 ~ (inner$19, return$7)
++                         join apply$24 = (inner$19, return$7)
++                         in outer$18 ~ apply$24
+                        }
+                        in invoke Nil ~ return$8
+-                     } )
++                     }
++                     in join apply$26 = (inner$17, then$25)
++                     in outer$16 ~ apply$26
+                    }
+                    in join return$9 = then var$21 -> {
+                      Tuple( var$21
+                      , \param$4 return$10 . {
+-                       param$4 ~ select {
++                       join select$23 = select {
+                          _#2 -> Tuple() ~ return$10
+                        }
++                       in param$4 ~ select$23
+                      } ) ~ label$20
+                    }
+                    in invoke False ~ return$9
+                  }
++                 in invoke Cons ~ then$27
+                }
+-             } )
++               in invoke cond ~ then$29
++             }
++             in join apply$31 = (inner$13, then$30)
++             in outer$12 ~ apply$31
+            }
+-           in invoke String# ~ ("before cond", return$11)
++           in join apply$22 = ("before cond", return$11)
++           in invoke String# ~ apply$22
+          }
++         in invoke putStrLn ~ then$32
+      }
++     in param$3 ~ select$33
+    } ~ return$5
+
+
+=== Join -> ClosureConv ===
+- def main(return$5) =
++ toplevel fn main(return$5) =
+-   \param$3 return$6 . {
++   let closure$76 = closure lambda$35()
+-     join select$33 = select {
++   return return$5(closure$76)
+-       _#0 ->
++ 
+-         join then$32 = then outer$12 -> {
++ closure fn lambda$35(self$36, param$3, return$6) =
+-           join return$11 = then inner$13 -> {
++   if  then {
+-             join then$30 = then _#1 -> {
++     let _#0 = param$3
+-               join then$29 = then outer$14 -> {
++     let then$32 = closure join$37(return$6)
+-                 join return$7 = then inner$15 -> {
++     return putStrLn(then$32)
+-                   join apply$28 = (inner$15, return$6)
++   } else {
+-                   in outer$14 ~ apply$28
++     panic "no matching branch"
+-                 }
++   }
+-                 in join then$27 = then outer$16 -> {
++ 
+-                   join label$20 = then inner$17 -> {
++ closure fn join$37(self$38, value$39) =
+-                     join then$25 = then outer$18 -> {
++   let return$6 = self$38.cap[0]
+-                       join return$8 = then inner$19 -> {
++   let return$11 = closure join$40(return$6, value$39)
+-                         join apply$24 = (inner$19, return$7)
++   let apply$22 = closure join$72(return$11)
+-                         in outer$18 ~ apply$24
++   return String#(apply$22)
+-                       }
++ 
+-                       in invoke Nil ~ return$8
++ closure fn join$40(self$41, value$42) =
+-                     }
++   let return$6 = self$41.cap[0]
+-                     in join apply$26 = (inner$17, then$25)
++   let value$39 = self$41.cap[1]
+-                     in outer$16 ~ apply$26
++   let then$30 = closure join$43(return$6)
+-                   }
++   return value$39(value$42, then$30)
+-                   in join return$9 = then var$21 -> {
++ 
+-                     Tuple( var$21
++ closure fn join$43(self$44, value$45) =
+-                     , \param$4 return$10 . {
++   let return$6 = self$44.cap[0]
+-                       join select$23 = select {
++   let then$29 = closure join$46(return$6)
+-                         _#2 -> Tuple() ~ return$10
++   return cond(then$29)
+-                       }
++ 
+-                       in param$4 ~ select$23
++ closure fn join$46(self$47, value$48) =
+-                     } ) ~ label$20
++   let return$6 = self$47.cap[0]
+-                   }
++   let return$7 = closure join$49(return$6, value$48)
+-                   in invoke False ~ return$9
++   let then$27 = closure join$52(return$7)
+-                 }
++   return Cons(then$27)
+-                 in invoke Cons ~ then$27
++ 
+-               }
++ closure fn join$49(self$50, value$51) =
+-               in invoke cond ~ then$29
++   let return$6 = self$50.cap[0]
+-             }
++   let value$48 = self$50.cap[1]
+-             in join apply$31 = (inner$13, then$30)
++   return value$48(value$51, return$6)
+-             in outer$12 ~ apply$31
++ 
+-           }
++ closure fn join$52(self$53, value$54) =
+-           in join apply$22 = ("before cond", return$11)
++   let return$7 = self$53.cap[0]
+-           in invoke String# ~ apply$22
++   let label$20 = closure join$55(return$7, value$54)
+-         }
++   let return$9 = closure join$64(label$20)
+-         in invoke putStrLn ~ then$32
++   return False(return$9)
+-     }
++ 
+-     in param$3 ~ select$33
++ closure fn join$55(self$56, value$57) =
+-   } ~ return$5
++   let return$7 = self$56.cap[0]
++   let value$54 = self$56.cap[1]
++   let then$25 = closure join$58(return$7)
++   return value$54(value$57, then$25)
++ 
++ closure fn join$58(self$59, value$60) =
++   let return$7 = self$59.cap[0]
++   let return$8 = closure join$61(return$7, value$60)
++   return Nil(return$8)
++ 
++ closure fn join$61(self$62, value$63) =
++   let return$7 = self$62.cap[0]
++   let value$60 = self$62.cap[1]
++   return value$60(value$63, return$7)
++ 
++ closure fn join$64(self$65, value$66) =
++   let label$20 = self$65.cap[0]
++   let closure$70 = closure lambda$67()
++   let struct$71 = Tuple(value$66, closure$70)
++   return label$20(struct$71)
++ 
++ closure fn lambda$67(self$68, param$4, return$10) =
++   if  then {
++     let _#2 = param$4
++     let struct$69 = Tuple()
++     return return$10(struct$69)
++   } else {
++     panic "no matching branch"
++   }
++ 
++ closure fn join$72(self$73, value$74) =
++   let return$11 = self$73.cap[0]
++   let lit$75 = "before cond"
++   return value$74(lit$75, return$11)
++ 
++ toplevel fn zig_main$79() =
++   let finish$77 = closure join$81()
++   let after_main$78 = closure join$84(finish$77)
++   return main(after_main$78)
++ 
++ closure fn join$81(self$82, value$83) = return value$83
++ 
++ closure fn join$84(self$85, value$86) =
++   let finish$77 = self$85.cap[0]
++   let struct$87 = Tuple()
++   return value$86(struct$87, finish$77)
++ 
++ entry = zig_main$79
+
+
+=== ClosureConv -> Peephole ===
+  toplevel fn main(return$5) =
+    let closure$76 = closure lambda$35()
+    return return$5(closure$76)
+  
+  closure fn lambda$35(self$36, param$3, return$6) =
+    if  then {
+-     let _#0 = param$3
+      let then$32 = closure join$37(return$6)
+      return putStrLn(then$32)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$37(self$38, value$39) =
+    let return$6 = self$38.cap[0]
+    let return$11 = closure join$40(return$6, value$39)
+    let apply$22 = closure join$72(return$11)
+    return String#(apply$22)
+  
+  closure fn join$40(self$41, value$42) =
+    let return$6 = self$41.cap[0]
+    let value$39 = self$41.cap[1]
+    let then$30 = closure join$43(return$6)
+    return value$39(value$42, then$30)
+  
+  closure fn join$43(self$44, value$45) =
+    let return$6 = self$44.cap[0]
+    let then$29 = closure join$46(return$6)
+    return cond(then$29)
+  
+  closure fn join$46(self$47, value$48) =
+    let return$6 = self$47.cap[0]
+    let return$7 = closure join$49(return$6, value$48)
+    let then$27 = closure join$52(return$7)
+    return Cons(then$27)
+  
+  closure fn join$49(self$50, value$51) =
+    let return$6 = self$50.cap[0]
+    let value$48 = self$50.cap[1]
+    return value$48(value$51, return$6)
+  
+  closure fn join$52(self$53, value$54) =
+    let return$7 = self$53.cap[0]
+    let label$20 = closure join$55(return$7, value$54)
+    let return$9 = closure join$64(label$20)
+    return False(return$9)
+  
+  closure fn join$55(self$56, value$57) =
+    let return$7 = self$56.cap[0]
+    let value$54 = self$56.cap[1]
+    let then$25 = closure join$58(return$7)
+    return value$54(value$57, then$25)
+  
+  closure fn join$58(self$59, value$60) =
+    let return$7 = self$59.cap[0]
+    let return$8 = closure join$61(return$7, value$60)
+    return Nil(return$8)
+  
+  closure fn join$61(self$62, value$63) =
+    let return$7 = self$62.cap[0]
+    let value$60 = self$62.cap[1]
+    return value$60(value$63, return$7)
+  
+  closure fn join$64(self$65, value$66) =
+    let label$20 = self$65.cap[0]
+    let closure$70 = closure lambda$67()
+    let struct$71 = Tuple(value$66, closure$70)
+    return label$20(struct$71)
+  
+  closure fn lambda$67(self$68, param$4, return$10) =
+    if  then {
+-     let _#2 = param$4
+      let struct$69 = Tuple()
+      return return$10(struct$69)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$72(self$73, value$74) =
+    let return$11 = self$73.cap[0]
+    let lit$75 = "before cond"
+    return value$74(lit$75, return$11)
+  
+  toplevel fn zig_main$79() =
+    let finish$77 = closure join$81()
+    let after_main$78 = closure join$84(finish$77)
+    return main(after_main$78)
+  
+  closure fn join$81(self$82, value$83) = return value$83
+  
+  closure fn join$84(self$85, value$86) =
+    let finish$77 = self$85.cap[0]
+    let struct$87 = Tuple()
+    return value$86(struct$87, finish$77)
+  
+  entry = zig_main$79
+
+
+=== Peephole -> Perceus ===
+  toplevel fn main(return$5) =
+    let closure$76 = closure lambda$35()
+    return return$5(closure$76)
+  
+  closure fn lambda$35(self$36, param$3, return$6) =
++   drop param$3
++   drop self$36
+    if  then {
+      let then$32 = closure join$37(return$6)
+      return putStrLn(then$32)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$37(self$38, value$39) =
+    let return$6 = self$38.cap[0]
++   dup return$6
++   drop self$38
+    let return$11 = closure join$40(return$6, value$39)
+    let apply$22 = closure join$72(return$11)
+    return String#(apply$22)
+  
+  closure fn join$40(self$41, value$42) =
+    let return$6 = self$41.cap[0]
++   dup return$6
+    let value$39 = self$41.cap[1]
++   dup value$39
++   drop self$41
+    let then$30 = closure join$43(return$6)
+    return value$39(value$42, then$30)
+  
+  closure fn join$43(self$44, value$45) =
++   drop value$45
+    let return$6 = self$44.cap[0]
++   dup return$6
++   drop self$44
+    let then$29 = closure join$46(return$6)
+    return cond(then$29)
+  
+  closure fn join$46(self$47, value$48) =
+    let return$6 = self$47.cap[0]
++   dup return$6
++   drop self$47
+    let return$7 = closure join$49(return$6, value$48)
+    let then$27 = closure join$52(return$7)
+    return Cons(then$27)
+  
+  closure fn join$49(self$50, value$51) =
+    let return$6 = self$50.cap[0]
++   dup return$6
+    let value$48 = self$50.cap[1]
++   dup value$48
++   drop self$50
+    return value$48(value$51, return$6)
+  
+  closure fn join$52(self$53, value$54) =
+    let return$7 = self$53.cap[0]
++   dup return$7
++   drop self$53
+    let label$20 = closure join$55(return$7, value$54)
+    let return$9 = closure join$64(label$20)
+    return False(return$9)
+  
+  closure fn join$55(self$56, value$57) =
+    let return$7 = self$56.cap[0]
++   dup return$7
+    let value$54 = self$56.cap[1]
++   dup value$54
++   drop self$56
+    let then$25 = closure join$58(return$7)
+    return value$54(value$57, then$25)
+  
+  closure fn join$58(self$59, value$60) =
+    let return$7 = self$59.cap[0]
++   dup return$7
++   drop self$59
+    let return$8 = closure join$61(return$7, value$60)
+    return Nil(return$8)
+  
+  closure fn join$61(self$62, value$63) =
+    let return$7 = self$62.cap[0]
++   dup return$7
+    let value$60 = self$62.cap[1]
++   dup value$60
++   drop self$62
+    return value$60(value$63, return$7)
+  
+  closure fn join$64(self$65, value$66) =
+    let label$20 = self$65.cap[0]
++   dup label$20
++   drop self$65
+    let closure$70 = closure lambda$67()
+    let struct$71 = Tuple(value$66, closure$70)
+    return label$20(struct$71)
+  
+  closure fn lambda$67(self$68, param$4, return$10) =
++   drop param$4
++   drop self$68
+    if  then {
+      let struct$69 = Tuple()
+      return return$10(struct$69)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$72(self$73, value$74) =
+    let return$11 = self$73.cap[0]
++   dup return$11
++   drop self$73
+    let lit$75 = "before cond"
+    return value$74(lit$75, return$11)
+  
+  toplevel fn zig_main$79() =
+    let finish$77 = closure join$81()
+    let after_main$78 = closure join$84(finish$77)
+    return main(after_main$78)
+  
+- closure fn join$81(self$82, value$83) = return value$83
++ closure fn join$81(self$82, value$83) =
++   drop self$82
++   return value$83
+  
+  closure fn join$84(self$85, value$86) =
+    let finish$77 = self$85.cap[0]
++   dup finish$77
++   drop self$85
+    let struct$87 = Tuple()
+    return value$86(struct$87, finish$77)
+  
+  entry = zig_main$79
+
+
+=== Perceus -> Reuse ===
+  toplevel fn main(return$5) =
+    let closure$76 = closure lambda$35()
+    return return$5(closure$76)
+  
+  closure fn lambda$35(self$36, param$3, return$6) =
+    drop param$3
+    drop self$36
+    if  then {
+      let then$32 = closure join$37(return$6)
+      return putStrLn(then$32)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$37(self$38, value$39) =
+    let return$6 = self$38.cap[0]
+    dup return$6
+-   drop self$38
+    let return$11 = closure join$40(return$6, value$39)
+    let apply$22 = closure join$72(return$11)
++   drop self$38
+    return String#(apply$22)
+  
+  closure fn join$40(self$41, value$42) =
+    let return$6 = self$41.cap[0]
+    dup return$6
+    let value$39 = self$41.cap[1]
+    dup value$39
+-   drop self$41
+    let then$30 = closure join$43(return$6)
++   drop self$41
+    return value$39(value$42, then$30)
+  
+  closure fn join$43(self$44, value$45) =
+-   drop value$45
+    let return$6 = self$44.cap[0]
+    dup return$6
+-   drop self$44
+    let then$29 = closure join$46(return$6)
++   drop value$45
++   drop self$44
+    return cond(then$29)
+  
+  closure fn join$46(self$47, value$48) =
+    let return$6 = self$47.cap[0]
+    dup return$6
+-   drop self$47
+    let return$7 = closure join$49(return$6, value$48)
+    let then$27 = closure join$52(return$7)
++   drop self$47
+    return Cons(then$27)
+  
+  closure fn join$49(self$50, value$51) =
+    let return$6 = self$50.cap[0]
+    dup return$6
+    let value$48 = self$50.cap[1]
+    dup value$48
+    drop self$50
+    return value$48(value$51, return$6)
+  
+  closure fn join$52(self$53, value$54) =
+    let return$7 = self$53.cap[0]
+    dup return$7
+-   drop self$53
+    let label$20 = closure join$55(return$7, value$54)
+    let return$9 = closure join$64(label$20)
++   drop self$53
+    return False(return$9)
+  
+  closure fn join$55(self$56, value$57) =
+    let return$7 = self$56.cap[0]
+    dup return$7
+    let value$54 = self$56.cap[1]
+    dup value$54
+-   drop self$56
+    let then$25 = closure join$58(return$7)
++   drop self$56
+    return value$54(value$57, then$25)
+  
+  closure fn join$58(self$59, value$60) =
+    let return$7 = self$59.cap[0]
+    dup return$7
+-   drop self$59
+    let return$8 = closure join$61(return$7, value$60)
++   drop self$59
+    return Nil(return$8)
+  
+  closure fn join$61(self$62, value$63) =
+    let return$7 = self$62.cap[0]
+    dup return$7
+    let value$60 = self$62.cap[1]
+    dup value$60
+    drop self$62
+    return value$60(value$63, return$7)
+  
+  closure fn join$64(self$65, value$66) =
+    let label$20 = self$65.cap[0]
+    dup label$20
+-   drop self$65
+    let closure$70 = closure lambda$67()
+-   let struct$71 = Tuple(value$66, closure$70)
++   dropReuse reuse$88 = self$65 /2
++   let struct$71 = reuse reuse$88 Tuple(value$66, closure$70)
+    return label$20(struct$71)
+  
+  closure fn lambda$67(self$68, param$4, return$10) =
+-   drop param$4
+-   drop self$68
+    if  then {
+-     let struct$69 = Tuple()
++     drop param$4
++     dropReuse reuse$89 = self$68 /0
++     let struct$69 = reuse reuse$89 Tuple()
+      return return$10(struct$69)
+    } else {
++     drop param$4
++     drop self$68
+      panic "no matching branch"
+    }
+  
+  closure fn join$72(self$73, value$74) =
+    let return$11 = self$73.cap[0]
+    dup return$11
+-   drop self$73
+    let lit$75 = "before cond"
++   drop self$73
+    return value$74(lit$75, return$11)
+  
+  toplevel fn zig_main$79() =
+    let finish$77 = closure join$81()
+    let after_main$78 = closure join$84(finish$77)
+    return main(after_main$78)
+  
+  closure fn join$81(self$82, value$83) =
+    drop self$82
+    return value$83
+  
+  closure fn join$84(self$85, value$86) =
+    let finish$77 = self$85.cap[0]
+    dup finish$77
+-   drop self$85
++   dropReuse reuse$90 = self$85 /0
+-   let struct$87 = Tuple()
++   let struct$87 = reuse reuse$90 Tuple()
+    return value$86(struct$87, finish$77)
+  
+  entry = zig_main$79

--- a/.golden/Malgo.Debug.PrettyIR/testcases/Panic/golden
+++ b/.golden/Malgo.Debug.PrettyIR/testcases/Panic/golden
@@ -1,0 +1,945 @@
+=== Parse ===
+import runtime/malgo/Builtin.mlg 
+
+import runtime/malgo/Prelude.mlg 
+
+def main =
+  fn {
+    _ ->
+      {
+        let _ = putStrLn("before panic")
+        panic("malgo#426 regression check")
+      }
+  }
+
+=== Rename ===
+import runtime/malgo/Builtin.mlg 
+
+import runtime/malgo/Prelude.mlg 
+
+def main =
+  fn {
+    _#0 ->
+      {
+        let _#1 = putStrLn(String#("before panic"))
+        panic(String#("malgo#426 regression check"))
+      }
+  }
+
+=== ToFun ===
+def main =
+  \param$2 ->
+    case param$2 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before panic"))
+        in
+          invoke panic(invoke String#("malgo#426 regression check"))
+    }
+
+=== SaturateCtor ===
+def main =
+  \param$2 ->
+    case param$2 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before panic"))
+        in
+          invoke panic(invoke String#("malgo#426 regression check"))
+    }
+
+=== ReuseSpecialize ===
+def main =
+  \param$2 ->
+    case param$2 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before panic"))
+        in
+          invoke panic(invoke String#("malgo#426 regression check"))
+    }
+
+=== ToCore ===
+def main(return$3) =
+  \param$2 return$4 . {
+    param$2 ~ select {
+      _#0 ->
+        invoke putStrLn ~ ( do return$6 . {
+          invoke String# ~ ("before panic", return$6)
+        }
+        , then _#1 -> {
+          invoke panic ~ ( do return$5 . {
+            invoke String# ~ ("malgo#426 regression check", return$5)
+          }
+          , return$4 )
+        } )
+    }
+  } ~ return$3
+
+=== Flat ===
+def main(return$3) =
+  \param$2 return$4 . {
+    param$2 ~ select {
+      _#0 ->
+        invoke putStrLn ~ then outer$7 -> {
+          join return$6 = then inner$8 -> {
+            outer$7 ~ ( inner$8
+            , then _#1 -> {
+              invoke panic ~ then outer$9 -> {
+                join return$5 = then inner$10 -> {
+                  outer$9 ~ (inner$10, return$4)
+                }
+                in invoke String# ~ ("malgo#426 regression check", return$5)
+              }
+            } )
+          }
+          in invoke String# ~ ("before panic", return$6)
+        }
+    }
+  } ~ return$3
+
+=== Join ===
+def main(return$3) =
+  \param$2 return$4 . {
+    join select$18 = select {
+      _#0 ->
+        join then$17 = then outer$7 -> {
+          join return$6 = then inner$8 -> {
+            join then$15 = then _#1 -> {
+              join then$14 = then outer$9 -> {
+                join return$5 = then inner$10 -> {
+                  join apply$13 = (inner$10, return$4)
+                  in outer$9 ~ apply$13
+                }
+                in join apply$12 = ("malgo#426 regression check", return$5)
+                in invoke String# ~ apply$12
+              }
+              in invoke panic ~ then$14
+            }
+            in join apply$16 = (inner$8, then$15)
+            in outer$7 ~ apply$16
+          }
+          in join apply$11 = ("before panic", return$6)
+          in invoke String# ~ apply$11
+        }
+        in invoke putStrLn ~ then$17
+    }
+    in param$2 ~ select$18
+  } ~ return$3
+
+=== ClosureConv ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  if  then {
+    let _#0 = param$2
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  let value$24 = self$26.cap[1]
+  let then$15 = closure join$28(return$4)
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  let return$4 = self$29.cap[0]
+  let then$14 = closure join$31(return$4)
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  let value$33 = self$35.cap[1]
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  let lit$40 = "malgo#426 regression check"
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  let lit$44 = "before panic"
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) = return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  let struct$56 = Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== Peephole ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  if  then {
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  let value$24 = self$26.cap[1]
+  let then$15 = closure join$28(return$4)
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  let return$4 = self$29.cap[0]
+  let then$14 = closure join$31(return$4)
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  let value$33 = self$35.cap[1]
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  let lit$40 = "malgo#426 regression check"
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  let lit$44 = "before panic"
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) = return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  let struct$56 = Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== Perceus ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  drop param$2
+  drop self$21
+  if  then {
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  dup return$4
+  drop self$23
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  dup return$4
+  let value$24 = self$26.cap[1]
+  dup value$24
+  drop self$26
+  let then$15 = closure join$28(return$4)
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  drop value$30
+  let return$4 = self$29.cap[0]
+  dup return$4
+  drop self$29
+  let then$14 = closure join$31(return$4)
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  dup return$4
+  drop self$32
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  dup return$4
+  let value$33 = self$35.cap[1]
+  dup value$33
+  drop self$35
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  dup return$5
+  drop self$38
+  let lit$40 = "malgo#426 regression check"
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  dup return$6
+  drop self$42
+  let lit$44 = "before panic"
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) =
+  drop self$51
+  return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  dup finish$46
+  drop self$54
+  let struct$56 = Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== Reuse ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  drop param$2
+  drop self$21
+  if  then {
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  dup return$4
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  drop self$23
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  dup return$4
+  let value$24 = self$26.cap[1]
+  dup value$24
+  let then$15 = closure join$28(return$4)
+  drop self$26
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  let return$4 = self$29.cap[0]
+  dup return$4
+  let then$14 = closure join$31(return$4)
+  drop value$30
+  drop self$29
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  dup return$4
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  drop self$32
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  dup return$4
+  let value$33 = self$35.cap[1]
+  dup value$33
+  drop self$35
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  dup return$5
+  let lit$40 = "malgo#426 regression check"
+  drop self$38
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  dup return$6
+  let lit$44 = "before panic"
+  drop self$42
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) =
+  drop self$51
+  return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  dup finish$46
+  dropReuse reuse$57 = self$54 /0
+  let struct$56 = reuse reuse$57 Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== DIFFS ===
+
+=== Parse -> Rename ===
+  import runtime/malgo/Builtin.mlg 
+  
+  import runtime/malgo/Prelude.mlg 
+  
+  def main =
+    fn {
+-     _ ->
++     _#0 ->
+        {
+-         let _ = putStrLn("before panic")
++         let _#1 = putStrLn(String#("before panic"))
+-         panic("malgo#426 regression check")
++         panic(String#("malgo#426 regression check"))
+        }
+    }
+
+
+=== Rename -> ToFun ===
+- import runtime/malgo/Builtin.mlg 
+- 
+- import runtime/malgo/Prelude.mlg 
+- 
+  def main =
+-   fn {
++   \param$2 ->
+-     _#0 ->
++     case param$2 of {
+-       {
++       _#0 ->
+-         let _#1 = putStrLn(String#("before panic"))
++         let _#1 =
+-         panic(String#("malgo#426 regression check"))
++           invoke putStrLn(invoke String#("before panic"))
+-       }
++         in
+-   }
++           invoke panic(invoke String#("malgo#426 regression check"))
++     }
+
+
+=== ToFun -> SaturateCtor ===
+  def main =
+    \param$2 ->
+      case param$2 of {
+        _#0 ->
+          let _#1 =
+            invoke putStrLn(invoke String#("before panic"))
+          in
+            invoke panic(invoke String#("malgo#426 regression check"))
+      }
+
+
+=== SaturateCtor -> ReuseSpecialize ===
+  def main =
+    \param$2 ->
+      case param$2 of {
+        _#0 ->
+          let _#1 =
+            invoke putStrLn(invoke String#("before panic"))
+          in
+            invoke panic(invoke String#("malgo#426 regression check"))
+      }
+
+
+=== ReuseSpecialize -> ToCore ===
+- def main =
++ def main(return$3) =
+-   \param$2 ->
++   \param$2 return$4 . {
+-     case param$2 of {
++     param$2 ~ select {
+        _#0 ->
+-         let _#1 =
++         invoke putStrLn ~ ( do return$6 . {
+-           invoke putStrLn(invoke String#("before panic"))
++           invoke String# ~ ("before panic", return$6)
+-         in
++         }
+-           invoke panic(invoke String#("malgo#426 regression check"))
++         , then _#1 -> {
++           invoke panic ~ ( do return$5 . {
++             invoke String# ~ ("malgo#426 regression check", return$5)
++           }
++           , return$4 )
++         } )
+      }
++   } ~ return$3
+
+
+=== ToCore -> Flat ===
+  def main(return$3) =
+    \param$2 return$4 . {
+      param$2 ~ select {
+        _#0 ->
+-         invoke putStrLn ~ ( do return$6 . {
++         invoke putStrLn ~ then outer$7 -> {
+-           invoke String# ~ ("before panic", return$6)
++           join return$6 = then inner$8 -> {
+-         }
++             outer$7 ~ ( inner$8
+-         , then _#1 -> {
++             , then _#1 -> {
+-           invoke panic ~ ( do return$5 . {
++               invoke panic ~ then outer$9 -> {
+-             invoke String# ~ ("malgo#426 regression check", return$5)
++                 join return$5 = then inner$10 -> {
++                   outer$9 ~ (inner$10, return$4)
++                 }
++                 in invoke String# ~ ("malgo#426 regression check", return$5)
++               }
++             } )
+            }
+-           , return$4 )
++           in invoke String# ~ ("before panic", return$6)
+-         } )
++         }
+      }
+    } ~ return$3
+
+
+=== Flat -> Join ===
+  def main(return$3) =
+    \param$2 return$4 . {
+-     param$2 ~ select {
++     join select$18 = select {
+        _#0 ->
+-         invoke putStrLn ~ then outer$7 -> {
++         join then$17 = then outer$7 -> {
+            join return$6 = then inner$8 -> {
+-             outer$7 ~ ( inner$8
++             join then$15 = then _#1 -> {
+-             , then _#1 -> {
++               join then$14 = then outer$9 -> {
+-               invoke panic ~ then outer$9 -> {
+                  join return$5 = then inner$10 -> {
+-                   outer$9 ~ (inner$10, return$4)
++                   join apply$13 = (inner$10, return$4)
++                   in outer$9 ~ apply$13
+                  }
+-                 in invoke String# ~ ("malgo#426 regression check", return$5)
++                 in join apply$12 = ("malgo#426 regression check", return$5)
++                 in invoke String# ~ apply$12
+                }
+-             } )
++               in invoke panic ~ then$14
++             }
++             in join apply$16 = (inner$8, then$15)
++             in outer$7 ~ apply$16
+            }
+-           in invoke String# ~ ("before panic", return$6)
++           in join apply$11 = ("before panic", return$6)
++           in invoke String# ~ apply$11
+          }
++         in invoke putStrLn ~ then$17
+      }
++     in param$2 ~ select$18
+    } ~ return$3
+
+
+=== Join -> ClosureConv ===
+- def main(return$3) =
++ toplevel fn main(return$3) =
+-   \param$2 return$4 . {
++   let closure$45 = closure lambda$20()
+-     join select$18 = select {
++   return return$3(closure$45)
+-       _#0 ->
++ 
+-         join then$17 = then outer$7 -> {
++ closure fn lambda$20(self$21, param$2, return$4) =
+-           join return$6 = then inner$8 -> {
++   if  then {
+-             join then$15 = then _#1 -> {
++     let _#0 = param$2
+-               join then$14 = then outer$9 -> {
++     let then$17 = closure join$22(return$4)
+-                 join return$5 = then inner$10 -> {
++     return putStrLn(then$17)
+-                   join apply$13 = (inner$10, return$4)
++   } else {
+-                   in outer$9 ~ apply$13
++     panic "no matching branch"
+-                 }
++   }
+-                 in join apply$12 = ("malgo#426 regression check", return$5)
++ 
+-                 in invoke String# ~ apply$12
++ closure fn join$22(self$23, value$24) =
+-               }
++   let return$4 = self$23.cap[0]
+-               in invoke panic ~ then$14
++   let return$6 = closure join$25(return$4, value$24)
+-             }
++   let apply$11 = closure join$41(return$6)
+-             in join apply$16 = (inner$8, then$15)
++   return String#(apply$11)
+-             in outer$7 ~ apply$16
++ 
+-           }
++ closure fn join$25(self$26, value$27) =
+-           in join apply$11 = ("before panic", return$6)
++   let return$4 = self$26.cap[0]
+-           in invoke String# ~ apply$11
++   let value$24 = self$26.cap[1]
+-         }
++   let then$15 = closure join$28(return$4)
+-         in invoke putStrLn ~ then$17
++   return value$24(value$27, then$15)
+-     }
++ 
+-     in param$2 ~ select$18
++ closure fn join$28(self$29, value$30) =
+-   } ~ return$3
++   let return$4 = self$29.cap[0]
++   let then$14 = closure join$31(return$4)
++   return panic(then$14)
++ 
++ closure fn join$31(self$32, value$33) =
++   let return$4 = self$32.cap[0]
++   let return$5 = closure join$34(return$4, value$33)
++   let apply$12 = closure join$37(return$5)
++   return String#(apply$12)
++ 
++ closure fn join$34(self$35, value$36) =
++   let return$4 = self$35.cap[0]
++   let value$33 = self$35.cap[1]
++   return value$33(value$36, return$4)
++ 
++ closure fn join$37(self$38, value$39) =
++   let return$5 = self$38.cap[0]
++   let lit$40 = "malgo#426 regression check"
++   return value$39(lit$40, return$5)
++ 
++ closure fn join$41(self$42, value$43) =
++   let return$6 = self$42.cap[0]
++   let lit$44 = "before panic"
++   return value$43(lit$44, return$6)
++ 
++ toplevel fn zig_main$48() =
++   let finish$46 = closure join$50()
++   let after_main$47 = closure join$53(finish$46)
++   return main(after_main$47)
++ 
++ closure fn join$50(self$51, value$52) = return value$52
++ 
++ closure fn join$53(self$54, value$55) =
++   let finish$46 = self$54.cap[0]
++   let struct$56 = Tuple()
++   return value$55(struct$56, finish$46)
++ 
++ entry = zig_main$48
+
+
+=== ClosureConv -> Peephole ===
+  toplevel fn main(return$3) =
+    let closure$45 = closure lambda$20()
+    return return$3(closure$45)
+  
+  closure fn lambda$20(self$21, param$2, return$4) =
+    if  then {
+-     let _#0 = param$2
+      let then$17 = closure join$22(return$4)
+      return putStrLn(then$17)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$22(self$23, value$24) =
+    let return$4 = self$23.cap[0]
+    let return$6 = closure join$25(return$4, value$24)
+    let apply$11 = closure join$41(return$6)
+    return String#(apply$11)
+  
+  closure fn join$25(self$26, value$27) =
+    let return$4 = self$26.cap[0]
+    let value$24 = self$26.cap[1]
+    let then$15 = closure join$28(return$4)
+    return value$24(value$27, then$15)
+  
+  closure fn join$28(self$29, value$30) =
+    let return$4 = self$29.cap[0]
+    let then$14 = closure join$31(return$4)
+    return panic(then$14)
+  
+  closure fn join$31(self$32, value$33) =
+    let return$4 = self$32.cap[0]
+    let return$5 = closure join$34(return$4, value$33)
+    let apply$12 = closure join$37(return$5)
+    return String#(apply$12)
+  
+  closure fn join$34(self$35, value$36) =
+    let return$4 = self$35.cap[0]
+    let value$33 = self$35.cap[1]
+    return value$33(value$36, return$4)
+  
+  closure fn join$37(self$38, value$39) =
+    let return$5 = self$38.cap[0]
+    let lit$40 = "malgo#426 regression check"
+    return value$39(lit$40, return$5)
+  
+  closure fn join$41(self$42, value$43) =
+    let return$6 = self$42.cap[0]
+    let lit$44 = "before panic"
+    return value$43(lit$44, return$6)
+  
+  toplevel fn zig_main$48() =
+    let finish$46 = closure join$50()
+    let after_main$47 = closure join$53(finish$46)
+    return main(after_main$47)
+  
+  closure fn join$50(self$51, value$52) = return value$52
+  
+  closure fn join$53(self$54, value$55) =
+    let finish$46 = self$54.cap[0]
+    let struct$56 = Tuple()
+    return value$55(struct$56, finish$46)
+  
+  entry = zig_main$48
+
+
+=== Peephole -> Perceus ===
+  toplevel fn main(return$3) =
+    let closure$45 = closure lambda$20()
+    return return$3(closure$45)
+  
+  closure fn lambda$20(self$21, param$2, return$4) =
++   drop param$2
++   drop self$21
+    if  then {
+      let then$17 = closure join$22(return$4)
+      return putStrLn(then$17)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$22(self$23, value$24) =
+    let return$4 = self$23.cap[0]
++   dup return$4
++   drop self$23
+    let return$6 = closure join$25(return$4, value$24)
+    let apply$11 = closure join$41(return$6)
+    return String#(apply$11)
+  
+  closure fn join$25(self$26, value$27) =
+    let return$4 = self$26.cap[0]
++   dup return$4
+    let value$24 = self$26.cap[1]
++   dup value$24
++   drop self$26
+    let then$15 = closure join$28(return$4)
+    return value$24(value$27, then$15)
+  
+  closure fn join$28(self$29, value$30) =
++   drop value$30
+    let return$4 = self$29.cap[0]
++   dup return$4
++   drop self$29
+    let then$14 = closure join$31(return$4)
+    return panic(then$14)
+  
+  closure fn join$31(self$32, value$33) =
+    let return$4 = self$32.cap[0]
++   dup return$4
++   drop self$32
+    let return$5 = closure join$34(return$4, value$33)
+    let apply$12 = closure join$37(return$5)
+    return String#(apply$12)
+  
+  closure fn join$34(self$35, value$36) =
+    let return$4 = self$35.cap[0]
++   dup return$4
+    let value$33 = self$35.cap[1]
++   dup value$33
++   drop self$35
+    return value$33(value$36, return$4)
+  
+  closure fn join$37(self$38, value$39) =
+    let return$5 = self$38.cap[0]
++   dup return$5
++   drop self$38
+    let lit$40 = "malgo#426 regression check"
+    return value$39(lit$40, return$5)
+  
+  closure fn join$41(self$42, value$43) =
+    let return$6 = self$42.cap[0]
++   dup return$6
++   drop self$42
+    let lit$44 = "before panic"
+    return value$43(lit$44, return$6)
+  
+  toplevel fn zig_main$48() =
+    let finish$46 = closure join$50()
+    let after_main$47 = closure join$53(finish$46)
+    return main(after_main$47)
+  
+- closure fn join$50(self$51, value$52) = return value$52
++ closure fn join$50(self$51, value$52) =
++   drop self$51
++   return value$52
+  
+  closure fn join$53(self$54, value$55) =
+    let finish$46 = self$54.cap[0]
++   dup finish$46
++   drop self$54
+    let struct$56 = Tuple()
+    return value$55(struct$56, finish$46)
+  
+  entry = zig_main$48
+
+
+=== Perceus -> Reuse ===
+  toplevel fn main(return$3) =
+    let closure$45 = closure lambda$20()
+    return return$3(closure$45)
+  
+  closure fn lambda$20(self$21, param$2, return$4) =
+    drop param$2
+    drop self$21
+    if  then {
+      let then$17 = closure join$22(return$4)
+      return putStrLn(then$17)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$22(self$23, value$24) =
+    let return$4 = self$23.cap[0]
+    dup return$4
+-   drop self$23
+    let return$6 = closure join$25(return$4, value$24)
+    let apply$11 = closure join$41(return$6)
++   drop self$23
+    return String#(apply$11)
+  
+  closure fn join$25(self$26, value$27) =
+    let return$4 = self$26.cap[0]
+    dup return$4
+    let value$24 = self$26.cap[1]
+    dup value$24
+-   drop self$26
+    let then$15 = closure join$28(return$4)
++   drop self$26
+    return value$24(value$27, then$15)
+  
+  closure fn join$28(self$29, value$30) =
+-   drop value$30
+    let return$4 = self$29.cap[0]
+    dup return$4
+-   drop self$29
+    let then$14 = closure join$31(return$4)
++   drop value$30
++   drop self$29
+    return panic(then$14)
+  
+  closure fn join$31(self$32, value$33) =
+    let return$4 = self$32.cap[0]
+    dup return$4
+-   drop self$32
+    let return$5 = closure join$34(return$4, value$33)
+    let apply$12 = closure join$37(return$5)
++   drop self$32
+    return String#(apply$12)
+  
+  closure fn join$34(self$35, value$36) =
+    let return$4 = self$35.cap[0]
+    dup return$4
+    let value$33 = self$35.cap[1]
+    dup value$33
+    drop self$35
+    return value$33(value$36, return$4)
+  
+  closure fn join$37(self$38, value$39) =
+    let return$5 = self$38.cap[0]
+    dup return$5
+-   drop self$38
+    let lit$40 = "malgo#426 regression check"
++   drop self$38
+    return value$39(lit$40, return$5)
+  
+  closure fn join$41(self$42, value$43) =
+    let return$6 = self$42.cap[0]
+    dup return$6
+-   drop self$42
+    let lit$44 = "before panic"
++   drop self$42
+    return value$43(lit$44, return$6)
+  
+  toplevel fn zig_main$48() =
+    let finish$46 = closure join$50()
+    let after_main$47 = closure join$53(finish$46)
+    return main(after_main$47)
+  
+  closure fn join$50(self$51, value$52) =
+    drop self$51
+    return value$52
+  
+  closure fn join$53(self$54, value$55) =
+    let finish$46 = self$54.cap[0]
+    dup finish$46
+-   drop self$54
++   dropReuse reuse$57 = self$54 /0
+-   let struct$56 = Tuple()
++   let struct$56 = reuse reuse$57 Tuple()
+    return value$55(struct$56, finish$46)
+  
+  entry = zig_main$48

--- a/.golden/Malgo.Sequent.ToCore/flat-fingerprint/CondPanic/golden
+++ b/.golden/Malgo.Sequent.ToCore/flat-fingerprint/CondPanic/golden
@@ -1,0 +1,1 @@
+applies=5 constructs=2 cuts=9 definitions=1 invokes=6 joins=5 labels=8 lambdas=2 literals=1 selects=2 thens=10 vars=11

--- a/.golden/Malgo.Sequent.ToCore/flat-fingerprint/Panic/golden
+++ b/.golden/Malgo.Sequent.ToCore/flat-fingerprint/Panic/golden
@@ -1,0 +1,1 @@
+applies=4 cuts=4 definitions=1 invokes=4 joins=2 labels=4 lambdas=1 literals=2 selects=1 thens=5 vars=5

--- a/.golden/Malgo.Sequent.ToCore/golden/CondPanic/join/golden
+++ b/.golden/Malgo.Sequent.ToCore/golden/CondPanic/join/golden
@@ -1,0 +1,117 @@
+((main
+    $CondPanic.return_5
+    (cut
+       (lambda
+          ($CondPanic.param_3 $CondPanic.return_6)
+          (join
+             $CondPanic.select_33
+             (select
+                (#CondPanic.__0
+                   (join
+                      $CondPanic.then_32
+                      (then
+                         $CondPanic.outer_12
+                         (join
+                            $CondPanic.return_11
+                            (then
+                               $CondPanic.inner_13
+                               (join
+                                  $CondPanic.then_30
+                                  (then
+                                     #CondPanic.__1
+                                     (join
+                                        $CondPanic.then_29
+                                        (then
+                                           $CondPanic.outer_14
+                                           (join
+                                              $CondPanic.return_7
+                                              (then
+                                                 $CondPanic.inner_15
+                                                 (join
+                                                    $CondPanic.apply_28
+                                                    (apply
+                                                       ($CondPanic.inner_15)
+                                                       ($CondPanic.return_6))
+                                                    (cut
+                                                       $CondPanic.outer_14
+                                                       $CondPanic.apply_28)))
+                                              (join
+                                                 $CondPanic.then_27
+                                                 (then
+                                                    $CondPanic.outer_16
+                                                    (join
+                                                       $CondPanic.label_20
+                                                       (then
+                                                          $CondPanic.inner_17
+                                                          (join
+                                                             $CondPanic.then_25
+                                                             (then
+                                                                $CondPanic.outer_18
+                                                                (join
+                                                                   $CondPanic.return_8
+                                                                   (then
+                                                                      $CondPanic.inner_19
+                                                                      (join
+                                                                         $CondPanic.apply_24
+                                                                         (apply
+                                                                            ($CondPanic.inner_19)
+                                                                            ($CondPanic.return_7))
+                                                                         (cut
+                                                                            $CondPanic.outer_18
+                                                                            $CondPanic.apply_24)))
+                                                                   (invoke
+                                                                      Nil
+                                                                      $CondPanic.return_8)))
+                                                             (join
+                                                                $CondPanic.apply_26
+                                                                (apply
+                                                                   ($CondPanic.inner_17)
+                                                                   ($CondPanic.then_25))
+                                                                (cut
+                                                                   $CondPanic.outer_16
+                                                                   $CondPanic.apply_26))))
+                                                       (join
+                                                          $CondPanic.return_9
+                                                          (then
+                                                             $CondPanic.var_21
+                                                             (cut
+                                                                (construct
+                                                                   tuple
+                                                                   ($CondPanic.var_21
+                                                                      (lambda
+                                                                         ($CondPanic.param_4
+                                                                            $CondPanic.return_10)
+                                                                         (join
+                                                                            $CondPanic.select_23
+                                                                            (select
+                                                                               (#CondPanic.__2
+                                                                                  (cut
+                                                                                     (construct
+                                                                                        tuple
+                                                                                        ()
+                                                                                        ())
+                                                                                     $CondPanic.return_10)))
+                                                                            (cut
+                                                                               $CondPanic.param_4
+                                                                               $CondPanic.select_23))))
+                                                                   ())
+                                                                $CondPanic.label_20))
+                                                          (invoke
+                                                             False
+                                                             $CondPanic.return_9))))
+                                                 (invoke Cons $CondPanic.then_27))))
+                                        (invoke cond $CondPanic.then_29)))
+                                  (join
+                                     $CondPanic.apply_31
+                                     (apply
+                                        ($CondPanic.inner_13)
+                                        ($CondPanic.then_30))
+                                     (cut $CondPanic.outer_12 $CondPanic.apply_31))))
+                            (join
+                               $CondPanic.apply_22
+                               (apply ("before cond") ($CondPanic.return_11))
+                               (invoke String# $CondPanic.apply_22))))
+                      (invoke putStrLn $CondPanic.then_32))))
+             (cut $CondPanic.param_3 $CondPanic.select_33)))
+       $CondPanic.return_5))
+   ("runtime/malgo/Builtin.mlg" "runtime/malgo/Prelude.mlg"))

--- a/.golden/Malgo.Sequent.ToCore/golden/Panic/join/golden
+++ b/.golden/Malgo.Sequent.ToCore/golden/Panic/join/golden
@@ -1,0 +1,56 @@
+((main
+    $Panic.return_3
+    (cut
+       (lambda
+          ($Panic.param_2 $Panic.return_4)
+          (join
+             $Panic.select_18
+             (select
+                (#Panic.__0
+                   (join
+                      $Panic.then_17
+                      (then
+                         $Panic.outer_7
+                         (join
+                            $Panic.return_6
+                            (then
+                               $Panic.inner_8
+                               (join
+                                  $Panic.then_15
+                                  (then
+                                     #Panic.__1
+                                     (join
+                                        $Panic.then_14
+                                        (then
+                                           $Panic.outer_9
+                                           (join
+                                              $Panic.return_5
+                                              (then
+                                                 $Panic.inner_10
+                                                 (join
+                                                    $Panic.apply_13
+                                                    (apply
+                                                       ($Panic.inner_10)
+                                                       ($Panic.return_4))
+                                                    (cut
+                                                       $Panic.outer_9
+                                                       $Panic.apply_13)))
+                                              (join
+                                                 $Panic.apply_12
+                                                 (apply
+                                                    ("malgo#426 regression check")
+                                                    ($Panic.return_5))
+                                                 (invoke String# $Panic.apply_12))))
+                                        (invoke panic $Panic.then_14)))
+                                  (join
+                                     $Panic.apply_16
+                                     (apply ($Panic.inner_8) ($Panic.then_15))
+                                     (cut $Panic.outer_7 $Panic.apply_16))))
+                            (join
+                               $Panic.apply_11
+                               (apply ("before panic") ($Panic.return_6))
+                               (invoke String# $Panic.apply_11))))
+                      (invoke putStrLn $Panic.then_17))))
+             (cut $Panic.param_2 $Panic.select_18)))
+       $Panic.return_3))
+   ("runtime/malgo/Builtin.mlg" "runtime/malgo/Prelude.mlg"))

--- a/.golden/Malgo.Sequent.ToCore/join-fingerprint/CondPanic/golden
+++ b/.golden/Malgo.Sequent.ToCore/join-fingerprint/CondPanic/golden
@@ -1,0 +1,1 @@
+applies=5 constructs=2 cuts=9 definitions=1 invokes=6 joins=17 lambdas=2 literals=1 selects=2 thens=10 vars=11

--- a/.golden/Malgo.Sequent.ToCore/join-fingerprint/Panic/golden
+++ b/.golden/Malgo.Sequent.ToCore/join-fingerprint/Panic/golden
@@ -1,0 +1,1 @@
+applies=4 cuts=4 definitions=1 invokes=4 joins=10 lambdas=1 literals=2 selects=1 thens=5 vars=5

--- a/lean/Malgo/Sequent/Eval.lean
+++ b/lean/Malgo/Sequent/Eval.lean
@@ -137,6 +137,14 @@ inductive EvalError where
   | noMatch (range : Range) (value : Value)
   | primitiveNotImplemented (range : Range) (name : String) (values : List Value)
   | invalidArguments (range : Range) (name : String) (values : List Value)
+  /-- `malgo_panic`: a fatal, uncatchable error carrying a user-supplied
+  message (Builtin.mlg's `panic : String -> a`). Not control-flow like
+  `exitSuccess`/`exitWith` below -- unlike those, the Zig/Scheme backends
+  both treat this as an error (Zig: `panic(msg)` to stderr + `exit(1)`;
+  Scheme: `(error 'panic msg)`), so it belongs with the other `EvalError`
+  cases and terminates via the same throw-and-render path as `noMatch`
+  rather than a bespoke mechanism. -/
+  | panic (range : Range) (message : String)
   /-- Haskell `div`/`mod` throw a divide-by-zero `ArithException`;
   `Int.fdiv/fmod` would silently yield 0/`a`. -/
   | divideByZero (range : Range)
@@ -175,6 +183,7 @@ def EvalError.render : EvalError → String
     s!"Invalid arguments for {name}: " ++
       String.intercalate ", " (values.map valueToText)
   | .divideByZero _ => "divide by zero"
+  | .panic _ message => s!"panic: {message}"
   | .exitSuccess => "ExitSuccess"
   | .exitWith code => s!"ExitWith {code}"
 
@@ -189,6 +198,7 @@ def EvalError.rangeOf : EvalError → Option Range
   | .primitiveNotImplemented r _ _ => some r
   | .invalidArguments r _ _ => some r
   | .divideByZero r => some r
+  | .panic r _ => some r
   | .exitSuccess => none
   | .exitWith _ => none
 
@@ -693,6 +703,10 @@ def fetchPrimitive (range : Range) (name : String) (values : List Value) : EvalM
     | "malgo_get_args" =>
       unaryPrim range name (fun _ _ =>
         pure (.immediate (.string (String.intercalate "\n" h.arguments)))) values
+    | "malgo_panic" =>
+      unaryPrim range name (fun _ v => match v with
+        | .immediate (.string message) => throw (.panic range message)
+        | _ => throw (.invalidArguments range name [v])) values
     | "malgo_exit_success" =>
       unaryPrim range name (fun _ _ => throw .exitSuccess) values
     | "malgo_exit_with_code" =>

--- a/lean/Malgo/Sequent/Eval.lean
+++ b/lean/Malgo/Sequent/Eval.lean
@@ -142,9 +142,15 @@ inductive EvalError where
   `exitSuccess`/`exitWith` below -- unlike those, the Zig/Scheme backends
   both treat this as an error (Zig: `panic(msg)` to stderr + `exit(1)`;
   Scheme: `(error 'panic msg)`), so it belongs with the other `EvalError`
-  cases and terminates via the same throw-and-render path as `noMatch`
-  rather than a bespoke mechanism. -/
-  | panic (range : Range) (message : String)
+  cases and terminates via the same throw-and-render path as `noMatch`.
+  Carries no `range`, unlike most `EvalError` cases above (same shape as
+  `exitSuccess`/`exitWith` below): `panic` is a shared Malgo-level wrapper
+  (`runtime/malgo/Builtin.mlg`'s `def panic = { (String# message) ->
+  malgo_panic message }`), so `fetchPrimitive`'s call-site range is always
+  that wrapper's own foreign-import declaration, never the caller's actual
+  `panic(...)` site -- reporting it would be actively misleading, not
+  merely imprecise. -/
+  | panic (message : String)
   /-- Haskell `div`/`mod` throw a divide-by-zero `ArithException`;
   `Int.fdiv/fmod` would silently yield 0/`a`. -/
   | divideByZero (range : Range)
@@ -183,7 +189,7 @@ def EvalError.render : EvalError → String
     s!"Invalid arguments for {name}: " ++
       String.intercalate ", " (values.map valueToText)
   | .divideByZero _ => "divide by zero"
-  | .panic _ message => s!"panic: {message}"
+  | .panic message => s!"panic: {message}"
   | .exitSuccess => "ExitSuccess"
   | .exitWith code => s!"ExitWith {code}"
 
@@ -198,7 +204,7 @@ def EvalError.rangeOf : EvalError → Option Range
   | .primitiveNotImplemented r _ _ => some r
   | .invalidArguments r _ _ => some r
   | .divideByZero r => some r
-  | .panic r _ => some r
+  | .panic _ => none
   | .exitSuccess => none
   | .exitWith _ => none
 
@@ -705,7 +711,7 @@ def fetchPrimitive (range : Range) (name : String) (values : List Value) : EvalM
         pure (.immediate (.string (String.intercalate "\n" h.arguments)))) values
     | "malgo_panic" =>
       unaryPrim range name (fun _ v => match v with
-        | .immediate (.string message) => throw (.panic range message)
+        | .immediate (.string message) => throw (.panic message)
         | _ => throw (.invalidArguments range name [v])) values
     | "malgo_exit_success" =>
       unaryPrim range name (fun _ _ => throw .exitSuccess) values

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -237,21 +237,30 @@ Linking mirrors Haskell `compileTestCase`: `builtin <> prelude <> program`
 the ToCore gate validated), stdin is the fixed `"Hello\n"` of
 `setupTestStdin`, and the golden is the captured stdout. -/
 
-/-- Testcases this fixed three-program link can't run correctly, so they're
-excluded from `evalCases`/`bigStepEvalCases` entirely rather than pinned
-with a golden this harness can only ever get wrong. `TaggedRecordCrossModuleUse`
-imports a third module (`TaggedRecordCrossModuleDef.mlg`) beyond
-Builtin/Prelude to regression-test a #422 cross-module fix; `linkPrograms
-[builtin, prelude, ir]` above has no way to see that third module's compiled
-program, so evaluating the linked result always fails with "Undefined
-variable: Point" here regardless of whether the compiler itself is correct.
-The real CLI's `Query.Engine.fetchLinkedProgram` does link the full
-dependency closure and evaluates this case correctly (verified manually) —
-excluding it here keeps `scripts/cli-gate.sh`'s `eval` mode (which runs that
-real CLI against these same `.golden/Malgo.Sequent.Eval` files) from ever
-diffing a correct answer against a golden this harness structurally cannot
-produce. -/
-def evalHarnessUnsupported : List String := ["TaggedRecordCrossModuleUse"]
+/-- Testcases excluded from `evalCases`/`bigStepEvalCases` (and therefore
+from ever getting a `.golden/Malgo.Sequent.Eval/<name>/golden` file), each
+for its own reason:
+
+- `TaggedRecordCrossModuleUse` imports a third module
+  (`TaggedRecordCrossModuleDef.mlg`) beyond Builtin/Prelude to
+  regression-test a #422 cross-module fix; `linkPrograms [builtin, prelude,
+  ir]` above has no way to see that third module's compiled program, so
+  evaluating the linked result always fails with "Undefined variable:
+  Point" here regardless of whether the compiler itself is correct. The
+  real CLI's `Query.Engine.fetchLinkedProgram` does link the full
+  dependency closure and evaluates this case correctly (verified manually).
+- `Panic` (malgo#426) calls `malgo_panic`, which *by design* terminates
+  evaluation nonzero with a message on stderr, matching the Zig
+  (`runtime/zig/runtime.zig`'s `panic`) and Scheme (`Backend/Scheme.lean`'s
+  `(error 'panic ...)`) backends — there is no successful stdout to pin as
+  a golden. `PanicGate.run` below exercises it directly instead.
+
+Excluding both here keeps `scripts/cli-gate.sh`'s `eval` mode, and
+`scripts/zig-golden.sh`/`scripts/scheme-golden.sh`/`scripts/selfhost-golden.sh`
+(all of which discover their cases by listing `.golden/Malgo.Sequent.Eval/*/`
+rather than scanning `test/testcases/malgo/` directly), from ever seeing
+either name — no per-script skip-list needed. -/
+def evalHarnessUnsupported : List String := ["TaggedRecordCrossModuleUse", "Panic"]
 
 private def evalGolden (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR))
     (name : String) : IO String := do
@@ -295,6 +304,54 @@ def bigStepEvalCases (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR))
     (names : List String) : List GoldenCase :=
   names.map fun n =>
     { group := "Malgo.Sequent.BigStepEval", name := s!"golden/{n}", run := bigStepEvalGolden memo n }
+
+/-! ## Panic gate (regression test for malgo#426, not golden — see
+`evalHarnessUnsupported` for why `Panic` is excluded from `evalCases`/
+`bigStepEvalCases`).
+
+Checks both entry points against one linked program: `BigStepEval.lean`
+calls `Eval.fetchPrimitive` directly rather than reimplementing it, so this
+also confirms the big-step evaluator didn't need its own `malgo_panic`
+case. Only the stdout captured before the throw and a substring of the
+error message are pinned — not the full rendered message, which embeds
+`fetchPrimitive`'s call-site range (here, `malgo_panic`'s own foreign-import
+declaration in Builtin.mlg, not `Panic.mlg`'s call site — a pre-existing
+quirk of every wrapped foreign primitive, not specific to panic). -/
+namespace PanicGate
+
+private def expectedStdout : String := "before panic\n"
+private def expectedMessage : String := "panic: malgo#426 regression check"
+
+def run (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR)) : IO Nat := do
+  let builtin ← getAllIR memo (System.FilePath.mk "runtime/malgo/Builtin.mlg")
+  let prel ← getAllIR memo (System.FilePath.mk "runtime/malgo/Prelude.mlg")
+  let ir ← getAllIR memo (testcasePath "Panic")
+  let linked := Malgo.Driver.linkPrograms [builtin.join, prel.join, ir.join]
+  let evaluators :=
+    [ ("Malgo.Sequent.Eval", Malgo.Sequent.Eval.evalProgram),
+      ("Malgo.Sequent.BigStepEval", Malgo.Sequent.BigStepEval.bigStepEvalProgram) ]
+  let mut failed := 0
+  for (label, runProgram) in evaluators do
+    let (handlers, outRef) ← Malgo.Sequent.Eval.Handlers.buffered "Hello\n"
+    try
+      let _ ← MalgoM.run flag {} (runProgram ir.moduleName handlers linked)
+      IO.println s!"FAIL {label}/Panic: malgo_panic did not terminate evaluation"
+      failed := failed + 1
+    catch e =>
+      let out ← outRef.get
+      let msg := toString e
+      if out != expectedStdout then
+        IO.println s!"FAIL {label}/Panic: stdout was {out}, expected {expectedStdout}"
+        failed := failed + 1
+      else if (msg.splitOn expectedMessage).length <= 1 then
+        IO.println s!"FAIL {label}/Panic: message did not contain \"{expectedMessage}\": {msg}"
+        failed := failed + 1
+      else
+        IO.println s!"ok {label}/Panic"
+  IO.println s!"=== panic-gate {2 - failed}/2 passed ==="
+  return failed
+
+end PanicGate
 
 /-! ## Forth gate (captured stdout, per `ForthSpec`)
 
@@ -1212,7 +1269,8 @@ def main (args : List String) : IO UInt32 := do
     let irFailures ← Malgo.Test.IrInvariants.run memo names
     let specFailures ← Malgo.Test.ReuseSpec.run
     let parserFailures ← Malgo.Test.ParserSurface.run
+    let panicFailures ← Malgo.Test.PanicGate.run memo
     return (if goldenCode == 0 && inferCode == 0 && metPageFailures == 0
         && reuseFailures == 0 && corpusFailures == 0 && irFailures == 0
-        && specFailures == 0 && parserFailures == 0
+        && specFailures == 0 && parserFailures == 0 && panicFailures == 0
       then 0 else 1)

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -249,18 +249,21 @@ for its own reason:
   Point" here regardless of whether the compiler itself is correct. The
   real CLI's `Query.Engine.fetchLinkedProgram` does link the full
   dependency closure and evaluates this case correctly (verified manually).
-- `Panic` (malgo#426) calls `malgo_panic`, which *by design* terminates
-  evaluation nonzero with a message on stderr, matching the Zig
-  (`runtime/zig/runtime.zig`'s `panic`) and Scheme (`Backend/Scheme.lean`'s
-  `(error 'panic ...)`) backends — there is no successful stdout to pin as
-  a golden. `PanicGate.run` below exercises it directly instead.
+- `Panic` and `CondPanic` (both malgo#426) call `malgo_panic` -- the former
+  directly, the latter via `Prelude.mlg`'s `cond`'s `Nil -> panic "no
+  branch"` fallback (the specific path #426's own issue text called out as
+  untested) -- which *by design* terminates evaluation nonzero with a
+  message on stderr, matching the Zig (`runtime/zig/runtime.zig`'s `panic`)
+  and Scheme (`Backend/Scheme.lean`'s `(error 'panic ...)`) backends —
+  there is no successful stdout to pin as a golden. `PanicGate.run` below
+  exercises both directly instead.
 
-Excluding both here keeps `scripts/cli-gate.sh`'s `eval` mode, and
+Excluding these here keeps `scripts/cli-gate.sh`'s `eval` mode, and
 `scripts/zig-golden.sh`/`scripts/scheme-golden.sh`/`scripts/selfhost-golden.sh`
 (all of which discover their cases by listing `.golden/Malgo.Sequent.Eval/*/`
 rather than scanning `test/testcases/malgo/` directly), from ever seeing
-either name — no per-script skip-list needed. -/
-def evalHarnessUnsupported : List String := ["TaggedRecordCrossModuleUse", "Panic"]
+any of these names — no per-script skip-list needed. -/
+def evalHarnessUnsupported : List String := ["TaggedRecordCrossModuleUse", "Panic", "CondPanic"]
 
 private def evalGolden (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR))
     (name : String) : IO String := do
@@ -306,49 +309,71 @@ def bigStepEvalCases (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR))
     { group := "Malgo.Sequent.BigStepEval", name := s!"golden/{n}", run := bigStepEvalGolden memo n }
 
 /-! ## Panic gate (regression test for malgo#426, not golden — see
-`evalHarnessUnsupported` for why `Panic` is excluded from `evalCases`/
-`bigStepEvalCases`).
+`evalHarnessUnsupported` for why `Panic`/`CondPanic` are excluded from
+`evalCases`/`bigStepEvalCases`).
 
-Checks both entry points against one linked program: `BigStepEval.lean`
+Checks both entry points against each linked program: `BigStepEval.lean`
 calls `Eval.fetchPrimitive` directly rather than reimplementing it, so this
 also confirms the big-step evaluator didn't need its own `malgo_panic`
-case. Only the stdout captured before the throw and a substring of the
-error message are pinned — not the full rendered message, which embeds
-`fetchPrimitive`'s call-site range (here, `malgo_panic`'s own foreign-import
-declaration in Builtin.mlg, not `Panic.mlg`'s call site — a pre-existing
-quirk of every wrapped foreign primitive, not specific to panic). -/
+case. Two scenarios: `Panic` calls `panic(...)` directly; `CondPanic` walks
+one `Cons (False, _) xs` step of `Prelude.mlg`'s `cond` before hitting its
+`Nil -> panic "no branch"` fallback -- the specific path #426's issue text
+called out as untested. Both stdout and the full rendered error message are
+pinned exactly: `EvalError.rangeOf`'s `.panic` case returns `none` (its
+`range` would be `fetchPrimitive`'s call-site range, i.e. `panic`'s own
+foreign-import declaration in Builtin.mlg, never the caller's actual
+`panic(...)` site), so the message is just `[<passName>] panic: <msg>` with
+no location prefix to make an exact match brittle -- `<passName>` differs
+per evaluator (`Eval.lean`/`BigStepEval.lean` each `throw`s their own
+`CompileError` with their own module name as `passName`), so it's supplied
+per evaluator below rather than baked into `Scenario.expectedMessage`. -/
 namespace PanicGate
 
-private def expectedStdout : String := "before panic\n"
-private def expectedMessage : String := "panic: malgo#426 regression check"
+private structure Scenario where
+  testcase : String
+  expectedStdout : String
+  /-- Suffix after `[<passName>] `, e.g. `"panic: no branch"`. -/
+  expectedMessage : String
+
+private def scenarios : List Scenario :=
+  [ { testcase := "Panic", expectedStdout := "before panic\n",
+      expectedMessage := "panic: malgo#426 regression check" },
+    { testcase := "CondPanic", expectedStdout := "before cond\n",
+      expectedMessage := "panic: no branch" } ]
 
 def run (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR)) : IO Nat := do
-  let builtin ← getAllIR memo (System.FilePath.mk "runtime/malgo/Builtin.mlg")
-  let prel ← getAllIR memo (System.FilePath.mk "runtime/malgo/Prelude.mlg")
-  let ir ← getAllIR memo (testcasePath "Panic")
-  let linked := Malgo.Driver.linkPrograms [builtin.join, prel.join, ir.join]
   let evaluators :=
-    [ ("Malgo.Sequent.Eval", Malgo.Sequent.Eval.evalProgram),
-      ("Malgo.Sequent.BigStepEval", Malgo.Sequent.BigStepEval.bigStepEvalProgram) ]
+    [ ("Malgo.Sequent.Eval", "Eval", Malgo.Sequent.Eval.evalProgram),
+      ("Malgo.Sequent.BigStepEval", "BigStepEval", Malgo.Sequent.BigStepEval.bigStepEvalProgram) ]
   let mut failed := 0
-  for (label, runProgram) in evaluators do
-    let (handlers, outRef) ← Malgo.Sequent.Eval.Handlers.buffered "Hello\n"
-    try
-      let _ ← MalgoM.run flag {} (runProgram ir.moduleName handlers linked)
-      IO.println s!"FAIL {label}/Panic: malgo_panic did not terminate evaluation"
-      failed := failed + 1
-    catch e =>
-      let out ← outRef.get
-      let msg := toString e
-      if out != expectedStdout then
-        IO.println s!"FAIL {label}/Panic: stdout was {out}, expected {expectedStdout}"
+  let mut total := 0
+  for scenario in scenarios do
+    let builtin ← getAllIR memo (System.FilePath.mk "runtime/malgo/Builtin.mlg")
+    let prel ← getAllIR memo (System.FilePath.mk "runtime/malgo/Prelude.mlg")
+    let ir ← getAllIR memo (testcasePath scenario.testcase)
+    let linked := Malgo.Driver.linkPrograms [builtin.join, prel.join, ir.join]
+    for (label, passName, runProgram) in evaluators do
+      total := total + 1
+      let expectedMessage := s!"[{passName}] {scenario.expectedMessage}"
+      let (handlers, outRef) ← Malgo.Sequent.Eval.Handlers.buffered "Hello\n"
+      try
+        let _ ← MalgoM.run flag {} (runProgram ir.moduleName handlers linked)
+        IO.println s!"FAIL {label}/{scenario.testcase}: malgo_panic did not terminate evaluation"
         failed := failed + 1
-      else if (msg.splitOn expectedMessage).length <= 1 then
-        IO.println s!"FAIL {label}/Panic: message did not contain \"{expectedMessage}\": {msg}"
-        failed := failed + 1
-      else
-        IO.println s!"ok {label}/Panic"
-  IO.println s!"=== panic-gate {2 - failed}/2 passed ==="
+      catch e =>
+        let out ← outRef.get
+        let msg := toString e
+        if out != scenario.expectedStdout then
+          IO.println
+            s!"FAIL {label}/{scenario.testcase}: stdout was {out}, expected {scenario.expectedStdout}"
+          failed := failed + 1
+        else if msg != expectedMessage then
+          IO.println
+            s!"FAIL {label}/{scenario.testcase}: message was \"{msg}\", expected \"{expectedMessage}\""
+          failed := failed + 1
+        else
+          IO.println s!"ok {label}/{scenario.testcase}"
+  IO.println s!"=== panic-gate {total - failed}/{total} passed ==="
   return failed
 
 end PanicGate

--- a/runtime/malgo/Prelude.mlg
+++ b/runtime/malgo/Prelude.mlg
@@ -134,11 +134,11 @@ def containsNulAt = { s i len ->
     }
 }
 
--- Print `msg` to stderr and exit 1. `panic` (Builtin.mlg) now behaves
--- identically on every backend, including the interpreter (malgo#426), so
--- it is no longer blocked from use here -- this helper predates that fix
--- and is kept as-is rather than migrated to `panic`, which is out of this
--- fix's scope.
+-- Print `msg` to stderr and exit 1. `panic` (Builtin.mlg) is now
+-- implemented on the interpreter too (malgo#426), so it's no longer
+-- blocked from use here on that specific ground -- this helper predates
+-- that fix and is kept as-is; migrating it to `panic` is a separate
+-- decision this fix doesn't make.
 def failLoudly : String -> a
 def failLoudly = { msg -> let _ = printStderr msg; exitWith 1i32 }
 

--- a/runtime/malgo/Prelude.mlg
+++ b/runtime/malgo/Prelude.mlg
@@ -134,12 +134,11 @@ def containsNulAt = { s i len ->
     }
 }
 
--- Print `msg` to stderr and exit 1. `panic` (Builtin.mlg) would be the
--- obvious choice for an invariant violation like this, but it's only
--- implemented on the Zig and Scheme backends today -- unimplemented on
--- the interpreter (`malgo_panic` throws "Primitive malgo_panic is not
--- implemented"), so a guard meant to fire identically everywhere can't
--- use it yet. Tracked as malgo#426; not this fix's scope.
+-- Print `msg` to stderr and exit 1. `panic` (Builtin.mlg) now behaves
+-- identically on every backend, including the interpreter (malgo#426), so
+-- it is no longer blocked from use here -- this helper predates that fix
+-- and is kept as-is rather than migrated to `panic`, which is out of this
+-- fix's scope.
 def failLoudly : String -> a
 def failLoudly = { msg -> let _ = printStderr msg; exitWith 1i32 }
 

--- a/test/testcases/malgo/CondPanic.mlg
+++ b/test/testcases/malgo/CondPanic.mlg
@@ -1,0 +1,17 @@
+#c-style-apply
+module {..} = import "../../../runtime/malgo/Builtin.mlg"
+module {..} = import "../../../runtime/malgo/Prelude.mlg"
+
+-- Regression test for malgo#426's own "untested territory": the issue text
+-- specifically calls out `cond`'s empty/no-match fallback (Prelude.mlg's
+-- `Nil -> panic "no branch"`) as a path that hadn't been exercised through
+-- `malgo_panic` -- `Panic.mlg` only covers a direct `panic(...)` call. The
+-- one `False` guard below makes this walk the real `Cons (False, _) xs`
+-- recursion before falling through to `Nil`, not just the degenerate
+-- empty-list literal. Not a `.golden/Malgo.Sequent.Eval` golden case --
+-- see `evalHarnessUnsupported` and `Malgo.Test.PanicGate.run` in
+-- lean/Test/Main.lean for why.
+def main = { (_) ->
+  let _ = putStrLn("before cond");
+  cond [(False, { () })]
+}

--- a/test/testcases/malgo/Panic.mlg
+++ b/test/testcases/malgo/Panic.mlg
@@ -1,0 +1,12 @@
+#c-style-apply
+module {..} = import "../../../runtime/malgo/Builtin.mlg"
+module {..} = import "../../../runtime/malgo/Prelude.mlg"
+
+-- Regression test for malgo#426: `malgo_panic` must terminate evaluation
+-- and surface this message, matching the Zig/Scheme backends. Not a
+-- `.golden/Malgo.Sequent.Eval` golden case -- see `evalHarnessUnsupported`
+-- and `Malgo.Test.PanicGate.run` in lean/Test/Main.lean for why.
+def main = { (_) ->
+  let _ = putStrLn("before panic");
+  panic "malgo#426 regression check"
+}


### PR DESCRIPTION
> *This was generated by AI as a triage follow-up.*

Fixes #426

## Summary

- `lean/Malgo/Sequent/Eval.lean`'s `fetchPrimitive` had no case for `malgo_panic`, so `panic : String -> a` (`runtime/malgo/Builtin.mlg`) fell through to the generic "primitive not implemented" error in the interpreter (`--target eval`). Added an `EvalError.panic` case that terminates evaluation and surfaces the message, matching how the Zig backend's `panic()` (stderr + `exit(1)`) and the Scheme backend's `(error 'panic ...)` already behave. `BigStepEval.lean` shares `Eval.fetchPrimitive` directly, so both evaluators are covered by this one change.
- `test/testcases/malgo/Panic.mlg` is a small regression case (`putStrLn` then `panic`). It is **not** a normal `.golden/Malgo.Sequent.Eval` golden case: `malgo_panic` exits nonzero *by design* on every backend (confirmed empirically — Lean eval interpreter exit 1, compiled Zig binary exit 1, Chez Scheme exit 255, all three with stdout `"before panic\n"` then the message on stderr). `scripts/zig-golden.sh`, `scripts/scheme-golden.sh`, `scripts/cli-gate.sh`, and `scripts/selfhost-golden.sh` all discover their cases by listing `.golden/Malgo.Sequent.Eval/*/` and treat a nonzero exit as failure, so pinning a golden there would break all four. Instead, `Panic` is added to `evalHarnessUnsupported` (never generating that golden) and a new dedicated, non-golden gate — `Malgo.Test.PanicGate.run` in `lean/Test/Main.lean` — exercises `malgo_panic` directly against both the small-step and big-step evaluators, asserting the captured pre-panic stdout and a substring of the rendered error message.
- The 4 new *static* IR-dump goldens this testcase needed regardless (ToCore join/flat-fingerprint/join-fingerprint, PrettyIR) were generated via `mise run test -- --update` — these don't execute the program, so they're unaffected by the exit-code issue above.

## Test plan

- [x] `mise run test` — 612/612 golden cases plus all non-golden gates pass, including the new `panic-gate` (2/2).
- [x] `bash scripts/zig-golden.sh` — 80/80 passed.
- [x] `bash scripts/scheme-golden.sh` — 79/79 passed (verified manually, unaffected by this change).
- [x] Manually confirmed all three backends agree on `Panic.mlg`'s observable behavior: stdout `"before panic\n"`, nonzero exit, panic message on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## （日本語訳）

> *このコメントはAIによるトリアージのフォローアップとして生成されました。*

#426 を修正。

### 概要

- `lean/Malgo/Sequent/Eval.lean` の `fetchPrimitive` に `malgo_panic` のケースが存在せず、`panic : String -> a`（`runtime/malgo/Builtin.mlg`）はinterpreter（`--target eval`）では汎用の「primitive not implemented」エラーに落ちていた。評価を終了し、メッセージを表示する `EvalError.panic` ケースを追加し、Zigバックエンドの `panic()`（stderr + `exit(1)`）やSchemeバックエンドの `(error 'panic ...)` の既存の挙動と一致させた。`BigStepEval.lean` は `Eval.fetchPrimitive` を直接共有しているため、この1つの変更で両方のevaluatorがカバーされる。
- `test/testcases/malgo/Panic.mlg` は小さな回帰ケース（`putStrLn` の後に `panic`）。これは通常の `.golden/Malgo.Sequent.Eval` goldenケースには**していない**: `malgo_panic` は設計上すべてのバックエンドで非ゼロ終了する（実証確認済み — Lean evalのinterpreterはexit 1、コンパイル済みZigバイナリはexit 1、Chez Schemeはexit 255、いずれもstdoutに `"before panic\n"` を出した後、メッセージはstderrへ）。`scripts/zig-golden.sh`、`scripts/scheme-golden.sh`、`scripts/cli-gate.sh`、`scripts/selfhost-golden.sh` はいずれも `.golden/Malgo.Sequent.Eval/*/` を列挙してケースを検出し、非ゼロ終了を失敗として扱うため、そこにgoldenを固定すると4つ全てが壊れる。代わりに `Panic` を `evalHarnessUnsupported` に追加し（そのgoldenを生成しない）、専用の非golden gate — `lean/Test/Main.lean` の `Malgo.Test.PanicGate.run` — を新設して、small-step評価器とbig-step評価器の両方に対して直接 `malgo_panic` を検証し、panic前に捕捉したstdoutと、レンダリングされたエラーメッセージの部分文字列を検査する。
- このtestcaseがいずれにせよ必要とする4つの新しい*静的*IRダンプgolden（ToCoreのjoin/flat-fingerprint/join-fingerprint、PrettyIR）は `mise run test -- --update` で生成した — これらはプログラムを実行しないため、上記の終了コードの問題の影響を受けない。

### テストプラン

- [x] `mise run test` — 612/612件のgoldenケースおよび全ての非goldenゲートがpass、新しい `panic-gate`（2/2）も含む。
- [x] `bash scripts/zig-golden.sh` — 80/80 pass。
- [x] `bash scripts/scheme-golden.sh` — 79/79 pass（手動確認、本変更の影響を受けない）。
- [x] 3つのバックエンドすべてが `Panic.mlg` の観測可能な挙動について一致することを手動確認: stdout `"before panic\n"`、非ゼロ終了、panicメッセージはstderrへ。
