### PR TITLE
fix(query): key ArtifactPath identity on originPath, not relPath

### DIFF
--- a/lean/Malgo/Module.lean
+++ b/lean/Malgo/Module.lean
@@ -27,16 +27,37 @@ structure ArtifactPath where
 
 namespace ArtifactPath
 
-/-- Equality/ordering on `relPath` only, so paths reached via different
-traversal routes compare equal (mirrors the Haskell instances). -/
-instance : BEq ArtifactPath := ⟨fun a b => a.relPath == b.relPath⟩
+/-- Equality/ordering on `originPath` (the realPath-canonicalized file
+identity -- see `parseArtifactPathFromPwd`/`parseArtifactPath`), so paths
+reached via different traversal routes still compare equal (mirrors the
+Haskell instances' intent), but two artifacts that merely share a
+`relPath` string no longer collide. `relPath` alone used to be the key,
+which is injective only as long as every resolved path stays inside the
+project directory; #454 flagged that #440's external search roots would
+break that assumption. Switching to `originPath` is a semantic no-op
+today (`relPath` is already a deterministic function of `originPath` for
+every in-project file), and becomes load-bearing once #440 lands. -/
+instance : BEq ArtifactPath := ⟨fun a b => a.originPath == b.originPath⟩
 
-instance : Ord ArtifactPath := ⟨fun a b => compare a.relPath b.relPath⟩
+instance : Ord ArtifactPath := ⟨fun a b => compare a.originPath b.originPath⟩
 
 /-- Same "compare via a projection" trick as `Path`'s `Std.TransOrd`
-instance: `ArtifactPath`'s `Ord` is exactly `compareOn relPath`. -/
+instance: `ArtifactPath`'s `Ord` is exactly `compareOn originPath`. -/
 instance : Std.TransOrd ArtifactPath :=
-  inferInstanceAs (Std.TransCmp (compareOn ArtifactPath.relPath))
+  inferInstanceAs (Std.TransCmp (compareOn ArtifactPath.originPath))
+
+-- Regression for #454: two artifacts that happen to share an in-project
+-- `relPath` but resolve to different `originPath`s (as could arise once an
+-- external search root exists, see #440) must never compare equal --
+-- `relPath` alone is not an injective identity once paths can come from
+-- outside the project. Before this fix, `BEq`/`Ord` keyed on `relPath` alone
+-- made these two distinct files indistinguishable.
+#guard
+  let mkArtifactPath (origin rel : String) : ArtifactPath :=
+    { rawPath := rel, originPath := ⟨origin⟩, relPath := ⟨rel⟩, targetPath := ⟨origin⟩ }
+  let inProject := mkArtifactPath "/project/Foo.mlg" "Foo.mlg"
+  let external := mkArtifactPath "/external/lib/Foo.mlg" "Foo.mlg"
+  inProject != external && compare inProject external != .eq
 
 end ArtifactPath
 
@@ -232,10 +253,10 @@ distinct file. Multiple `ModuleName`s can denote the same file --
 a relative-path import resolves to both name the identical module -- but
 `ModuleName`'s derived `BEq`/`Ord` treats different constructors as
 always-unequal even when they resolve to the same file (`ArtifactPath`'s
-own equality is `relPath`-only precisely so that traversal-route aliases
-of one `.artifact` collapse, per its doc comment, but that never bridges a
-`.moduleName` alias to an `.artifact` one). `Query.Engine.buildDepsEnv` and
-`Query.Engine.linkDeps` both fold/load once per entry in a dependency set
+own equality is `originPath`-only precisely so that traversal-route
+aliases of one `.artifact` collapse, per its doc comment, but that never
+bridges a `.moduleName` alias to an `.artifact` one). `Query.Engine.buildDepsEnv`
+and `Query.Engine.linkDeps` both fold/load once per entry in a dependency set
 reached this way, so both call this to collapse alias-of-the-same-file
 entries into one before doing that work -- see #429. -/
 def dedupeByArtifactPath (ws : Workspace) (deps : Std.TreeSet ModuleName) :

--- a/lean/Malgo/Module.lean
+++ b/lean/Malgo/Module.lean
@@ -59,6 +59,19 @@ instance : Std.TransOrd ArtifactPath :=
   let external := mkArtifactPath "/external/lib/Foo.mlg" "Foo.mlg"
   inProject != external && compare inProject external != .eq
 
+-- Converse of the above, pinning the property the doc comment above still
+-- claims: two `ModuleName`s reached via different traversal routes but
+-- naming the same origin file (same `originPath`, different `rawPath`)
+-- must still collapse to one artifact -- this is what lets
+-- `dedupeByArtifactPath` (#429) treat aliases of one file as one entry.
+#guard
+  let mkArtifactPath (rawPath : String) : ArtifactPath :=
+    { rawPath, originPath := ⟨"/project/Foo.mlg"⟩, relPath := ⟨"Foo.mlg"⟩
+      targetPath := ⟨"/project/Foo.mlg"⟩ }
+  let viaBareImport := mkArtifactPath "Foo"
+  let viaRelativeImport := mkArtifactPath "./Foo.mlg"
+  viaBareImport == viaRelativeImport && compare viaBareImport viaRelativeImport == .eq
+
 end ArtifactPath
 
 inductive ModuleName where

--- a/lean/Malgo/Prelude.lean
+++ b/lean/Malgo/Prelude.lean
@@ -118,9 +118,10 @@ theorem mem_sortAssocAscending {κ α : Type} [Ord κ] {xs : List (κ × α)} {p
 monotonicity" lemma (`s ⊆ t → s.size ≤ t.size`), and no `TreeSet`-level
 extensionality principle usable without `LawfulEqCmp` (which a key type
 like `ModuleName` can genuinely fail — two `ModuleName.artifact` values
-with the same `relPath` but different other `ArtifactPath` fields compare
-`.eq` without being `=`). Both facts below are derived purely from
-existing size/diff/inter identities (`isEmpty_diff_iff`,
+with the same `originPath` but different other `ArtifactPath` fields
+(`rawPath`/`relPath`/`targetPath`) compare `.eq` without being `=`). Both
+facts below are derived purely from existing size/diff/inter identities
+(`isEmpty_diff_iff`,
 `size_diff_add_size_inter_eq_size_left`, `size_inter_le_size_right`,
 `size_erase`), so they need only `[Std.TransCmp cmp]`. -/
 

--- a/lean/Malgo/Query/Engine.lean
+++ b/lean/Malgo/Query/Engine.lean
@@ -180,9 +180,10 @@ same underlying file under two different `ModuleName` *aliases* — e.g.
 `.moduleName "Builtin"` (a bare `import Builtin`) and the `.artifact` form a
 relative-path import resolves to — because `ModuleName`'s derived `BEq`/`Ord`
 treats different constructors as always-unequal even when they name the
-same file on disk (`ArtifactPath`'s own equality is `relPath`-only precisely
-so that traversal-route aliases of one `.artifact` collapse, per its doc
-comment, but that never bridges a `.moduleName` alias to an `.artifact` one).
+same file on disk (`ArtifactPath`'s own equality is `originPath`-only
+precisely so that traversal-route aliases of one `.artifact` collapse, per
+its doc comment, but that never bridges a `.moduleName` alias to an
+`.artifact` one).
 Since `Prelude.mlg` re-exports `Builtin.mlg` via its own bare `import
 Builtin`, any program that imports both Builtin and Prelude by two different
 route shapes (confirmed via


### PR DESCRIPTION
## Summary

- `ArtifactPath`'s `BEq`/`Ord`/`Std.TransOrd` instances now key on `originPath` instead of `relPath`. `relPath` is injective only as long as every resolved path stays inside the project directory; #454 flagged that #440's external search roots would break that assumption, and since `ModuleName`'s derived `BEq`/`Ord` delegates to `ArtifactPath` for the `.artifact` case, the blast radius is wider than `Workspace.dedupeByArtifactPath`'s own local set -- it also reaches `RnState.dependencies` (a `Std.TreeSet ModuleName`) and `Workspace.moduleMap` (a `Std.TreeMap ModuleName ArtifactPath`).
- `originPath` is already realPath-canonicalized and already treated elsewhere in the pipeline as the file's real identity (`Driver.lean` reads bytes via `apath.originPath`; `Query/Engine.lean` reads source text via `modPath.originPath`).
- Semantically inert today, not just by argument but provably: for every `ArtifactPath` constructible today, `originPath.toString == pwd ++ "/" ++ relPath.toString` (construction throws otherwise -- see `parseArtifactPathFromPwd`/`parseArtifactPath`), and `Ord (Path b t)` is plain string comparison, which a shared prefix preserves the order of. So the induced total order is identical to the old one for every artifact that exists today. Also checked empirically: `find . -type l` (excluding `.lake`/`.malgo-work`/`.git`) finds only two doc symlinks at the repo root, neither reachable through the module search path (`runtime/`, `test/`, `examples/`, `bench/` contain none), so this change cannot today merge two previously-distinct `relPath`s that happen to symlink to the same file.
- Adds two `#guard` regressions next to the instances: (1) two artifacts sharing a `relPath` but with different `originPath`s must not compare equal (red under the old `relPath`-keyed instances, confirmed before applying the fix); (2) the converse -- two `ModuleName`s reached via different traversal routes but naming the same `originPath` must still collapse to one artifact, pinning the property `dedupeByArtifactPath` (#429) relies on.

Two follow-ups noted but intentionally not built here, since #440's external search paths don't exist yet:
- `ModuleName.digest` is basename-only with no root awareness (only matters once distinct roots exist).
- `parseArtifactPath`'s `originBase` is always the project root regardless of whether the "from" module was itself externally resolved (also only matters once #440 lands).

Closes #454

## Test plan

- [x] `mise run test` -- 935/935 (including the new `#guard` regressions, confirmed red before the fix and green after)
- [x] `bash scripts/zig-golden.sh` -- 81/81, no golden diffs
- [x] `bash scripts/scheme-golden.sh` -- 80/80, no golden diffs
- [x] `bash scripts/selfhost-golden.sh` -- 80/80, no golden diffs
- [x] `bash scripts/cli-gate.sh` -- all 4 modes pass
- [x] `bash scripts/json-check.sh` -- pass
- [x] `bash scripts/zig-deep-recursion.sh` -- pass, no leak
- [x] Confirmed the `selfhost-l1` perf-baseline "IMPROVED" note is pre-existing master staleness, not caused by this change (reproduced the identical counters by stashing this diff and re-running `mise run perf-baseline -- --tier=selfhost-l1` against bare `origin/master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)