### PR TITLE
fix(selfhost): resolve panic's wrapper through normal Builtin.mlg imports

### DIFF
--- a/.golden/Malgo.Debug.PrettyIR/testcases/PanicNamedImport/golden
+++ b/.golden/Malgo.Debug.PrettyIR/testcases/PanicNamedImport/golden
@@ -1,0 +1,953 @@
+=== Parse ===
+import runtime/malgo/Builtin.mlg (panic, String#)
+
+import runtime/malgo/Prelude.mlg 
+
+def main =
+  fn {
+    _ ->
+      {
+        let _ = putStrLn("before panic")
+        panic("malgo#452 named-import regression check")
+      }
+  }
+
+=== Rename ===
+import runtime/malgo/Builtin.mlg (panic, String#)
+
+import runtime/malgo/Prelude.mlg 
+
+def main =
+  fn {
+    _#0 ->
+      {
+        let _#1 = putStrLn(String#("before panic"))
+        panic(String#("malgo#452 named-import regression check"))
+      }
+  }
+
+=== ToFun ===
+def main =
+  \param$2 ->
+    case param$2 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before panic"))
+        in
+          invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
+    }
+
+=== SaturateCtor ===
+def main =
+  \param$2 ->
+    case param$2 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before panic"))
+        in
+          invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
+    }
+
+=== ReuseSpecialize ===
+def main =
+  \param$2 ->
+    case param$2 of {
+      _#0 ->
+        let _#1 =
+          invoke putStrLn(invoke String#("before panic"))
+        in
+          invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
+    }
+
+=== ToCore ===
+def main(return$3) =
+  \param$2 return$4 . {
+    param$2 ~ select {
+      _#0 ->
+        invoke putStrLn ~ ( do return$6 . {
+          invoke String# ~ ("before panic", return$6)
+        }
+        , then _#1 -> {
+          invoke panic ~ ( do return$5 . {
+            invoke String# ~ ( "malgo#452 named-import regression check"
+            , return$5 )
+          }
+          , return$4 )
+        } )
+    }
+  } ~ return$3
+
+=== Flat ===
+def main(return$3) =
+  \param$2 return$4 . {
+    param$2 ~ select {
+      _#0 ->
+        invoke putStrLn ~ then outer$7 -> {
+          join return$6 = then inner$8 -> {
+            outer$7 ~ ( inner$8
+            , then _#1 -> {
+              invoke panic ~ then outer$9 -> {
+                join return$5 = then inner$10 -> {
+                  outer$9 ~ (inner$10, return$4)
+                }
+                in invoke String# ~ ( "malgo#452 named-import regression check"
+                , return$5 )
+              }
+            } )
+          }
+          in invoke String# ~ ("before panic", return$6)
+        }
+    }
+  } ~ return$3
+
+=== Join ===
+def main(return$3) =
+  \param$2 return$4 . {
+    join select$18 = select {
+      _#0 ->
+        join then$17 = then outer$7 -> {
+          join return$6 = then inner$8 -> {
+            join then$15 = then _#1 -> {
+              join then$14 = then outer$9 -> {
+                join return$5 = then inner$10 -> {
+                  join apply$13 = (inner$10, return$4)
+                  in outer$9 ~ apply$13
+                }
+                in join apply$12 = ( "malgo#452 named-import regression check"
+                , return$5 )
+                in invoke String# ~ apply$12
+              }
+              in invoke panic ~ then$14
+            }
+            in join apply$16 = (inner$8, then$15)
+            in outer$7 ~ apply$16
+          }
+          in join apply$11 = ("before panic", return$6)
+          in invoke String# ~ apply$11
+        }
+        in invoke putStrLn ~ then$17
+    }
+    in param$2 ~ select$18
+  } ~ return$3
+
+=== ClosureConv ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  if  then {
+    let _#0 = param$2
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  let value$24 = self$26.cap[1]
+  let then$15 = closure join$28(return$4)
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  let return$4 = self$29.cap[0]
+  let then$14 = closure join$31(return$4)
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  let value$33 = self$35.cap[1]
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  let lit$40 = "malgo#452 named-import regression check"
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  let lit$44 = "before panic"
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) = return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  let struct$56 = Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== Peephole ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  if  then {
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  let value$24 = self$26.cap[1]
+  let then$15 = closure join$28(return$4)
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  let return$4 = self$29.cap[0]
+  let then$14 = closure join$31(return$4)
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  let value$33 = self$35.cap[1]
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  let lit$40 = "malgo#452 named-import regression check"
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  let lit$44 = "before panic"
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) = return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  let struct$56 = Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== Perceus ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  drop param$2
+  drop self$21
+  if  then {
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  dup return$4
+  drop self$23
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  dup return$4
+  let value$24 = self$26.cap[1]
+  dup value$24
+  drop self$26
+  let then$15 = closure join$28(return$4)
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  drop value$30
+  let return$4 = self$29.cap[0]
+  dup return$4
+  drop self$29
+  let then$14 = closure join$31(return$4)
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  dup return$4
+  drop self$32
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  dup return$4
+  let value$33 = self$35.cap[1]
+  dup value$33
+  drop self$35
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  dup return$5
+  drop self$38
+  let lit$40 = "malgo#452 named-import regression check"
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  dup return$6
+  drop self$42
+  let lit$44 = "before panic"
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) =
+  drop self$51
+  return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  dup finish$46
+  drop self$54
+  let struct$56 = Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== Reuse ===
+toplevel fn main(return$3) =
+  let closure$45 = closure lambda$20()
+  return return$3(closure$45)
+
+closure fn lambda$20(self$21, param$2, return$4) =
+  drop param$2
+  drop self$21
+  if  then {
+    let then$17 = closure join$22(return$4)
+    return putStrLn(then$17)
+  } else {
+    panic "no matching branch"
+  }
+
+closure fn join$22(self$23, value$24) =
+  let return$4 = self$23.cap[0]
+  dup return$4
+  let return$6 = closure join$25(return$4, value$24)
+  let apply$11 = closure join$41(return$6)
+  drop self$23
+  return String#(apply$11)
+
+closure fn join$25(self$26, value$27) =
+  let return$4 = self$26.cap[0]
+  dup return$4
+  let value$24 = self$26.cap[1]
+  dup value$24
+  let then$15 = closure join$28(return$4)
+  drop self$26
+  return value$24(value$27, then$15)
+
+closure fn join$28(self$29, value$30) =
+  let return$4 = self$29.cap[0]
+  dup return$4
+  let then$14 = closure join$31(return$4)
+  drop value$30
+  drop self$29
+  return panic(then$14)
+
+closure fn join$31(self$32, value$33) =
+  let return$4 = self$32.cap[0]
+  dup return$4
+  let return$5 = closure join$34(return$4, value$33)
+  let apply$12 = closure join$37(return$5)
+  drop self$32
+  return String#(apply$12)
+
+closure fn join$34(self$35, value$36) =
+  let return$4 = self$35.cap[0]
+  dup return$4
+  let value$33 = self$35.cap[1]
+  dup value$33
+  drop self$35
+  return value$33(value$36, return$4)
+
+closure fn join$37(self$38, value$39) =
+  let return$5 = self$38.cap[0]
+  dup return$5
+  let lit$40 = "malgo#452 named-import regression check"
+  drop self$38
+  return value$39(lit$40, return$5)
+
+closure fn join$41(self$42, value$43) =
+  let return$6 = self$42.cap[0]
+  dup return$6
+  let lit$44 = "before panic"
+  drop self$42
+  return value$43(lit$44, return$6)
+
+toplevel fn zig_main$48() =
+  let finish$46 = closure join$50()
+  let after_main$47 = closure join$53(finish$46)
+  return main(after_main$47)
+
+closure fn join$50(self$51, value$52) =
+  drop self$51
+  return value$52
+
+closure fn join$53(self$54, value$55) =
+  let finish$46 = self$54.cap[0]
+  dup finish$46
+  dropReuse reuse$57 = self$54 /0
+  let struct$56 = reuse reuse$57 Tuple()
+  return value$55(struct$56, finish$46)
+
+entry = zig_main$48
+
+=== DIFFS ===
+
+=== Parse -> Rename ===
+  import runtime/malgo/Builtin.mlg (panic, String#)
+  
+  import runtime/malgo/Prelude.mlg 
+  
+  def main =
+    fn {
+-     _ ->
++     _#0 ->
+        {
+-         let _ = putStrLn("before panic")
++         let _#1 = putStrLn(String#("before panic"))
+-         panic("malgo#452 named-import regression check")
++         panic(String#("malgo#452 named-import regression check"))
+        }
+    }
+
+
+=== Rename -> ToFun ===
+- import runtime/malgo/Builtin.mlg (panic, String#)
+- 
+- import runtime/malgo/Prelude.mlg 
+- 
+  def main =
+-   fn {
++   \param$2 ->
+-     _#0 ->
++     case param$2 of {
+-       {
++       _#0 ->
+-         let _#1 = putStrLn(String#("before panic"))
++         let _#1 =
+-         panic(String#("malgo#452 named-import regression check"))
++           invoke putStrLn(invoke String#("before panic"))
+-       }
++         in
+-   }
++           invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
++     }
+
+
+=== ToFun -> SaturateCtor ===
+  def main =
+    \param$2 ->
+      case param$2 of {
+        _#0 ->
+          let _#1 =
+            invoke putStrLn(invoke String#("before panic"))
+          in
+            invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
+      }
+
+
+=== SaturateCtor -> ReuseSpecialize ===
+  def main =
+    \param$2 ->
+      case param$2 of {
+        _#0 ->
+          let _#1 =
+            invoke putStrLn(invoke String#("before panic"))
+          in
+            invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
+      }
+
+
+=== ReuseSpecialize -> ToCore ===
+- def main =
++ def main(return$3) =
+-   \param$2 ->
++   \param$2 return$4 . {
+-     case param$2 of {
++     param$2 ~ select {
+        _#0 ->
+-         let _#1 =
++         invoke putStrLn ~ ( do return$6 . {
+-           invoke putStrLn(invoke String#("before panic"))
++           invoke String# ~ ("before panic", return$6)
+-         in
++         }
+-           invoke panic( invoke String#( "malgo#452 named-import regression check" ) )
++         , then _#1 -> {
++           invoke panic ~ ( do return$5 . {
++             invoke String# ~ ( "malgo#452 named-import regression check"
++             , return$5 )
++           }
++           , return$4 )
++         } )
+      }
++   } ~ return$3
+
+
+=== ToCore -> Flat ===
+  def main(return$3) =
+    \param$2 return$4 . {
+      param$2 ~ select {
+        _#0 ->
+-         invoke putStrLn ~ ( do return$6 . {
++         invoke putStrLn ~ then outer$7 -> {
+-           invoke String# ~ ("before panic", return$6)
++           join return$6 = then inner$8 -> {
+-         }
++             outer$7 ~ ( inner$8
+-         , then _#1 -> {
++             , then _#1 -> {
+-           invoke panic ~ ( do return$5 . {
++               invoke panic ~ then outer$9 -> {
+-             invoke String# ~ ( "malgo#452 named-import regression check"
++                 join return$5 = then inner$10 -> {
+-             , return$5 )
++                   outer$9 ~ (inner$10, return$4)
++                 }
++                 in invoke String# ~ ( "malgo#452 named-import regression check"
++                 , return$5 )
++               }
++             } )
+            }
+-           , return$4 )
++           in invoke String# ~ ("before panic", return$6)
+-         } )
++         }
+      }
+    } ~ return$3
+
+
+=== Flat -> Join ===
+  def main(return$3) =
+    \param$2 return$4 . {
+-     param$2 ~ select {
++     join select$18 = select {
+        _#0 ->
+-         invoke putStrLn ~ then outer$7 -> {
++         join then$17 = then outer$7 -> {
+            join return$6 = then inner$8 -> {
+-             outer$7 ~ ( inner$8
++             join then$15 = then _#1 -> {
+-             , then _#1 -> {
++               join then$14 = then outer$9 -> {
+-               invoke panic ~ then outer$9 -> {
+                  join return$5 = then inner$10 -> {
+-                   outer$9 ~ (inner$10, return$4)
++                   join apply$13 = (inner$10, return$4)
++                   in outer$9 ~ apply$13
+                  }
+-                 in invoke String# ~ ( "malgo#452 named-import regression check"
++                 in join apply$12 = ( "malgo#452 named-import regression check"
+                  , return$5 )
++                 in invoke String# ~ apply$12
+                }
+-             } )
++               in invoke panic ~ then$14
++             }
++             in join apply$16 = (inner$8, then$15)
++             in outer$7 ~ apply$16
+            }
+-           in invoke String# ~ ("before panic", return$6)
++           in join apply$11 = ("before panic", return$6)
++           in invoke String# ~ apply$11
+          }
++         in invoke putStrLn ~ then$17
+      }
++     in param$2 ~ select$18
+    } ~ return$3
+
+
+=== Join -> ClosureConv ===
+- def main(return$3) =
++ toplevel fn main(return$3) =
+-   \param$2 return$4 . {
++   let closure$45 = closure lambda$20()
+-     join select$18 = select {
++   return return$3(closure$45)
+-       _#0 ->
++ 
+-         join then$17 = then outer$7 -> {
++ closure fn lambda$20(self$21, param$2, return$4) =
+-           join return$6 = then inner$8 -> {
++   if  then {
+-             join then$15 = then _#1 -> {
++     let _#0 = param$2
+-               join then$14 = then outer$9 -> {
++     let then$17 = closure join$22(return$4)
+-                 join return$5 = then inner$10 -> {
++     return putStrLn(then$17)
+-                   join apply$13 = (inner$10, return$4)
++   } else {
+-                   in outer$9 ~ apply$13
++     panic "no matching branch"
+-                 }
++   }
+-                 in join apply$12 = ( "malgo#452 named-import regression check"
++ 
+-                 , return$5 )
++ closure fn join$22(self$23, value$24) =
+-                 in invoke String# ~ apply$12
++   let return$4 = self$23.cap[0]
+-               }
++   let return$6 = closure join$25(return$4, value$24)
+-               in invoke panic ~ then$14
++   let apply$11 = closure join$41(return$6)
+-             }
++   return String#(apply$11)
+-             in join apply$16 = (inner$8, then$15)
++ 
+-             in outer$7 ~ apply$16
++ closure fn join$25(self$26, value$27) =
+-           }
++   let return$4 = self$26.cap[0]
+-           in join apply$11 = ("before panic", return$6)
++   let value$24 = self$26.cap[1]
+-           in invoke String# ~ apply$11
++   let then$15 = closure join$28(return$4)
+-         }
++   return value$24(value$27, then$15)
+-         in invoke putStrLn ~ then$17
++ 
+-     }
++ closure fn join$28(self$29, value$30) =
+-     in param$2 ~ select$18
++   let return$4 = self$29.cap[0]
+-   } ~ return$3
++   let then$14 = closure join$31(return$4)
++   return panic(then$14)
++ 
++ closure fn join$31(self$32, value$33) =
++   let return$4 = self$32.cap[0]
++   let return$5 = closure join$34(return$4, value$33)
++   let apply$12 = closure join$37(return$5)
++   return String#(apply$12)
++ 
++ closure fn join$34(self$35, value$36) =
++   let return$4 = self$35.cap[0]
++   let value$33 = self$35.cap[1]
++   return value$33(value$36, return$4)
++ 
++ closure fn join$37(self$38, value$39) =
++   let return$5 = self$38.cap[0]
++   let lit$40 = "malgo#452 named-import regression check"
++   return value$39(lit$40, return$5)
++ 
++ closure fn join$41(self$42, value$43) =
++   let return$6 = self$42.cap[0]
++   let lit$44 = "before panic"
++   return value$43(lit$44, return$6)
++ 
++ toplevel fn zig_main$48() =
++   let finish$46 = closure join$50()
++   let after_main$47 = closure join$53(finish$46)
++   return main(after_main$47)
++ 
++ closure fn join$50(self$51, value$52) = return value$52
++ 
++ closure fn join$53(self$54, value$55) =
++   let finish$46 = self$54.cap[0]
++   let struct$56 = Tuple()
++   return value$55(struct$56, finish$46)
++ 
++ entry = zig_main$48
+
+
+=== ClosureConv -> Peephole ===
+  toplevel fn main(return$3) =
+    let closure$45 = closure lambda$20()
+    return return$3(closure$45)
+  
+  closure fn lambda$20(self$21, param$2, return$4) =
+    if  then {
+-     let _#0 = param$2
+      let then$17 = closure join$22(return$4)
+      return putStrLn(then$17)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$22(self$23, value$24) =
+    let return$4 = self$23.cap[0]
+    let return$6 = closure join$25(return$4, value$24)
+    let apply$11 = closure join$41(return$6)
+    return String#(apply$11)
+  
+  closure fn join$25(self$26, value$27) =
+    let return$4 = self$26.cap[0]
+    let value$24 = self$26.cap[1]
+    let then$15 = closure join$28(return$4)
+    return value$24(value$27, then$15)
+  
+  closure fn join$28(self$29, value$30) =
+    let return$4 = self$29.cap[0]
+    let then$14 = closure join$31(return$4)
+    return panic(then$14)
+  
+  closure fn join$31(self$32, value$33) =
+    let return$4 = self$32.cap[0]
+    let return$5 = closure join$34(return$4, value$33)
+    let apply$12 = closure join$37(return$5)
+    return String#(apply$12)
+  
+  closure fn join$34(self$35, value$36) =
+    let return$4 = self$35.cap[0]
+    let value$33 = self$35.cap[1]
+    return value$33(value$36, return$4)
+  
+  closure fn join$37(self$38, value$39) =
+    let return$5 = self$38.cap[0]
+    let lit$40 = "malgo#452 named-import regression check"
+    return value$39(lit$40, return$5)
+  
+  closure fn join$41(self$42, value$43) =
+    let return$6 = self$42.cap[0]
+    let lit$44 = "before panic"
+    return value$43(lit$44, return$6)
+  
+  toplevel fn zig_main$48() =
+    let finish$46 = closure join$50()
+    let after_main$47 = closure join$53(finish$46)
+    return main(after_main$47)
+  
+  closure fn join$50(self$51, value$52) = return value$52
+  
+  closure fn join$53(self$54, value$55) =
+    let finish$46 = self$54.cap[0]
+    let struct$56 = Tuple()
+    return value$55(struct$56, finish$46)
+  
+  entry = zig_main$48
+
+
+=== Peephole -> Perceus ===
+  toplevel fn main(return$3) =
+    let closure$45 = closure lambda$20()
+    return return$3(closure$45)
+  
+  closure fn lambda$20(self$21, param$2, return$4) =
++   drop param$2
++   drop self$21
+    if  then {
+      let then$17 = closure join$22(return$4)
+      return putStrLn(then$17)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$22(self$23, value$24) =
+    let return$4 = self$23.cap[0]
++   dup return$4
++   drop self$23
+    let return$6 = closure join$25(return$4, value$24)
+    let apply$11 = closure join$41(return$6)
+    return String#(apply$11)
+  
+  closure fn join$25(self$26, value$27) =
+    let return$4 = self$26.cap[0]
++   dup return$4
+    let value$24 = self$26.cap[1]
++   dup value$24
++   drop self$26
+    let then$15 = closure join$28(return$4)
+    return value$24(value$27, then$15)
+  
+  closure fn join$28(self$29, value$30) =
++   drop value$30
+    let return$4 = self$29.cap[0]
++   dup return$4
++   drop self$29
+    let then$14 = closure join$31(return$4)
+    return panic(then$14)
+  
+  closure fn join$31(self$32, value$33) =
+    let return$4 = self$32.cap[0]
++   dup return$4
++   drop self$32
+    let return$5 = closure join$34(return$4, value$33)
+    let apply$12 = closure join$37(return$5)
+    return String#(apply$12)
+  
+  closure fn join$34(self$35, value$36) =
+    let return$4 = self$35.cap[0]
++   dup return$4
+    let value$33 = self$35.cap[1]
++   dup value$33
++   drop self$35
+    return value$33(value$36, return$4)
+  
+  closure fn join$37(self$38, value$39) =
+    let return$5 = self$38.cap[0]
++   dup return$5
++   drop self$38
+    let lit$40 = "malgo#452 named-import regression check"
+    return value$39(lit$40, return$5)
+  
+  closure fn join$41(self$42, value$43) =
+    let return$6 = self$42.cap[0]
++   dup return$6
++   drop self$42
+    let lit$44 = "before panic"
+    return value$43(lit$44, return$6)
+  
+  toplevel fn zig_main$48() =
+    let finish$46 = closure join$50()
+    let after_main$47 = closure join$53(finish$46)
+    return main(after_main$47)
+  
+- closure fn join$50(self$51, value$52) = return value$52
++ closure fn join$50(self$51, value$52) =
++   drop self$51
++   return value$52
+  
+  closure fn join$53(self$54, value$55) =
+    let finish$46 = self$54.cap[0]
++   dup finish$46
++   drop self$54
+    let struct$56 = Tuple()
+    return value$55(struct$56, finish$46)
+  
+  entry = zig_main$48
+
+
+=== Perceus -> Reuse ===
+  toplevel fn main(return$3) =
+    let closure$45 = closure lambda$20()
+    return return$3(closure$45)
+  
+  closure fn lambda$20(self$21, param$2, return$4) =
+    drop param$2
+    drop self$21
+    if  then {
+      let then$17 = closure join$22(return$4)
+      return putStrLn(then$17)
+    } else {
+      panic "no matching branch"
+    }
+  
+  closure fn join$22(self$23, value$24) =
+    let return$4 = self$23.cap[0]
+    dup return$4
+-   drop self$23
+    let return$6 = closure join$25(return$4, value$24)
+    let apply$11 = closure join$41(return$6)
++   drop self$23
+    return String#(apply$11)
+  
+  closure fn join$25(self$26, value$27) =
+    let return$4 = self$26.cap[0]
+    dup return$4
+    let value$24 = self$26.cap[1]
+    dup value$24
+-   drop self$26
+    let then$15 = closure join$28(return$4)
++   drop self$26
+    return value$24(value$27, then$15)
+  
+  closure fn join$28(self$29, value$30) =
+-   drop value$30
+    let return$4 = self$29.cap[0]
+    dup return$4
+-   drop self$29
+    let then$14 = closure join$31(return$4)
++   drop value$30
++   drop self$29
+    return panic(then$14)
+  
+  closure fn join$31(self$32, value$33) =
+    let return$4 = self$32.cap[0]
+    dup return$4
+-   drop self$32
+    let return$5 = closure join$34(return$4, value$33)
+    let apply$12 = closure join$37(return$5)
++   drop self$32
+    return String#(apply$12)
+  
+  closure fn join$34(self$35, value$36) =
+    let return$4 = self$35.cap[0]
+    dup return$4
+    let value$33 = self$35.cap[1]
+    dup value$33
+    drop self$35
+    return value$33(value$36, return$4)
+  
+  closure fn join$37(self$38, value$39) =
+    let return$5 = self$38.cap[0]
+    dup return$5
+-   drop self$38
+    let lit$40 = "malgo#452 named-import regression check"
++   drop self$38
+    return value$39(lit$40, return$5)
+  
+  closure fn join$41(self$42, value$43) =
+    let return$6 = self$42.cap[0]
+    dup return$6
+-   drop self$42
+    let lit$44 = "before panic"
++   drop self$42
+    return value$43(lit$44, return$6)
+  
+  toplevel fn zig_main$48() =
+    let finish$46 = closure join$50()
+    let after_main$47 = closure join$53(finish$46)
+    return main(after_main$47)
+  
+  closure fn join$50(self$51, value$52) =
+    drop self$51
+    return value$52
+  
+  closure fn join$53(self$54, value$55) =
+    let finish$46 = self$54.cap[0]
+    dup finish$46
+-   drop self$54
++   dropReuse reuse$57 = self$54 /0
+-   let struct$56 = Tuple()
++   let struct$56 = reuse reuse$57 Tuple()
+    return value$55(struct$56, finish$46)
+  
+  entry = zig_main$48

--- a/.golden/Malgo.Sequent.ToCore/flat-fingerprint/PanicNamedImport/golden
+++ b/.golden/Malgo.Sequent.ToCore/flat-fingerprint/PanicNamedImport/golden
@@ -1,0 +1,1 @@
+applies=4 cuts=4 definitions=1 invokes=4 joins=2 labels=4 lambdas=1 literals=2 selects=1 thens=5 vars=5

--- a/.golden/Malgo.Sequent.ToCore/golden/PanicNamedImport/join/golden
+++ b/.golden/Malgo.Sequent.ToCore/golden/PanicNamedImport/join/golden
@@ -1,0 +1,64 @@
+((main
+    $PanicNamedImport.return_3
+    (cut
+       (lambda
+          ($PanicNamedImport.param_2 $PanicNamedImport.return_4)
+          (join
+             $PanicNamedImport.select_18
+             (select
+                (#PanicNamedImport.__0
+                   (join
+                      $PanicNamedImport.then_17
+                      (then
+                         $PanicNamedImport.outer_7
+                         (join
+                            $PanicNamedImport.return_6
+                            (then
+                               $PanicNamedImport.inner_8
+                               (join
+                                  $PanicNamedImport.then_15
+                                  (then
+                                     #PanicNamedImport.__1
+                                     (join
+                                        $PanicNamedImport.then_14
+                                        (then
+                                           $PanicNamedImport.outer_9
+                                           (join
+                                              $PanicNamedImport.return_5
+                                              (then
+                                                 $PanicNamedImport.inner_10
+                                                 (join
+                                                    $PanicNamedImport.apply_13
+                                                    (apply
+                                                       ($PanicNamedImport.inner_10)
+                                                       ($PanicNamedImport.return_4))
+                                                    (cut
+                                                       $PanicNamedImport.outer_9
+                                                       $PanicNamedImport.apply_13)))
+                                              (join
+                                                 $PanicNamedImport.apply_12
+                                                 (apply
+                                                    ("malgo#452 named-import regression check")
+                                                    ($PanicNamedImport.return_5))
+                                                 (invoke
+                                                    String#
+                                                    $PanicNamedImport.apply_12))))
+                                        (invoke panic $PanicNamedImport.then_14)))
+                                  (join
+                                     $PanicNamedImport.apply_16
+                                     (apply
+                                        ($PanicNamedImport.inner_8)
+                                        ($PanicNamedImport.then_15))
+                                     (cut
+                                        $PanicNamedImport.outer_7
+                                        $PanicNamedImport.apply_16))))
+                            (join
+                               $PanicNamedImport.apply_11
+                               (apply
+                                  ("before panic")
+                                  ($PanicNamedImport.return_6))
+                               (invoke String# $PanicNamedImport.apply_11))))
+                      (invoke putStrLn $PanicNamedImport.then_17))))
+             (cut $PanicNamedImport.param_2 $PanicNamedImport.select_18)))
+       $PanicNamedImport.return_3))
+   ("runtime/malgo/Builtin.mlg" "runtime/malgo/Prelude.mlg"))

--- a/.golden/Malgo.Sequent.ToCore/join-fingerprint/PanicNamedImport/golden
+++ b/.golden/Malgo.Sequent.ToCore/join-fingerprint/PanicNamedImport/golden
@@ -1,0 +1,1 @@
+applies=4 cuts=4 definitions=1 invokes=4 joins=10 lambdas=1 literals=2 selects=1 thens=5 vars=5

--- a/lean/Test/Main.lean
+++ b/lean/Test/Main.lean
@@ -257,13 +257,19 @@ for its own reason:
   and Scheme (`Backend/Scheme.lean`'s `(error 'panic ...)`) backends —
   there is no successful stdout to pin as a golden. `PanicGate.run` below
   exercises both directly instead.
+- `PanicNamedImport` (malgo#452) is `Panic`'s named-import twin (`module
+  {panic} = import ...` instead of `module {..} = import ...`), added to
+  regression-test the self-hosted evaluator's `import Builtin.mlg`
+  substitution (see `scripts/selfhost-golden.sh`'s panic-import gate) --
+  excluded from this harness for the same reason as `Panic`.
 
 Excluding these here keeps `scripts/cli-gate.sh`'s `eval` mode, and
 `scripts/zig-golden.sh`/`scripts/scheme-golden.sh`/`scripts/selfhost-golden.sh`
 (all of which discover their cases by listing `.golden/Malgo.Sequent.Eval/*/`
 rather than scanning `test/testcases/malgo/` directly), from ever seeing
 any of these names — no per-script skip-list needed. -/
-def evalHarnessUnsupported : List String := ["TaggedRecordCrossModuleUse", "Panic", "CondPanic"]
+def evalHarnessUnsupported : List String :=
+  ["TaggedRecordCrossModuleUse", "Panic", "CondPanic", "PanicNamedImport"]
 
 private def evalGolden (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR))
     (name : String) : IO String := do
@@ -309,18 +315,20 @@ def bigStepEvalCases (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR))
     { group := "Malgo.Sequent.BigStepEval", name := s!"golden/{n}", run := bigStepEvalGolden memo n }
 
 /-! ## Panic gate (regression test for malgo#426, not golden — see
-`evalHarnessUnsupported` for why `Panic`/`CondPanic` are excluded from
-`evalCases`/`bigStepEvalCases`).
+`evalHarnessUnsupported` for why `Panic`/`CondPanic`/`PanicNamedImport` are
+excluded from `evalCases`/`bigStepEvalCases`).
 
 Checks both entry points against each linked program: `BigStepEval.lean`
 calls `Eval.fetchPrimitive` directly rather than reimplementing it, so this
 also confirms the big-step evaluator didn't need its own `malgo_panic`
-case. Two scenarios: `Panic` calls `panic(...)` directly; `CondPanic` walks
+case. Three scenarios: `Panic` calls `panic(...)` directly; `CondPanic` walks
 one `Cons (False, _) xs` step of `Prelude.mlg`'s `cond` before hitting its
 `Nil -> panic "no branch"` fallback -- the specific path #426's issue text
-called out as untested. Both stdout and the full rendered error message are
-pinned exactly: `EvalError.rangeOf`'s `.panic` case returns `none` (its
-`range` would be `fetchPrimitive`'s call-site range, i.e. `panic`'s own
+called out as untested; `PanicNamedImport` (malgo#452) is `Panic`'s
+named-import twin, confirming the Lean interpreters -- unlike the
+self-hosted evaluator -- have no trouble with either import form. Both
+stdout and the full rendered error message are pinned exactly:
+`EvalError.rangeOf`'s `.panic` case returns `none` (its
 foreign-import declaration in Builtin.mlg, never the caller's actual
 `panic(...)` site), so the message is just `[<passName>] panic: <msg>` with
 no location prefix to make an exact match brittle -- `<passName>` differs
@@ -339,7 +347,9 @@ private def scenarios : List Scenario :=
   [ { testcase := "Panic", expectedStdout := "before panic\n",
       expectedMessage := "panic: malgo#426 regression check" },
     { testcase := "CondPanic", expectedStdout := "before cond\n",
-      expectedMessage := "panic: no branch" } ]
+      expectedMessage := "panic: no branch" },
+    { testcase := "PanicNamedImport", expectedStdout := "before panic\n",
+      expectedMessage := "panic: malgo#452 named-import regression check" } ]
 
 def run (memo : IO.Ref (Std.HashMap String Malgo.Driver.AllIR)) : IO Nat := do
   let evaluators :=

--- a/runtime/malgo/compiler/Eval.mlg
+++ b/runtime/malgo/compiler/Eval.mlg
@@ -1065,6 +1065,19 @@ def applyBuiltin8 = { gEnv name args ->
     "exitSuccess" -> Left "exitSuccess",
     "malgo_exit_success" -> Left "exitSuccess",
     "malgo_panic" -> case args { (Cons (VString s) Nil) -> Left (appendString "panic: " s), (Cons x Nil) -> Left (appendString "panic: " (valueToText x)), _ -> Left "panic" },
+    -- `panic`'s real Builtin.mlg definition is a thin wrapper --
+    -- `{ (String# message) -> malgo_panic message }` -- but `import
+    -- Builtin.mlg` never evaluates that source (see `isPreloadedImport`
+    -- above), so the wrapper needs its own synthetic entry here, exactly
+    -- like `malgo_panic` itself, or it's unresolvable as `undefined:
+    -- panic` after a normal import (malgo#452). Not passthrough, unlike
+    -- `malgo_panic`: `panic`'s argument still carries its literal's
+    -- `String#` box at this point (the wrapper's own pattern match, which
+    -- would normally strip it, never runs), so it must go through the
+    -- default unboxing in `unwrapBuiltinArgs` to reach here as a plain
+    -- `VString`, matching what `malgo_panic` receives when called via a
+    -- real (non-preloaded) `panic` wrapper.
+    "panic" -> case args { (Cons (VString s) Nil) -> Left (appendString "panic: " s), (Cons x Nil) -> Left (appendString "panic: " (valueToText x)), _ -> Left "panic" },
     _ -> applyBuiltin9 gEnv name args
   }
 }
@@ -1287,6 +1300,7 @@ def foreignArity8 = {
   "exitSuccess" -> 1i32,
   "malgo_exit_success" -> 1i32,
   "malgo_panic" -> 1i32,
+  "panic" -> 1i32,
   name -> foreignArity9 name
 }
 
@@ -1385,13 +1399,13 @@ def preludeBuiltinNames =
   Cons "max" (Cons "min" (Cons "abs" (Cons "const" (Cons "getContents" (Cons "print" (Cons "malgo_print" (Cons "toStringDouble" (Cons "negInt32" (
   Cons "addDouble#" (Cons "subDouble#" (Cons "mulDouble#" (Cons "goto" (
   Cons "eqChar" (Cons "neChar" (Cons "geInt32" (Cons "neInt32" (Cons "neInt64" (Cons "geInt64" (Cons "negInt64" (Cons "modInt64" (
-  Cons "exitSuccess" (Cons "malgo_exit_success" (Cons "malgo_panic" (Cons "malgo_unsafe_cast" (
+  Cons "exitSuccess" (Cons "malgo_exit_success" (Cons "malgo_panic" (Cons "panic" (Cons "malgo_unsafe_cast" (
   Cons "getRawArgs" (Cons "readFile" (Cons "charToString" (Cons "hasEnv#" (Cons "getEnvRaw#" (Cons "modInt64#" (
   Cons "malgo_mod_int64_t" (Cons "malgo_neg_int64_t" (Cons "malgo_mod_int32_t" (Cons "malgo_neg_int32_t" (
   Cons "malgo_gt_int32_t" (Cons "malgo_ge_int32_t" (Cons "malgo_ne_int32_t" (
   Cons "malgo_eq_int64_t" (Cons "malgo_lt_int64_t" (Cons "malgo_le_int64_t" (
   Cons "malgo_gt_int64_t" (Cons "malgo_ge_int64_t" (Cons "malgo_ne_int64_t" Nil
-  )))))))))))))))))))))))))))))))))))))))))))
+  ))))))))))))))))))))))))))))))))))))))))))))
 def makeBaseEnv : Env
 def makeBaseEnv = addBaseConstructors (foldl addBuiltin EnvEmpty builtinNames)
 

--- a/scripts/selfhost-golden.sh
+++ b/scripts/selfhost-golden.sh
@@ -195,6 +195,64 @@ done
 
 printf 'PASS: %s\nFAIL: %s\nTIMEOUT: %s\n' "$pass" "$fail" "$timeout_count"
 
+# Self-hosted panic-import gate (regression test for malgo#452, not part of
+# the golden sweep above -- see below for why). `panic` is a Builtin.mlg
+# wrapper around the `malgo_panic` foreign primitive
+# (`def panic = { (String# message) -> malgo_panic message }`), but under
+# self-hosting `import Builtin.mlg` substitutes a synthetic roster
+# (`makeBaseEnv` in Eval.mlg) instead of actually evaluating that file's
+# source (see `isPreloadedImport`'s doc comment there) -- so a wrapper
+# defined there needs its own entry mirrored into that roster, or it comes
+# back `undefined: panic` after a normal import. `Panic`/`CondPanic` cover
+# a wildcard import (`module {..} = import ...`); `PanicNamedImport` covers
+# the named form (`module {panic} = import ...`), which resolves through a
+# different code path in Eval.mlg's import machinery
+# (`extendImportOnlyDirect`'s per-name `envLookup` vs `mergeEnvs`).
+#
+# Not part of the golden sweep above because `panic` *by design* never
+# returns normally (mirroring the Lean interpreters' `PanicGate` in
+# `lean/Test/Main.lean`, whose `evalHarnessUnsupported` excludes these same
+# three cases from ever getting a `.golden/Malgo.Sequent.Eval/*` entry --
+# which is also why the sweep above, which discovers its cases by listing
+# that directory, never runs them). Unlike the Lean/Zig/Scheme backends,
+# the self-hosted evaluator's `Main.mlg` always exits 0 and reports the
+# panic on stdout (`"Runtime error: " ++ msg`), so this checks stdout
+# content, not exit status.
+panic_fail=0
+panic_scenarios=(
+  $'Panic\001before panic\001panic: malgo#426 regression check'
+  $'CondPanic\001before cond\001panic: no branch'
+  $'PanicNamedImport\001before panic\001panic: malgo#452 named-import regression check'
+)
+for entry in "${panic_scenarios[@]}"; do
+  case_name=$(cut -d $'\001' -f1 <<< "$entry")
+  expected_stdout_line=$(cut -d $'\001' -f2 <<< "$entry")
+  expected_message=$(cut -d $'\001' -f3 <<< "$entry")
+  src="test/testcases/malgo/$case_name.mlg"
+  expected=$(printf '%s\nRuntime error: %s\n' "$expected_stdout_line" "$expected_message")
+  out=$(mktemp)
+  err=$(mktemp)
+  if printf 'Hello\n' | timeout "$CASE_TIMEOUT" "$NATIVE_MAIN" "$src" >"$out" 2>"$err"; then
+    actual=$(< "$out")
+    if [[ -s "$err" ]]; then
+      log "panic gate FAIL: $case_name wrote to stderr unexpectedly ($(printf '%q' "$(< "$err")"))"
+      panic_fail=1
+    elif [[ "$actual" == "$expected" ]]; then
+      log "panic gate pass: $case_name"
+    else
+      log "panic gate FAIL: $case_name (want: $(printf '%q' "$expected"), got: $(printf '%q' "$actual"))"
+      panic_fail=1
+    fi
+  else
+    log "panic gate FAIL: $case_name exited nonzero unexpectedly"
+    panic_fail=1
+  fi
+  rm -f "$out" "$err"
+done
+if [[ $panic_fail -eq 0 ]]; then
+  log "panic gate: ${#panic_scenarios[@]}/${#panic_scenarios[@]} passed"
+fi
+
 # One extra serial run of the evaluator already built above, instrumented, to gate
 # the selfhost-l1 counters (#399). Costs ~1s: this is the tier #385's own baseline
 # reading came from, and the sweep above is parallel so its wall clock is
@@ -240,4 +298,4 @@ else
   [[ -f "$BASELINE" ]] || log "perf gate: no $BASELINE -- skipping"
 fi
 
-[[ $fail -eq 0 && $perf_fail -eq 0 ]]
+[[ $fail -eq 0 && $perf_fail -eq 0 && $panic_fail -eq 0 ]]

--- a/test/testcases/malgo/PanicNamedImport.mlg
+++ b/test/testcases/malgo/PanicNamedImport.mlg
@@ -1,0 +1,23 @@
+#c-style-apply
+module {panic, String#} = import "../../../runtime/malgo/Builtin.mlg"
+module {..} = import "../../../runtime/malgo/Prelude.mlg"
+
+-- Regression test for malgo#452: the self-hosted evaluator's `import
+-- Builtin.mlg` substitutes a synthetic roster (`makeBaseEnv`) instead of
+-- actually evaluating Builtin.mlg's source, so any wrapper defined there in
+-- terms of a foreign primitive (`panic = { (String# message) -> malgo_panic
+-- message }`) has to be mirrored into that roster by hand or it comes back
+-- `undefined: panic`. Panic.mlg already covers a *wildcard* import
+-- (`module {..} = import ...`); this covers the *named* form (`module
+-- {panic} = import ...`), which resolves via a different code path
+-- (`extendImportOnlyDirect`'s per-name `envLookup`, vs `mergeEnvs` for
+-- wildcard) that needs the same fix. `String#` is imported alongside
+-- `panic` only so the Lean renderer's literal-boxing desugar
+-- (`Malgo.Rename.Pass.lookupBox`) has it in scope -- it isn't otherwise
+-- used by this test. Not a `.golden/Malgo.Sequent.Eval` golden case -- see
+-- `evalHarnessUnsupported` and `Malgo.Test.PanicGate.run` in
+-- lean/Test/Main.lean for why.
+def main = { (_) ->
+  let _ = putStrLn("before panic");
+  panic "malgo#452 named-import regression check"
+}


### PR DESCRIPTION
## Summary

The self-hosted evaluator's `import Builtin.mlg` doesn't actually parse/evaluate `Builtin.mlg`'s source — `evalImport`'s `isPreloadedImport` path in `runtime/malgo/compiler/Eval.mlg` substitutes a synthetic roster (`makeBaseEnv`) instead. `panic` is a thin Malgo-level wrapper around the `malgo_panic` foreign primitive (`def panic = { (String# message) -> malgo_panic message }`), not a foreign import itself, so it was never mirrored into that roster — hence `undefined: panic` after any normal import, while an inline clone of the identical definition worked (a non-imported top-level `def panic` evaluates normally).

**Fix:** registered `"panic"` alongside `"malgo_panic"` in `preludeBuiltinNames`, `foreignArity8`, and `applyBuiltin8` (same dispatch site), but deliberately left it out of `isPassthroughBuiltin` — its literal argument still carries the `String#` box at the call site (the wrapper's own pattern match, which would normally strip it, never runs), so it needs the default unboxing in `unwrapBuiltinArgs` to reach dispatch as a plain `VString`.

## Test plan

- [x] Named import (`module {panic} = ...`) terminates with the panic message, not `undefined: panic`
- [x] Wildcard import (`module {..} = ...`) terminates with the panic message (pre-existing `Panic.mlg`, now actually exercised via a new dedicated gate)
- [x] `bash scripts/selfhost-golden.sh` (80/80 + new panic-import gate 3/3)
- [x] `mise run test` (full suite, including extended `panic-gate` 6/6)
- [x] Level 2 sanity (`BUILD_ONLY=1`/`EVAL_BIN=... L2_CASES=Fib bash scripts/selfhost-level2.sh`)
- [x] Confirmed no other `.mlg` under `runtime/`/`test/`/`examples/` defines its own `panic` that could now be silently shadowed by the new `makeBaseEnv` entry

New `test/testcases/malgo/PanicNamedImport.mlg` regression case, mirroring `Panic.mlg`'s pattern, added to `evalHarnessUnsupported` and `PanicGate.scenarios` in `lean/Test/Main.lean` (confirms both Lean interpreters handle named import fine, unlike self-hosted pre-fix).

## Out of scope

Lean interpreter `malgo_panic` semantics (#426/#447, already fixed); rebox semantics for builtin results (#451, separate PR).

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)