### PR TITLE
ci(lean): replace leanprover/lean-action with an in-repo elan+cache step

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -1,0 +1,73 @@
+name: "Set up Lean and build"
+description: >
+  Installs elan (with its own retry loop), restores/saves the .lake build
+  cache, and optionally runs `lake build` / `lake test`. A minimal in-repo
+  replacement for leanprover/lean-action's malgo-relevant subset -- this
+  project uses none of that action's Mathlib cache, lint, mk_all-check, or
+  external-checker features, and its own elan-install script does an
+  unretried `curl | sh` with no way to configure retry via inputs (confirmed
+  by reading leanprover/lean-action's scripts/install_elan.sh directly), so
+  a transient network blip there fails the whole step outright.
+inputs:
+  lake-package-directory:
+    description: "Directory containing the Lake package"
+    required: false
+    default: "lean"
+  build:
+    description: "Run `lake build`"
+    required: false
+    default: "true"
+  test:
+    description: "Run `lake test`"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install elan
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+      run: |
+        set -euo pipefail
+        attempt=1
+        max_attempts=5
+        until curl --retry 3 --retry-connrefused -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+                | sh -s -- -y --default-toolchain none; do
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "::error::elan install failed after $attempt attempts"
+            exit 1
+          fi
+          delay=$((attempt * 10))
+          echo "elan install attempt $attempt failed, retrying in ${delay}s..."
+          sleep "$delay"
+          attempt=$((attempt + 1))
+        done
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+    # Same cache key shape leanprover/lean-action used, for continuity.
+    - name: Restore .lake build cache
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ${{ inputs.lake-package-directory }}/.lake
+        key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/lean-toolchain', inputs.lake-package-directory)) }}-${{ hashFiles(format('{0}/lake-manifest.json', inputs.lake-package-directory)) }}-${{ github.sha }}
+        restore-keys: |
+          lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/lean-toolchain', inputs.lake-package-directory)) }}-${{ hashFiles(format('{0}/lake-manifest.json', inputs.lake-package-directory)) }}
+
+    - name: lake build
+      if: ${{ inputs.build == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+      run: lake build
+
+    - name: Save .lake build cache
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ${{ inputs.lake-package-directory }}/.lake
+        key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}/lean-toolchain', inputs.lake-package-directory)) }}-${{ hashFiles(format('{0}/lake-manifest.json', inputs.lake-package-directory)) }}-${{ github.sha }}
+
+    - name: lake test
+      if: ${{ inputs.test == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+      run: lake test

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -40,9 +40,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
+      - uses: ./.github/actions/setup-lean
         with:
-          lake-package-directory: lean
           test: true
 
   # What lean-parity used to be: it diffed the two implementations' output
@@ -56,11 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
-        with:
-          lake-package-directory: lean
-          build: true
-          test: false
+      - uses: ./.github/actions/setup-lean
 
       - name: CLI gate (eval / bigstep / error)
         run: bash scripts/cli-gate.sh
@@ -79,11 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
-        with:
-          lake-package-directory: lean
-          build: true
-          test: false
+      - uses: ./.github/actions/setup-lean
 
       # Same include_str staleness as lean-zig-golden: without this the job
       # compiles Main.mlg against a cached, stale embedded runtime. That is
@@ -131,11 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
-        with:
-          lake-package-directory: lean
-          build: true
-          test: false
+      - uses: ./.github/actions/setup-lean
 
       # Not optional, for the same reason lean-selfhost and lean-zig-golden do
       # it: Lake does not reliably track the include_str that embeds
@@ -208,18 +195,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
-        with:
-          lake-package-directory: lean
-          build: true
-          test: false
+      - uses: ./.github/actions/setup-lean
 
       # Lake's tracking of `include_str` is not reliable: measured on one edit,
       # changing runtime.zig rebuilt Runtime.olean but reverting that change did
       # not, and `lake build` reported success while the binary kept embedding
-      # the old runtime text. Combined with lean-action's .lake cache, a PR that
+      # the old runtime text. Combined with setup-lean's .lake cache, a PR that
       # touches only runtime.zig would otherwise compile all 73 cases against
-      # the PREVIOUS runtime and report green. Runs after lean-action because
+      # the PREVIOUS runtime and report green. Runs after setup-lean because
       # that is what restores the cache; rebuilding one module is negligible
       # against this job's Zig toolchain time. Unconditional on purpose — a
       # "did runtime.zig change?" guard reintroduces the bug it fixes.
@@ -261,11 +244,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
-        with:
-          lake-package-directory: lean
-          build: true
-          test: false
+      - uses: ./.github/actions/setup-lean
 
       # Not `apt-get install chezscheme`: Ubuntu's apt package tracks its own
       # release cadence, not Chez's upstream version, so it silently drifts


### PR DESCRIPTION
## Summary

`leanprover/lean-action`'s own elan-install script does an unretried `curl | sh` with no skip-if-present check and no way to configure retry via the action's inputs (confirmed by reading its `scripts/install_elan.sh` directly). A transient network blip fails the whole step outright, and this recurred across multiple PRs in one afternoon — most recently PR #459's `cli-gate` job: `curl: (35) Recv failure: Connection reset by peer`.

Considered wrapping the flaky third-party action with a generic retry-wrapper action (e.g. `Wandalen/wretry.action`), but decided against adding a second external dependency just to paper over the first — especially since `lean-action`'s only actually-used features here are elan install, the `.lake` build cache, and `lake build`/`lake test`. This project uses none of its other features (Mathlib cache, lint, `mk_all-check`, reservoir/leanchecker/nanoda checks).

Instead, replaced it outright with a small local composite action (`.github/actions/setup-lean`, following the existing `.github/actions/create-update-pr` precedent) covering exactly that subset:
- elan install with its own retry loop (5 attempts, linear backoff)
- `.lake` build cache, same key shape as `lean-action`'s own (`lake-${os}-${arch}-${lean-toolchain hash}-${lake-manifest hash}-${sha}`, with a fallback restore key), for continuity — no cache-invalidation churn from this change
- `lake build` / `lake test`, gated by simple boolean inputs

All 6 jobs that used `leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9` now use `./.github/actions/setup-lean` instead.

## Test plan

- [x] `.github/workflows/lean.yml` and `.github/actions/setup-lean/action.yml` parse as valid YAML
- [x] Diff reviewed: every job's `build`/`test` selection preserved exactly (e.g. `lean-build` still runs both build+test, `cli-gate`/`lean-selfhost`/`l2-build`/`lean-zig-golden`/`lean-scheme-golden` still build-only)
- [ ] CI itself is the real test here — this PR's own checks exercise the new composite action on every job that uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)