### PR TITLE
perf(zig): tighten MAX_ARGS from 4 to 2 (part of #407)

### DIFF
--- a/docs/zig-backend.md
+++ b/docs/zig-backend.md
@@ -110,8 +110,12 @@ step, and any program of more than ~150k steps died with SIGSEGV — `fib 16` wa
 is not a substitute: Zig requires the callee's signature to match the caller's, which
 rules out helpers like `applyCovalue(Value, Value)`, and a genuine tail call would
 release the frame holding the `&[_]rt.Value{...}` argument slice before the callee read
-it. An `Action` carries its arguments in a fixed inline array (`MAX_ARGS`, currently 4;
-the front end tops out at 2) precisely so no argument outlives its storage.
+it. An `Action` carries its arguments in a fixed inline array (`MAX_ARGS`, currently 2 —
+tightened from 4 by #407 after confirming empirically that no call site in the golden
+corpus, either self-hosted compiler level, `examples/`, or `bench/fixtures/` ever
+carries more than 2) precisely so no argument outlives its storage. Shrinking
+`MAX_ARGS` shrinks every `Action` by two words, which `rt.run` copies by value on
+every one of `selfhost-l2`'s 1.4e10+ dispatches.
 
 **An Action is a move, not a borrow.** It carries exactly the references a direct call
 would have transferred — one of the callee into `self`, one of each operand into

--- a/lean/Malgo/Backend/Zig/Emit.lean
+++ b/lean/Malgo/Backend/Zig/Emit.lean
@@ -105,9 +105,16 @@ def valueSlice (pv : Name → String) (vs : List Name) : String :=
   "&[_]rt.Value{" ++ ", ".intercalate (vs.map pv) ++ "}"
 
 /-- Mirrors `MAX_ARGS` in `runtime/zig/runtime.zig`, the fixed argument capacity
-of an `rt.Action`. The runtime's own `rcInvariant` in `mkAction` is the
-authoritative backstop if the two ever drift. -/
-def maxCallArgs : Nat := 4
+of an `rt.Action`. Tightened from 4 to 2 by #407 after confirming (by dumping
+generated Zig for the full golden corpus, both self-hosted compiler levels,
+`examples/`, and `bench/fixtures/`) that no call site ever carries more than 2
+arguments -- shrinking `Action` by two words reduces the per-dispatch copy on
+`selfhost-l2`'s 1.4e10+ dispatches, each of which copies an `Action` by value
+(a mechanism argument; the workload's actual wall clock is too noisy at this
+harness's resolution to attribute a specific delta to this change alone). The
+runtime's own `rcInvariant` in `mkAction` is the authoritative backstop if the
+two ever drift. -/
+def maxCallArgs : Nat := 2
 
 /-- `valueSlice` for a call site, rejecting an arity the runtime's Action cannot
 carry. The front end tops out at 2 (`callClosure f [arg, kont]`), so exceeding

--- a/runtime/zig/runtime.zig
+++ b/runtime/zig/runtime.zig
@@ -44,14 +44,24 @@ pub const Tag = union(enum) { tuple: void, named: []const u8 };
 /// recursive process gets an explicit loop rather than the native stack.
 pub const CodeFn = *const fn (self: Value, args: []const Value) Action;
 
-/// Maximum number of arguments at any call site. The front end cannot
+/// Maximum number of arguments at any call site. Was 4 (a defensive margin
+/// with no known call site needing it); tightened to 2 by #407 once that
+/// margin was actually checked rather than assumed. The front end cannot
 /// currently produce more than 2 (`ToFun` builds only single-parameter
 /// lambdas and singleton applies; `ToCore` appends exactly one consumer,
-/// giving `TCallClosure f [arg, kont]`), but nothing in the IR enforces
-/// that, so this is generous. `Malgo.Backend.Zig.Emit` mirrors the number
-/// to reject an over-arity call site with a readable message; `mkAction`'s
-/// `rcInvariant` below is the authoritative backstop if the two drift.
-pub const MAX_ARGS: usize = 4;
+/// giving `TCallClosure f [arg, kont]`) -- confirmed empirically, not just
+/// by reading the front end: every `rt.callClosure`/`rt.staticCall` site in
+/// the generated Zig for the full golden corpus, both self-hosted compiler
+/// levels, `examples/`, and `bench/fixtures/` (220k+ call sites) carries at
+/// most 2 arguments. Nothing in the IR *enforces* that bound, so
+/// `Malgo.Backend.Zig.Emit`'s `maxCallArgs` mirrors this number to reject an
+/// over-arity call site with a readable compile-time message rather than
+/// truncating args silently; `mkAction`'s `rcInvariant` below is the
+/// authoritative runtime backstop if the two ever drift. Lowering it shrinks
+/// every `Action` (see below) by two words, which matters on
+/// `selfhost-l2`'s 1.4e10+ dispatches (#407): each `run` iteration copies an
+/// `Action` by value.
+pub const MAX_ARGS: usize = 2;
 
 /// What a generated function returns instead of calling: either the next
 /// call to perform (`code != null`) or the finished value (`code == null`,
@@ -66,6 +76,16 @@ pub const Action = struct {
     argv: [MAX_ARGS]Value,
     argc: usize,
 };
+
+// #407: Action must actually be 5 words (40 bytes on a 64-bit target), not
+// 7 -- the whole point of shrinking MAX_ARGS. A future MAX_ARGS bump that
+// forgets this comptime check would silently grow every `run` dispatch's
+// per-call copy back to 7 words with no compiler error to catch it.
+comptime {
+    if (@sizeOf(usize) == 8) {
+        std.debug.assert(@sizeOf(Action) == 5 * @sizeOf(usize));
+    }
+}
 
 pub const Struct = struct { tag: Tag, fields: []const Value };
 pub const Closure = struct { code: CodeFn, captures: []const Value };


### PR DESCRIPTION
## Summary

Part of #407 -- a subset of the four levers in the Agent Brief. This lands lever 4 (call-dispatch bookkeeping) only, with lever 2 investigated and confirmed unnecessary, and levers 1 and 3 deferred with concrete reasoning below.

### Landed: lever 4 -- shrink `rt.Action`

`MAX_ARGS` sized `Action.argv` with a defensive margin the doc comment itself called out as unverified ("nothing in the IR enforces that, so this is generous"). Confirmed empirically rather than re-reading the front end: dumped generated Zig for the full golden corpus, both self-hosted compiler levels, `examples/`, and `bench/fixtures/` (220k+ `rt.callClosure`/`rt.staticCall` call sites) and none carries more than 2 arguments. Tightened `MAX_ARGS` from 4 to 2, shrinking `Action` from 7 words to 5 (comptime-asserted in `runtime.zig`, verified red-before/green-after: reverting `MAX_ARGS` to 4 against the new assertion fails to compile with an `unreachable` at comptime, confirming the check is load-bearing). `rt.run`'s trampoline copies an `Action` by value on every dispatch -- 1.4e10+ of them on `selfhost-l2` alone.

### Investigated, confirmed unnecessary: lever 2 -- tag/field-name interning

The issue's own acceptance criteria require checking this before implementing it. Confirmed on Zig 0.16.0 across Debug/ReleaseSafe/ReleaseFast: `std.mem.eql(u8, ...)` for byte slices already takes `eqlBytes`'s `a.ptr == b.ptr` fast path before any byte comparison, and identical string literals within one compiled Zig file (which is what every generated Malgo program is -- one `.zig` file) get deduplicated to the same address by the Zig compiler itself, not just by a linker ICF pass. So `runtime.zig`'s `stringEq`, and therefore `tagEq`/`projectField`/`forceField`, already get the pointer-equality fast path on every *matching* tag/field-name comparison, at zero implementation cost (`applyDestructor` is unreachable from generated code today -- codata lowers to a panic stub in `Emit.lean`, confirmed by grepping `Emit.lean`/`Ir.lean` for any codata-constructing case; the runtime's own unit test for it says as much). A *mismatching* comparison still falls through to a byte scan, and the branch/field linear scan itself is unchanged -- but that's exactly the cost the issue's own precondition asked about (the string comparison, not the scan structure), and branch/field counts in this corpus are small enough that the issue's own text already treats this as covered. No interning work needed.

### Deferred: lever 1 -- container allocation (largest lever, not attempted)

The issue itself calls this "invasive." Both proposed shapes have a real correctness hazard:
- The "one over-allocated block" shape would move the `Object`'s address on an arity-mismatched `dropReuse`/`mkStructReuse` rebuild, breaking the token-identity contract those functions rely on.
- The safer "inline small array" shape (`Object` grows N inline slots) still touches every construction/free/reuse site across all 4 Value kinds -- and `dropReuse` converts both `.strukt` and `.closure` into the *same* reuse-token protocol (see `runtime.zig`'s `dropReuse`), so the two highest-volume kinds cannot be inlined independently. It's the whole hazard surface (empty-slice pointer ambiguity, inline<->heap transitions inside `mkStructReuse`, four new conditional-free cases in `drainFreeWorklist`) or none of it.

On top of that, `g_total_allocs` counts `Object`s, not raw `malloc` calls, so halving backing-array allocations would be invisible to every counter this issue gates on -- and an `Object` size increase crossing an `smp_allocator` size-class boundary could offset the win invisibly too. Verifying it properly needs a new instrumented counter plus several build+golden-sweep+leak-check cycles (each several minutes), which is disproportionate risk/effort for one session on top of a verified lever 4. Recommend as a dedicated follow-up issue.

### Deferred: lever 3 -- object pool / `-fsingle-threaded`

The issue's own text predicts a modest win, since `std.heap.SmpAllocator` already runs a per-thread free list -- a custom pool would only save the thread-id lookup and branching. A pool that recycles `Object`s in place would also defeat `DebugAllocator`'s UAF/double-free detection in Debug/ReleaseSafe, which the golden sweep and leak-check gate depend on as their actual safety net. Not worth that tradeoff for a predicted-modest gain.

## Acceptance criteria

- [x] Lever 2 precondition checked before any interning work -- confirmed already covered, documented above.
- [x] `mise run perf-baseline -- --tier=all`: `total_allocs`/`dispatches` are **byte-identical** with and without this change on the same commit (measured both ways) for every tier -- `fib-shallow`, `fib-deep`, `selfhost-l1` (7913768/8915692), `selfhost-l2` (12956047112/14767867190). `force_depth_max` unchanged (0/0/1/1). **However**: `selfhost-l2`'s row already fails against the *committed* `bench/perf-baseline.json` on a clean `origin/master` checkout, before this PR touches anything -- verified by stashing this diff and re-measuring. That drift is real (total_allocs +48982103, dispatches +55743343 vs the committed baseline) but predates this PR and is not one of #407's four levers, so I have **not** run `--update` -- doing so would silently absorb someone else's regression under a `MAX_ARGS` commit message. Re-baselining `bench/perf-baseline.json` is a separate concern; happy to file it as a follow-up issue if useful.
- [ ] `mise run perf-baseline -- --tier=l2-ratio`: **not verifiable at this harness's resolution**, not "met." Measured 5.13x vs the committed 5.21x baseline, but this is a single noisy sample taken while other verification jobs were running concurrently on the same machine -- the harness's own 15% band exists because one sample can't resolve a change this size, and I'm not claiming this as evidence of improvement or regression either way. The lever is justified on mechanism (5 words copied per dispatch instead of 7, across 1.4e10+ dispatches), not a measured wall-clock delta. It did not regress past the 15% band, which is the hard gate the issue actually asks for.
- [x] No leak-check regression: `zig-golden.sh` 81/81, zero leaks. `zig-deep-recursion.sh` counters unchanged, no leak. `selfhost-golden.sh` 80/80.
- [x] `mise run test`: green.

## Testing

- `zig test -lc runtime/zig/runtime.zig` -- 23/23, including the new comptime size assertion; confirmed it actually catches a regression by reverting `MAX_ARGS` to 4 against the new assert and observing a comptime `unreachable` failure.
- `bash scripts/zig-golden.sh` -- 81/81, zero leaks.
- `bash scripts/zig-deep-recursion.sh` -- counters within baseline (`total_allocs=15659730 dispatches=18815851`, identical to committed baseline), no leak.
- `bash scripts/selfhost-golden.sh` -- 80/80.
- `mise run test` -- green (62.58s).
- `mise run perf-baseline -- --tier=all` -- run twice on the same commit (with and without this diff) to isolate the change's effect from pre-existing workload drift; counters identical both times except for the pre-existing `selfhost-l2` drift described above.

Co-Authored-By: Yuya Kono <takohati0821@gmail.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
