### PR TITLE
feat(web): document and automate Claude Code on the web setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,50 +5,90 @@
 # Heavy, environment-wide toolchain provisioning (elan, the pinned Lean
 # toolchain, mise, zig, chezscheme) belongs in the cloud environment's
 # *Setup script* instead, because that step is cached across sessions for
-# ~7 days -- see docs/agents/web-environment.md. This hook only does the
+# ~7 days -- see docs/claude-code-web.md. This hook only does the
 # repo-aware, per-session work: exporting PATH for tools the setup script
-# installed, trusting mise.toml, and compiling this checkout (a fresh clone
-# has no .lake build cache, so this is unavoidable each session).
+# installed, reconciling mise's pinned tools against this checkout, and
+# compiling it (a fresh clone has no .lake build cache, so that's
+# unavoidable each session).
 set -uo pipefail
 
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Tools installed by the environment's Setup script live under these
-# locations regardless of which session VM you land on (see
-# docs/agents/web-environment.md for the setup script that puts them there).
-for line in \
-  'export PATH="$HOME/.elan/bin:$PATH"' \
-  'export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"'
-do
-  echo "$line" >> "$CLAUDE_ENV_FILE"
-  eval "$line"
-done
-
-echo "== malgo web session setup =="
-for tool in elan lean lake mise zig; do
-  if command -v "$tool" >/dev/null 2>&1; then
-    echo "  $tool: $(command -v "$tool")"
-  else
-    echo "  $tool: NOT FOUND"
-  fi
-done
-
-if ! command -v elan >/dev/null 2>&1; then
-  echo "elan is missing -- the environment's Setup script did not run or failed." >&2
-  echo "See docs/agents/web-environment.md to configure it." >&2
+# $CLAUDE_ENV_FILE/$CLAUDE_PROJECT_DIR are always set alongside
+# $CLAUDE_CODE_REMOTE=true in a normal cloud session, but default them
+# explicitly (matching the CLAUDE_CODE_REMOTE check above) so a harness
+# variant that doesn't set them yet gets this diagnostic under `set -u`
+# instead of an "unbound variable" crash.
+env_file="${CLAUDE_ENV_FILE:-}"
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$env_file" ] || [ -z "$project_dir" ]; then
+  echo "session-start hook: CLAUDE_ENV_FILE or CLAUDE_PROJECT_DIR is not set; skipping." >&2
   exit 0
 fi
 
-if command -v mise >/dev/null 2>&1; then
-  mise trust --yes "$CLAUDE_PROJECT_DIR/mise.toml" 2>&1 || true
+# Tools installed by the environment's Setup script live under these
+# locations regardless of which session VM you land on (see
+# docs/claude-code-web.md for the setup script that puts them there).
+# Written once with a dedupe check: this hook can fire more than once per
+# session (resume/compact), and $CLAUDE_ENV_FILE persists across firings.
+path_line='export PATH="$HOME/.elan/bin:$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"'
+grep -qF "$path_line" "$env_file" 2>/dev/null || echo "$path_line" >> "$env_file"
+eval "$path_line"
+
+echo "== malgo web session setup =="
+elan_path="$(command -v elan || true)"
+lean_path="$(command -v lean || true)"
+lake_path="$(command -v lake || true)"
+mise_path="$(command -v mise || true)"
+zig_path="$(command -v zig || true)"
+for pair in "elan=$elan_path" "lean=$lean_path" "lake=$lake_path" "mise=$mise_path" "zig=$zig_path"; do
+  name="${pair%%=*}"
+  path="${pair#*=}"
+  if [ -n "$path" ]; then
+    echo "  $name: $path"
+  else
+    echo "  $name: NOT FOUND"
+  fi
+done
+
+if [ -z "$elan_path" ]; then
+  echo "elan is missing -- the environment's Setup script did not run or failed." >&2
+  echo "See docs/claude-code-web.md to configure it." >&2
+  exit 0
+fi
+
+if [ -n "$mise_path" ]; then
+  mise_log="$(mise trust --yes "$project_dir/mise.toml" 2>&1)" || {
+    echo "mise trust failed:" >&2
+    echo "$mise_log" >&2
+  }
+  # Repo-aware reconciliation: (re-)installs mise.toml's pinned zig/chezscheme
+  # from the actual checkout, a no-op if the Setup script's own hardcoded
+  # pre-fetch (docs/claude-code-web.md) already matches -- and self-heals if
+  # it drifted out of sync, at the cost of a network fetch instead of the
+  # Setup script's cached one.
+  mise_log="$(cd "$project_dir" && mise install 2>&1)" || {
+    echo "mise install reported problems:" >&2
+    echo "$mise_log" >&2
+  }
 fi
 
 echo "Building the compiler (lake build)..."
-if ! (cd "$CLAUDE_PROJECT_DIR/lean" && lake build); then
-  echo "lake build failed -- likely missing network access to release.lean-lang.org" >&2
-  echo "for the pinned Lean toolchain. See docs/agents/web-environment.md." >&2
+build_output="$(cd "$project_dir/lean" && lake build 2>&1)"
+build_status=$?
+echo "$build_output"
+if [ "$build_status" -ne 0 ]; then
+  echo "lake build failed (exit $build_status)." >&2
+  if echo "$build_output" | grep -qE 'CONNECT tunnel failed|error during download'; then
+    echo "That looks like a blocked network fetch, not a compile error --" >&2
+    echo "see docs/claude-code-web.md for the domains this repo's toolchain needs" >&2
+    echo "(release.lean-lang.org, elan.lean-lang.org, ziglang.org, mise.jdx.dev)." >&2
+  else
+    echo "That doesn't match the known network-access failure signature --" >&2
+    echo "check the build output above for a real compile error or regression." >&2
+  fi
 fi
 
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SessionStart hook: makes `lake build`/`lake test`/`mise run ...` work in a
+# fresh Claude Code on the web session without manual setup.
+#
+# Heavy, environment-wide toolchain provisioning (elan, the pinned Lean
+# toolchain, mise, zig, chezscheme) belongs in the cloud environment's
+# *Setup script* instead, because that step is cached across sessions for
+# ~7 days -- see docs/agents/web-environment.md. This hook only does the
+# repo-aware, per-session work: exporting PATH for tools the setup script
+# installed, trusting mise.toml, and compiling this checkout (a fresh clone
+# has no .lake build cache, so this is unavoidable each session).
+set -uo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Tools installed by the environment's Setup script live under these
+# locations regardless of which session VM you land on (see
+# docs/agents/web-environment.md for the setup script that puts them there).
+for line in \
+  'export PATH="$HOME/.elan/bin:$PATH"' \
+  'export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"'
+do
+  echo "$line" >> "$CLAUDE_ENV_FILE"
+  eval "$line"
+done
+
+echo "== malgo web session setup =="
+for tool in elan lean lake mise zig; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    echo "  $tool: $(command -v "$tool")"
+  else
+    echo "  $tool: NOT FOUND"
+  fi
+done
+
+if ! command -v elan >/dev/null 2>&1; then
+  echo "elan is missing -- the environment's Setup script did not run or failed." >&2
+  echo "See docs/agents/web-environment.md to configure it." >&2
+  exit 0
+fi
+
+if command -v mise >/dev/null 2>&1; then
+  mise trust --yes "$CLAUDE_PROJECT_DIR/mise.toml" 2>&1 || true
+fi
+
+echo "Building the compiler (lake build)..."
+if ! (cd "$CLAUDE_PROJECT_DIR/lean" && lake build); then
+  echo "lake build failed -- likely missing network access to release.lean-lang.org" >&2
+  echo "for the pinned Lean toolchain. See docs/agents/web-environment.md." >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,17 @@
       "Bash(mise run test:*)"
     ]
   },
-  "enabledPlugins": {}
+  "enabledPlugins": {},
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/docs/claude-code-web.md
+++ b/docs/claude-code-web.md
@@ -1,0 +1,125 @@
+# Claude Code on the web
+
+This repo's toolchain (elan/Lean, mise, Zig, Chez Scheme) pulls binaries
+from several vendor origins that Claude Code on the web's **Trusted**
+network access level does not allowlist by default. Without configuring
+the cloud environment as described here, `lake build` fails partway
+through with a network error rather than a missing-tool error, which is
+easy to misdiagnose. Configuration lives in the environment dialog at
+[claude.ai/code](https://claude.ai/code) (the cloud icon above the message
+box, or **Cloud environments** in org admin settings for a shared
+environment) — see [Configure cloud environments](https://code.claude.com/docs/en/cloud-environments).
+
+## Network access
+
+Elan's installer script is served from `raw.githubusercontent.com`
+(Trusted by default), but the pinned Lean toolchain it downloads
+afterwards comes from `release.lean-lang.org`, which is not. Verified by
+running the installer under a Trusted-only policy: it succeeds, and the
+first `lake build` then fails with `error during download ... CONNECT
+tunnel failed, response 403` against that host specifically.
+
+Set **Network access** to **Custom**, keep **Also include default list of
+common package managers** checked, and add:
+
+```
+release.lean-lang.org
+elan.lean-lang.org
+ziglang.org
+mise.jdx.dev
+```
+
+`release.lean-lang.org`/`elan.lean-lang.org` are required for any
+`lake build`. `ziglang.org` is required for the Zig backend (`malgo
+compile`, `zig-golden`, self-hosting) but not for the plain Lean test
+suite (`lake test` only shells out to `zig` from the `malgo compile`
+code path — see `lean/Malgo/Backend/Zig/Toolchain.lean` — not from the
+golden/gate tests `lake test` itself runs). `mise.jdx.dev` is required to
+install `mise` itself, which this repo's `mise.toml` uses to pin `zig`
+and `chezscheme` versions.
+
+Chez Scheme (`mise run scheme-golden`) is optional and not covered above:
+`mise`'s `chezscheme` plugin builds it from source from a host we haven't
+pinned down here. If you need the Scheme backend gates, use **Full**
+network access instead of Custom for this environment.
+
+## Environment variables
+
+Optional, for parity with `.devcontainer/post-create.sh`'s locale setup:
+
+```
+LANG=C.UTF-8
+LC_ALL=C.UTF-8
+LC_CTYPE=C.UTF-8
+```
+
+## Setup script
+
+Paste into the environment dialog's **Setup script** field. This is
+VM-level provisioning only (no dependency on the repo being cloned yet —
+see [Setup scripts vs. SessionStart hooks](https://code.claude.com/docs/en/cloud-environments#setup-scripts-vs-sessionstart-hooks)),
+so it's cached across sessions in this environment for about a week
+instead of re-running every time. It installs elan, mise, and pre-fetches
+the exact toolchain versions this repo pins — `lean/lean-toolchain` and
+`mise.toml`'s `zig`/`chezscheme` — so update the hardcoded versions below
+if those files change.
+
+```bash
+#!/bin/bash
+set -uo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# Headers Chez Scheme's from-source build needs (see mise.toml's chezscheme
+# comment); harmless no-op if network access doesn't reach its build source.
+# apt-get update and install are split so one broken/unreachable repo in
+# update doesn't skip the install via a short-circuited &&.
+apt-get update -qq >/dev/null 2>&1 || true
+apt-get install -y -qq --no-install-recommends \
+  build-essential libx11-dev libncurses-dev >/dev/null 2>&1 || true
+
+# elan (Lean 4 toolchain manager) -- installer is GitHub-hosted, Trusted by
+# default; the toolchain fetch that follows needs release.lean-lang.org
+# (see "Network access" above).
+if ! command -v elan >/dev/null 2>&1; then
+  curl --retry 3 --retry-connrefused -fsSf \
+    https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y --default-toolchain none || true
+fi
+export PATH="$HOME/.elan/bin:$PATH"
+# Keep in sync with lean/lean-toolchain.
+elan toolchain install leanprover/lean4:v4.32.0 || true
+
+# mise (pins zig/chezscheme for this repo's tasks; see mise.toml).
+if ! command -v mise >/dev/null 2>&1; then
+  curl --retry 3 -fsSL https://mise.jdx.dev/install.sh | sh || true
+fi
+export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"
+# Keep in sync with mise.toml's [tools] versions.
+mise use -g zig@0.16.0 || true
+mise use -g chezscheme@10.4.1 || true
+
+echo 'export PATH="$HOME/.elan/bin:$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"' \
+  > /etc/profile.d/malgo-toolchain.sh
+```
+
+## SessionStart hook
+
+`.claude/settings.json` registers `.claude/hooks/session-start.sh`, which
+runs on every session (cloud and local, a no-op locally since it checks
+`CLAUDE_CODE_REMOTE`). Unlike the setup script above, a fresh clone has no
+`.lake` build cache, so it re-runs `lake build` every session — this is
+the one setup step per-session latency can't avoid. It only exports `PATH`
+for what the setup script installed and runs `mise trust` / `lake build`;
+it does not install toolchains itself; if it reports `elan: NOT FOUND` or
+`lake build failed`, the setup script above hasn't run or the network
+access above isn't configured yet, and the transcript will point at
+whichever host is missing.
+
+Running the hook (synchronous) adds the fresh `lake build`'s time to every
+session start, in exchange for `mise run test`/`lake test`/lint working
+immediately once the session opens. If that startup latency isn't
+acceptable, change the hook's `SessionStart` registration to async
+(`echo '{"async": true, "asyncTimeout": 300000}'` as the hook's first line
+of output) so Claude Code launches immediately and the build finishes in
+the background — at the cost of Claude possibly running `lake build`/`lake
+test` itself before that background build finishes.

--- a/docs/claude-code-web.md
+++ b/docs/claude-code-web.md
@@ -62,7 +62,12 @@ so it's cached across sessions in this environment for about a week
 instead of re-running every time. It installs elan, mise, and pre-fetches
 the exact toolchain versions this repo pins — `lean/lean-toolchain` and
 `mise.toml`'s `zig`/`chezscheme` — so update the hardcoded versions below
-if those files change.
+if those files change. If you forget: it isn't a correctness bug, only a
+speed one. The SessionStart hook below reconciles against the actual
+checkout every session (`lake build` auto-resolves the toolchain from
+`lean/lean-toolchain`; `mise install` re-resolves `zig`/`chezscheme` from
+`mise.toml`), so a stale pre-fetch here just means that reconciliation
+falls back to a network fetch instead of using the cached one.
 
 ```bash
 #!/bin/bash
@@ -97,23 +102,32 @@ export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"
 # Keep in sync with mise.toml's [tools] versions.
 mise use -g zig@0.16.0 || true
 mise use -g chezscheme@10.4.1 || true
-
-echo 'export PATH="$HOME/.elan/bin:$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"' \
-  > /etc/profile.d/malgo-toolchain.sh
 ```
+
+This deliberately doesn't try to persist `PATH` for later shells (e.g. via
+`/etc/profile.d`): Claude Code's own commands run as non-login shells that
+wouldn't source it anyway, and it's not the mechanism that actually
+matters here — the SessionStart hook below exports `PATH` through
+`$CLAUDE_ENV_FILE`, which is guaranteed to reach every command Claude
+runs.
 
 ## SessionStart hook
 
-`.claude/settings.json` registers `.claude/hooks/session-start.sh`, which
-runs on every session (cloud and local, a no-op locally since it checks
-`CLAUDE_CODE_REMOTE`). Unlike the setup script above, a fresh clone has no
-`.lake` build cache, so it re-runs `lake build` every session — this is
-the one setup step per-session latency can't avoid. It only exports `PATH`
-for what the setup script installed and runs `mise trust` / `lake build`;
-it does not install toolchains itself; if it reports `elan: NOT FOUND` or
-`lake build failed`, the setup script above hasn't run or the network
-access above isn't configured yet, and the transcript will point at
-whichever host is missing.
+`.claude/settings.json` registers `.claude/hooks/session-start.sh` with
+`"matcher": "startup|resume"`, so it runs once per fresh cloud session (and
+on resume), not on every `/clear`/compact. It's a no-op locally since it
+checks `CLAUDE_CODE_REMOTE`. Unlike the setup script above, a fresh clone
+has no `.lake` build cache, so it re-runs `lake build` every session —
+this is the one setup step per-session latency can't avoid. Besides
+exporting `PATH` for what the setup script installed, it also runs `mise
+install` from the checkout so `zig`/`chezscheme` get reconciled against
+`mise.toml` even if the setup script's own pre-fetch drifted out of sync
+(see the note above). It does not install elan or the Lean toolchain
+itself — if it reports `elan: NOT FOUND`, the setup script above hasn't
+run or failed. If `lake build` fails, it greps the build output for the
+network-fetch error signature (`CONNECT tunnel failed` / `error during
+download`) before blaming network access, so an unrelated compile error
+isn't misdiagnosed as a missing domain.
 
 Running the hook (synchronous) adds the fresh `lake build`'s time to every
 session start, in exchange for `mise run test`/`lake test`/lint working


### PR DESCRIPTION
## Summary
- `lake build` fetches the pinned Lean toolchain from `release.lean-lang.org`, and `mise`/`zig` need `mise.jdx.dev`/`ziglang.org`, none of which are in Claude Code on the web's **Trusted** network allowlist — verified empirically (a plain elan install succeeds, but the toolchain fetch then fails with a 403 CONNECT against that host). A default cloud environment therefore fails `lake build` with a bare network error rather than an obviously-missing-tool error.
- `docs/claude-code-web.md` records the exact domains to add (Custom network access), optional locale env vars, and a setup script that pre-installs elan/mise/zig/chezscheme at the pinned versions so the environment's ~week-long cache covers them.
- `.claude/hooks/session-start.sh` (registered in `.claude/settings.json`) exports the resulting `PATH` every session, runs `mise trust`, and runs `lake build` so `lake test`/lint work immediately — it does not install toolchains itself (that's the setup script's job, since its work is cached).

## Test plan
- [x] Hook syntax validated (`bash -n`) and settings.json validated as JSON.
- [x] Ran the hook directly in a Claude Code on the web session: correctly detects `elan`/`lean`/`lake`, correctly reports `mise`/`zig` missing, and degrades gracefully (exit 0 with a clear diagnostic) when `lake build` fails due to network access.
- [ ] Full `lake build`/`lake test`/lint could not be validated end-to-end in this session because its own network policy also blocks `release.lean-lang.org` — this is exactly the constraint the new docs address; validating requires configuring an actual cloud environment with the recommended Custom network access.


---
_Generated by [Claude Code](https://claude.ai/code/session_016sM9YzEs7TJ4Vo1UGk3tgm)_